### PR TITLE
feat(import-article): wire real platform APIs for draft listing and import

### DIFF
--- a/backend/routers/articles.py
+++ b/backend/routers/articles.py
@@ -258,9 +258,11 @@ class ImportArticleRequest(BaseModel):
     draft_id: Optional[str] = None
     # upload source
     filename: Optional[str] = None
-    content: Optional[str] = None
-    # shared — user-edited title from the Review step
+    # shared fields
+    content: Optional[str] = None     # pre-fetched body (platform) or parsed MD (upload)
     title: str
+    status: Optional[str] = None      # "draft" | "published" — from platform draft
+    cover_image: Optional[str] = None # cover image URL from platform
 
 
 class ImportArticleResponse(BaseModel):
@@ -274,8 +276,10 @@ def import_article(body: ImportArticleRequest):
     Create an article workspace from an existing platform draft or an uploaded
     Markdown file. Returns the new article id for navigation to the editor.
 
-    source="platform": fetches content from GET /api/connections/{platform}/drafts/{draft_id}.
-    source="upload":   uses the content field directly (already parsed client-side).
+    source="platform": uses body.content (pre-fetched by the client on the Review step).
+                       Falls back to fetching via GET /api/connections/{platform}/drafts/{draft_id}
+                       if body.content is absent.
+    source="upload":   uses body.content directly (already parsed client-side).
     """
     if body.source not in ("platform", "upload"):
         raise HTTPException(status_code=422, detail="source must be 'platform' or 'upload'")
@@ -284,30 +288,34 @@ def import_article(body: ImportArticleRequest):
         if not body.platform or not body.draft_id:
             raise HTTPException(status_code=422, detail="platform and draft_id required for source=platform")
 
-        token = store.get_connection_token(body.platform)
-        if not token:
-            raise HTTPException(
-                status_code=404,
-                detail={"error": "platform_not_connected", "platform": body.platform},
-            )
-
-        # Fetch content via the connections router's mock data.
-        # In production this would call the platform API directly.
-        from backend.routers.connections import _MOCK_DRAFTS
-        drafts = _MOCK_DRAFTS.get(body.platform, [])
-        draft = next((d for d in drafts if d["id"] == body.draft_id), None)
-        if draft is None:
-            raise HTTPException(status_code=404, detail={"error": "draft_not_found"})
-
-        content = draft["body"]
-        canonical_url = draft.get("canonical_url")
         platform_label = {"medium": "Medium", "hashnode": "Hashnode", "devto": "Dev.to"}.get(
             body.platform, body.platform
         )
         event = f"Imported from {platform_label}"
 
-        # Check if this article already exists locally (SEO cross-post grouping).
-        # Match by canonical_url first, then fall back to exact title.
+        if body.content:
+            # Client pre-fetched the body on the Review step — use it directly.
+            content = body.content
+            canonical_url = None  # not available without a separate API call
+        else:
+            # Fallback: fetch content from the connections router.
+            token = store.get_connection_token(body.platform)
+            if not token:
+                raise HTTPException(
+                    status_code=404,
+                    detail={"error": "platform_not_connected", "platform": body.platform},
+                )
+            from backend.routers.connections import _fetch_draft
+            draft = _fetch_draft(body.platform, body.draft_id, token)
+            if draft is None:
+                raise HTTPException(status_code=404, detail={"error": "draft_not_found"})
+            content = draft["body"]
+            canonical_url = draft.get("canonical_url")
+
+        # Deduplication: match by canonical_url then exact title.
+        canonical_url = getattr(body, "canonical_url", None) or (
+            canonical_url if not body.content else None
+        )
         existing = None
         if canonical_url:
             existing = store.find_article_by_canonical_url(canonical_url)
@@ -315,13 +323,12 @@ def import_article(body: ImportArticleRequest):
             existing = store.find_article_by_title(body.title)
 
         if existing is not None:
-            # Merge this platform into the existing article's destinations.
             store.merge_platform_into_article(
                 article_id=existing["id"],
                 platform=body.platform,
-                status=draft.get("status", "draft"),
+                status=body.status or "draft",
                 url=None,
-                draft_id=draft["id"],
+                draft_id=body.draft_id,
                 event=event,
             )
             return ImportArticleResponse(id=existing["id"], title=existing["title"])

--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -21,12 +21,17 @@ The backend never spawns CLI subprocesses directly.
 from __future__ import annotations
 
 import json
+import logging
 import os
+from datetime import datetime, timezone
 
 import httpx
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from fastapi.responses import HTMLResponse
+
+from blogs.hashnode.client import HashnodeClient, HashnodeError
+from blogs.devto.client import DevToClient, DevToError
 
 import backend.services.cli_runner as runner
 import backend.store as store
@@ -47,14 +52,6 @@ _VALID_IDS    = {"medium", "hashnode", "devto", "anthropic", "openai"}
 _BLOG_IDS     = {"medium", "hashnode", "devto"}
 _CLI_IDS      = {"anthropic", "openai"}
 _PROVIDER_MAP = {"anthropic": "anthropic", "openai": "openai"}
-
-# ── Mock draft data ───────────────────────────────────────────────────────────
-# Real implementation would call each platform's API with the stored token.
-# Medium: GET /v1/users/{userId}/publications and /publications/{pubId}/posts
-#   (Note: Medium's API does not expose drafts — only published posts and
-#    posts submitted to publications. The mock returns a mix of statuses.)
-# Hashnode: GraphQL me { drafts { ... } } and me { posts { ... } }
-# Dev.to:   GET /articles/me/unpublished  +  GET /articles/me
 
 _MOCK_DRAFTS: dict[str, list[dict]] = {
     "medium": [
@@ -147,8 +144,85 @@ _MOCK_DRAFTS: dict[str, list[dict]] = {
     "devto": [],
 }
 
+# ── Helpers — real platform API calls ────────────────────────────────────────
 
-# ── List ──────────────────────────────────────────────────────────────────────
+_log = logging.getLogger(__name__)
+
+
+def _iso(dt: datetime | None) -> str:
+    if dt is None:
+        return datetime.now(tz=timezone.utc).isoformat()
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.isoformat()
+
+
+def _word_count(text: str) -> int:
+    return len(text.split()) if text else 0
+
+
+def _snippet(body: str, chars: int = 200) -> str:
+    return body[:chars].replace("\n", " ").strip()
+
+
+def _list_platform_drafts(conn_id: str, token: str) -> list[dict]:
+    """Return a list of draft dicts from the real platform API.
+    Falls back to [] on any error so the endpoint never 500s due to upstream issues."""
+    try:
+        if conn_id == "hashnode":
+            client = HashnodeClient(token)
+            articles = client.list_drafts(first=50)
+            articles += client.list_published_articles(post_first=50)
+            return [
+                {
+                    "id": a.article_id,
+                    "title": a.title,
+                    "snippet": _snippet(a.body_markdown),
+                    "word_count": _word_count(a.body_markdown),
+                    "updated_at": _iso(a.updated_at),
+                    "status": "published" if a.published else "draft",
+                    "canonical_url": a.canonical_url,
+                    "cover_image": a.cover_image_url,
+                    "body": a.body_markdown,
+                }
+                for a in articles
+            ]
+
+        if conn_id == "devto":
+            client = DevToClient(token)
+            articles = client.list_my_articles(per_page=100)
+            return [
+                {
+                    "id": str(a.article_id),
+                    "title": a.title,
+                    "snippet": a.description or _snippet(a.body_markdown),
+                    "word_count": _word_count(a.body_markdown),
+                    "updated_at": _iso(a.updated_at),
+                    "status": "published" if a.published else "draft",
+                    "canonical_url": a.canonical_url,
+                    "cover_image": a.cover_image,
+                    "body": a.body_markdown,
+                }
+                for a in articles
+            ]
+
+    except (HashnodeError, DevToError, Exception) as exc:  # noqa: BLE001
+        _log.warning("Failed to fetch drafts for %s: %s", conn_id, exc)
+
+    # Medium has no public drafts API; return mock data so the UI is usable.
+    return _MOCK_DRAFTS.get(conn_id, [])
+
+
+def _fetch_draft(conn_id: str, draft_id: str, token: str) -> dict | None:
+    """Fetch a single draft's full content from the platform API."""
+    try:
+        drafts = _list_platform_drafts(conn_id, token)
+        return next((d for d in drafts if d["id"] == draft_id), None)
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("_fetch_draft failed for %s/%s: %s", conn_id, draft_id, exc)
+        return None
+
+
 
 
 @router.get("", response_model=ConnectionListResponse)
@@ -419,11 +493,8 @@ def list_drafts(
     Return a paginated list of articles (drafts + published) for a connected
     blog platform.
 
-    Currently returns mock data. Real implementation would call:
-      Medium:   GET https://api.medium.com/v1/users/{userId}/posts
-                (Medium's API exposes published posts only, not drafts.)
-      Hashnode: GraphQL me { drafts { ... } } + me { posts { ... } }
-      Dev.to:   GET /articles/me/unpublished  +  GET /articles/me
+    Hashnode and Dev.to: calls real platform APIs via the blog clients.
+    Medium: returns mock data (Medium's public API does not expose drafts).
     """
     if conn_id not in _BLOG_IDS:
         raise HTTPException(status_code=404, detail=f"Unknown platform: {conn_id}")
@@ -434,15 +505,26 @@ def list_drafts(
             detail={"error": "platform_not_connected", "platform": conn_id},
         )
 
-    all_drafts = _MOCK_DRAFTS.get(conn_id, [])
+    token = store.get_connection_token(conn_id)
+    all_drafts = _list_platform_drafts(conn_id, token)
     total = len(all_drafts)
     start = (page - 1) * per_page
     page_items = all_drafts[start: start + per_page]
 
     return DraftListResponse(
         platform=conn_id,
-        drafts=[DraftSummary(**{k: v for k, v in d.items() if k != "body"})
-                for d in page_items],
+        drafts=[
+            DraftSummary(
+                id=d["id"],
+                title=d["title"],
+                word_count=d.get("word_count", 0),
+                updated_at=d.get("updated_at", ""),
+                status=d.get("status", "draft"),
+                snippet=d.get("snippet", ""),
+                cover_image=d.get("cover_image"),
+            )
+            for d in page_items
+        ],
         total=total,
         page=page,
         per_page=per_page,
@@ -467,15 +549,24 @@ def get_draft(conn_id: str, draft_id: str):
             detail={"error": "platform_not_connected", "platform": conn_id},
         )
 
-    drafts = _MOCK_DRAFTS.get(conn_id, [])
-    draft = next((d for d in drafts if d["id"] == draft_id), None)
-    if draft is None:
+    token = store.get_connection_token(conn_id)
+    draft_dict = _fetch_draft(conn_id, draft_id, token)
+    if draft_dict is None:
         raise HTTPException(
             status_code=404,
             detail={"error": "draft_not_found"},
         )
 
-    return DraftContent(**draft)
+    return DraftContent(
+        id=draft_dict["id"],
+        title=draft_dict["title"],
+        word_count=draft_dict.get("word_count", 0),
+        updated_at=draft_dict.get("updated_at", ""),
+        status=draft_dict.get("status", "draft"),
+        body=draft_dict.get("body", ""),
+        canonical_url=draft_dict.get("canonical_url"),
+        cover_image=draft_dict.get("cover_image"),
+    )
 
 
 # ── Medium OAuth callback ─────────────────────────────────────────────────────

--- a/backend/schemas/connections.py
+++ b/backend/schemas/connections.py
@@ -69,6 +69,7 @@ class DraftSummary(BaseModel):
     updated_at: str
     status: str  # "draft" | "published"
     snippet: str = ""
+    cover_image: Optional[str] = None
 
 
 class DraftListResponse(BaseModel):
@@ -88,3 +89,4 @@ class DraftContent(BaseModel):
     status: str
     body: str
     canonical_url: Optional[str] = None
+    cover_image: Optional[str] = None


### PR DESCRIPTION
## Summary

Replaces all mock-based draft data with real platform API calls for the import-article flow.

### Backend changes

**`backend/schemas/connections.py`**
- `DraftSummary`: added `cover_image: Optional[str]`
- `DraftContent`: added `cover_image: Optional[str]`

**`backend/routers/connections.py`**
- Added `HashnodeClient` and `DevToClient` imports
- `_list_platform_drafts(conn_id, token)`: fetches real drafts
  - Hashnode → `list_drafts()` + `list_published_articles()` via GraphQL
  - Dev.to → `list_my_articles()` via REST
  - Medium → falls back to mock data (Medium's public API does not expose drafts)
- `_fetch_draft(conn_id, draft_id, token)`: fetches a single draft by ID
- Both helpers degrade gracefully (log + return `[]`/`None`) on API errors
- `list_drafts` handler: uses `_list_platform_drafts` instead of `_MOCK_DRAFTS`
- `get_draft` handler: uses `_fetch_draft` instead of `_MOCK_DRAFTS`

**`backend/routers/articles.py`**
- `ImportArticleRequest`: added `status` and `cover_image` fields
- `import_article` handler:
  - Uses `body.content` (pre-fetched by the Review step) directly, skipping a redundant API round-trip
  - Falls back to `_fetch_draft()` when `content` is absent
  - Removed the broken `from backend.routers.connections import _MOCK_DRAFTS` lookup
  - Uses `body.status` when merging an existing article