### PR TITLE
Secure provider credential storage

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7,6 +7,10 @@ from fastapi.staticfiles import StaticFiles
 from backend.routers import agent, articles, comments, connections, dev, jobs, patches, platforms
 from backend.routers import auth as auth_router
 from backend.middleware.auth import AuthMiddleware
+from backend.security import install_secret_redaction
+
+install_secret_redaction()
+
 import backend.store as store
 
 app = FastAPI(

--- a/backend/security.py
+++ b/backend/security.py
@@ -1,0 +1,55 @@
+"""Helpers that keep credentials out of application logs."""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+_REDACTIONS = (
+    re.compile(r'(?i)("(?:access_token|refresh_token|token|code|cookie|api_key|client_secret)"\s*:\s*")[^"]*(")'),
+    re.compile(r"(?i)((?:authorization|proxy-authorization)\s*[:=]\s*(?:bearer\s+)?)[^\s,;]+"),
+    re.compile(r"(?i)((?:api[-_ ]?key|access[-_ ]?token|refresh[-_ ]?token|auth[-_ ]?code|client[-_ ]?secret|token)\s*[:=]\s*)[^\s,;]+"),
+    re.compile(r"(?i)(cookie\s*[:=]\s*)[^\r\n]+"),
+)
+
+
+def redact_secrets(value: Any) -> str:
+    redacted = str(value)
+    for pattern in _REDACTIONS:
+        redacted = pattern.sub(r"\1[REDACTED]\2" if pattern.groups == 2 else r"\1[REDACTED]", redacted)
+    return redacted
+
+
+class SecretRedactionFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        _redact_record(record)
+        return True
+
+
+def _redact_record(record: logging.LogRecord) -> None:
+    record.msg = redact_secrets(record.msg)
+    if record.args:
+        if isinstance(record.args, dict):
+            record.args = {
+                key: redact_secrets(value) if isinstance(value, str) else value
+                for key, value in record.args.items()
+            }
+        else:
+            record.args = tuple(
+                redact_secrets(value) if isinstance(value, str) else value
+                for value in record.args
+            )
+
+
+def install_secret_redaction() -> None:
+    current_factory = logging.getLogRecordFactory()
+    if getattr(current_factory, "_bloghub_redacts_secrets", False):
+        return
+
+    def redacting_factory(*args, **kwargs):
+        record = current_factory(*args, **kwargs)
+        _redact_record(record)
+        return record
+
+    redacting_factory._bloghub_redacts_secrets = True
+    logging.setLogRecordFactory(redacting_factory)

--- a/backend/store/backends/sqlite.py
+++ b/backend/store/backends/sqlite.py
@@ -7,6 +7,7 @@ BLOGHUB_DB_PATH env var overrides the default path; use ':memory:' for tests.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import secrets
 import shutil
@@ -16,7 +17,14 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
-from backend.store.crypto import decrypt_token, encrypt_token, needs_reencryption
+from backend.store.crypto import (
+    CredentialDecryptionError,
+    decrypt_token,
+    encrypt_token,
+    needs_reencryption,
+)
+
+logger = logging.getLogger(__name__)
 
 # ─── Static metadata ──────────────────────────────────────────────────────────
 
@@ -802,7 +810,14 @@ class SQLiteStore:
                                 (conn_id, user_id)).fetchone()
         if not row or not row["token"]:
             return None
-        return decrypt_token(row["token"]) or None
+        try:
+            return decrypt_token(row["token"]) or None
+        except CredentialDecryptionError:
+            logger.warning(
+                "undecryptable credential for connection %r (user %r); treating as disconnected",
+                conn_id, user_id,
+            )
+            return None
 
     def reencrypt_connection_credentials(self) -> int:
         """Move plaintext, legacy, and retired-key credentials to the active key."""

--- a/backend/store/backends/sqlite.py
+++ b/backend/store/backends/sqlite.py
@@ -16,7 +16,7 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
-from backend.store.crypto import decrypt_token, encrypt_token
+from backend.store.crypto import decrypt_token, encrypt_token, needs_reencryption
 
 # ─── Static metadata ──────────────────────────────────────────────────────────
 
@@ -350,6 +350,7 @@ class SQLiteStore:
             except Exception:
                 pass  # column already exists
         self._con.commit()
+        self.reencrypt_connection_credentials()
         self._seed_if_empty()
         # Ephemeral — no need to persist across restarts
         self._oauth_pending: dict[str, dict] = {}
@@ -778,7 +779,6 @@ class SQLiteStore:
             "label": meta["label"],
             "type": meta["type"],
             "auth_method": meta["auth"],
-            "token": token,
             "status": status,
             "username": username,
             "connected_at": now_s,
@@ -803,6 +803,27 @@ class SQLiteStore:
         if not row or not row["token"]:
             return None
         return decrypt_token(row["token"]) or None
+
+    def reencrypt_connection_credentials(self) -> int:
+        """Move plaintext, legacy, and retired-key credentials to the active key."""
+        rows = self._con.execute(
+            "SELECT platform, user_id, token FROM connections WHERE token <> ''"
+        ).fetchall()
+        replacements = []
+        for row in rows:
+            if needs_reencryption(row["token"]):
+                replacements.append((
+                    encrypt_token(decrypt_token(row["token"])),
+                    row["platform"],
+                    row["user_id"],
+                ))
+        if replacements:
+            with self._con:
+                self._con.executemany(
+                    "UPDATE connections SET token=? WHERE platform=? AND user_id IS ?",
+                    replacements,
+                )
+        return len(replacements)
 
     def count_connected(self, user_id: str) -> int:
         return sum(1 for c in self.list_connections(user_id) if c["status"] == "connected")

--- a/backend/store/crypto.py
+++ b/backend/store/crypto.py
@@ -1,84 +1,259 @@
-"""
-Token encryption/decryption using Fernet symmetric encryption.
+"""Encryption-at-rest for provider credentials.
 
-Key is read from BLOGHUB_SECRET_KEY env var (URL-safe base64, 32 bytes).
-Generate a key with:
-    python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
-
-Encrypted tokens are stored with a "fernet:" prefix so plaintext legacy
-values continue to round-trip correctly without a migration step.
-
-If BLOGHUB_SECRET_KEY is not set, tokens are stored and returned as
-plaintext with a warning logged. Set the env var in production.
+Ciphertext is versioned and identifies the key used to encrypt it.  Key
+providers deliberately live outside SQLite so a database copy is insufficient
+to recover credentials.
 """
 from __future__ import annotations
 
-import logging
+import json
 import os
+import secrets
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Protocol
 
-logger = logging.getLogger(__name__)
+from cryptography.fernet import Fernet, InvalidToken
 
-_PREFIX = "fernet:"
+_PREFIX = "enc:v1:"
+_LEGACY_PREFIX = "fernet:"
+_DEFAULT_KEY_FILE = Path(__file__).resolve().parents[2] / "data" / "credential-keys.json"
 
-_fernet = None
-_warned = False
+
+class CredentialConfigurationError(RuntimeError):
+    """Credential key configuration is missing or invalid."""
 
 
-def _get_fernet():
-    global _fernet, _warned
-    if _fernet is not None:
-        return _fernet
+class CredentialDecryptionError(RuntimeError):
+    """A stored credential cannot be decrypted with the available keys."""
 
-    raw_key = os.environ.get("BLOGHUB_SECRET_KEY", "").strip()
-    if not raw_key:
-        if not _warned:
-            logger.warning(
-                "BLOGHUB_SECRET_KEY is not set. API tokens are stored in plaintext. "
-                "Set this env var in production to encrypt tokens at rest."
-            )
-            _warned = True
-        return None
 
-    from cryptography.fernet import Fernet, InvalidToken  # noqa: F401
+class KeyProvider(Protocol):
+    """Hook for environment, file, KMS, Vault, or other key providers."""
+
+    def active_key(self) -> tuple[str, bytes]: ...
+
+    def keys(self) -> Mapping[str, bytes]: ...
+
+
+def _validate_key(key: str | bytes, *, name: str) -> bytes:
+    value = key.encode() if isinstance(key, str) else key
     try:
-        _fernet = Fernet(raw_key.encode())
-    except Exception:
-        logger.error(
-            "BLOGHUB_SECRET_KEY is set but is not a valid Fernet key. "
-            "Tokens will be stored in plaintext until the key is fixed."
-        )
-        return None
+        Fernet(value)
+    except (TypeError, ValueError) as exc:
+        raise CredentialConfigurationError(f"{name} is not a valid Fernet key") from exc
+    return value
 
-    return _fernet
+
+@dataclass(frozen=True)
+class StaticKeyProvider:
+    """Simple provider suitable for environment variables and external adapters."""
+
+    active_key_id: str
+    keyring: Mapping[str, str | bytes]
+
+    def keys(self) -> Mapping[str, bytes]:
+        if any(not key_id or ":" in key_id for key_id in self.keyring):
+            raise CredentialConfigurationError("credential key id is invalid")
+        validated = {
+            key_id: _validate_key(key, name=f"credential key {key_id!r}")
+            for key_id, key in self.keyring.items()
+        }
+        if self.active_key_id not in validated:
+            raise CredentialConfigurationError("active credential key is absent from keyring")
+        return validated
+
+    def active_key(self) -> tuple[str, bytes]:
+        return self.active_key_id, self.keys()[self.active_key_id]
+
+
+class FileKeyProvider:
+    """Local keyring stored separately from the application database."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path).expanduser().resolve()
+        if not self.path.exists():
+            self._write_new_keyring()
+
+    def _read(self) -> dict:
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise CredentialConfigurationError(
+                f"cannot read credential key file {self.path}"
+            ) from exc
+        if payload.get("version") != 1 or not isinstance(payload.get("keys"), dict):
+            raise CredentialConfigurationError("credential key file has an unsupported format")
+        return payload
+
+    def _write(self, payload: dict) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        fd, temporary = tempfile.mkstemp(prefix=f".{self.path.name}.", dir=self.path.parent)
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self.path)
+            try:
+                self.path.chmod(0o600)
+            except OSError:
+                pass
+        except Exception:
+            try:
+                os.unlink(temporary)
+            except OSError:
+                pass
+            raise
+
+    def _write_new_keyring(self) -> None:
+        key_id = secrets.token_hex(8)
+        payload = {
+            "version": 1,
+            "active": key_id,
+            "keys": {key_id: Fernet.generate_key().decode()},
+        }
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        fd, temporary = tempfile.mkstemp(prefix=f".{self.path.name}.", dir=self.path.parent)
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            try:
+                os.link(temporary, self.path)
+            except FileExistsError:
+                pass  # Another process won first-run initialization.
+        finally:
+            try:
+                os.unlink(temporary)
+            except OSError:
+                pass
+
+    def keys(self) -> Mapping[str, bytes]:
+        payload = self._read()
+        return StaticKeyProvider(payload.get("active", ""), payload["keys"]).keys()
+
+    def active_key(self) -> tuple[str, bytes]:
+        payload = self._read()
+        provider = StaticKeyProvider(payload.get("active", ""), payload["keys"])
+        return provider.active_key()
+
+    def rotate(self) -> str:
+        payload = self._read()
+        key_id = secrets.token_hex(8)
+        payload["keys"][key_id] = Fernet.generate_key().decode()
+        payload["active"] = key_id
+        self._write(payload)
+        return key_id
+
+    def retire_inactive(self) -> int:
+        """Remove retired keys after all credentials have been re-encrypted."""
+        payload = self._read()
+        active = payload["active"]
+        removed = len(payload["keys"]) - 1
+        payload["keys"] = {active: payload["keys"][active]}
+        self._write(payload)
+        return removed
+
+
+_provider: KeyProvider | None = None
+
+
+def _provider_from_environment() -> KeyProvider:
+    active_key = os.environ.get("BLOGHUB_SECRET_KEY", "").strip()
+    if active_key:
+        active_id = os.environ.get("BLOGHUB_SECRET_KEY_ID", "primary").strip()
+        previous_raw = os.environ.get("BLOGHUB_PREVIOUS_SECRET_KEYS", "{}").strip() or "{}"
+        try:
+            previous = json.loads(previous_raw)
+        except json.JSONDecodeError as exc:
+            raise CredentialConfigurationError(
+                "BLOGHUB_PREVIOUS_SECRET_KEYS must be a JSON object of key ids to Fernet keys"
+            ) from exc
+        if not isinstance(previous, dict):
+            raise CredentialConfigurationError("BLOGHUB_PREVIOUS_SECRET_KEYS must be a JSON object")
+        return StaticKeyProvider(active_id, {**previous, active_id: active_key})
+
+    key_file = os.environ.get("BLOGHUB_CREDENTIAL_KEY_FILE", "").strip()
+    return FileKeyProvider(key_file or _DEFAULT_KEY_FILE)
+
+
+def get_key_provider() -> KeyProvider:
+    global _provider
+    if _provider is None:
+        _provider = _provider_from_environment()
+        _provider.active_key()  # Validate eagerly; invalid configuration must fail startup.
+    return _provider
+
+
+def configure_key_provider(provider: KeyProvider | None) -> None:
+    """Install an external key provider, or reset to configured defaults."""
+    global _provider
+    _provider = provider
 
 
 def encrypt_token(plaintext: str) -> str:
-    """Encrypt a token. Returns 'fernet:<ciphertext>' or plaintext if key not set."""
     if not plaintext:
         return plaintext
-    f = _get_fernet()
-    if f is None:
-        return plaintext
-    ciphertext = f.encrypt(plaintext.encode()).decode()
-    return f"{_PREFIX}{ciphertext}"
+    key_id, key = get_key_provider().active_key()
+    ciphertext = Fernet(key).encrypt(plaintext.encode()).decode()
+    return f"{_PREFIX}{key_id}:{ciphertext}"
 
 
 def decrypt_token(stored: str) -> str:
-    """Decrypt a stored token. Handles both encrypted and legacy plaintext values."""
+    """Decrypt current or legacy ciphertext; plaintext is accepted for migration only."""
     if not stored:
         return stored
-    if not stored.startswith(_PREFIX):
-        # Legacy plaintext value — return as-is.
-        return stored
-    f = _get_fernet()
-    if f is None:
-        logger.error(
-            "Token is encrypted but BLOGHUB_SECRET_KEY is not set. Cannot decrypt."
+    keys = get_key_provider().keys()
+    if stored.startswith(_PREFIX):
+        remainder = stored[len(_PREFIX):]
+        try:
+            key_id, ciphertext = remainder.split(":", 1)
+            key = keys[key_id]
+            return Fernet(key).decrypt(ciphertext.encode()).decode()
+        except (KeyError, ValueError, InvalidToken, UnicodeDecodeError) as exc:
+            raise CredentialDecryptionError(
+                "stored credential cannot be decrypted; restore its key or reconnect"
+            ) from exc
+    if stored.startswith(_LEGACY_PREFIX):
+        ciphertext = stored[len(_LEGACY_PREFIX):].encode()
+        for key in keys.values():
+            try:
+                return Fernet(key).decrypt(ciphertext).decode()
+            except (InvalidToken, UnicodeDecodeError):
+                continue
+        raise CredentialDecryptionError(
+            "legacy credential cannot be decrypted; restore its key or reconnect"
         )
-        return ""
-    from cryptography.fernet import InvalidToken
-    try:
-        return f.decrypt(stored[len(_PREFIX):].encode()).decode()
-    except InvalidToken:
-        logger.error("Token decryption failed. Key may have changed.")
-        return ""
+    return stored
+
+
+def needs_reencryption(stored: str) -> bool:
+    if not stored:
+        return False
+    active_id, _ = get_key_provider().active_key()
+    return not stored.startswith(f"{_PREFIX}{active_id}:")
+
+
+def rotate_file_key() -> str:
+    provider = get_key_provider()
+    if not isinstance(provider, FileKeyProvider):
+        raise CredentialConfigurationError(
+            "key rotation is managed by the configured external key provider"
+        )
+    return provider.rotate()
+
+
+def retire_inactive_file_keys() -> int:
+    provider = get_key_provider()
+    if not isinstance(provider, FileKeyProvider):
+        raise CredentialConfigurationError(
+            "key retirement is managed by the configured external key provider"
+        )
+    return provider.retire_inactive()

--- a/backend/store/crypto.py
+++ b/backend/store/crypto.py
@@ -75,6 +75,9 @@ class FileKeyProvider:
         self.path = Path(path).expanduser().resolve()
         if not self.path.exists():
             self._write_new_keyring()
+        self._cached_mtime: float | None = None
+        self._cached_keys: Mapping[str, bytes] | None = None
+        self._cached_active: str | None = None
 
     def _read(self) -> dict:
         try:
@@ -86,6 +89,15 @@ class FileKeyProvider:
         if payload.get("version") != 1 or not isinstance(payload.get("keys"), dict):
             raise CredentialConfigurationError("credential key file has an unsupported format")
         return payload
+
+    def _read_cached(self) -> tuple[str, Mapping[str, bytes]]:
+        mtime = self.path.stat().st_mtime
+        if self._cached_mtime != mtime:
+            payload = self._read()
+            self._cached_keys = StaticKeyProvider(payload.get("active", ""), payload["keys"]).keys()
+            self._cached_active = payload.get("active", "")
+            self._cached_mtime = mtime
+        return self._cached_active, self._cached_keys
 
     def _write(self, payload: dict) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -136,13 +148,12 @@ class FileKeyProvider:
                 pass
 
     def keys(self) -> Mapping[str, bytes]:
-        payload = self._read()
-        return StaticKeyProvider(payload.get("active", ""), payload["keys"]).keys()
+        _, keys = self._read_cached()
+        return keys
 
     def active_key(self) -> tuple[str, bytes]:
-        payload = self._read()
-        provider = StaticKeyProvider(payload.get("active", ""), payload["keys"])
-        return provider.active_key()
+        active, keys = self._read_cached()
+        return active, keys[active]
 
     def rotate(self) -> str:
         payload = self._read()
@@ -150,6 +161,7 @@ class FileKeyProvider:
         payload["keys"][key_id] = Fernet.generate_key().decode()
         payload["active"] = key_id
         self._write(payload)
+        self._cached_mtime = None
         return key_id
 
     def retire_inactive(self) -> int:
@@ -159,6 +171,7 @@ class FileKeyProvider:
         removed = len(payload["keys"]) - 1
         payload["keys"] = {active: payload["keys"][active]}
         self._write(payload)
+        self._cached_mtime = None
         return removed
 
 

--- a/docs/credential-storage.md
+++ b/docs/credential-storage.md
@@ -1,0 +1,69 @@
+# Credential storage
+
+BlogHub encrypts every provider credential before writing it to SQLite. New
+installations create `data/credential-keys.json` with restricted file
+permissions. The key file must be protected separately from database backups;
+losing it makes stored provider credentials unrecoverable.
+
+The ciphertext format is versioned (`enc:v1:<key-id>:...`). On startup, BlogHub
+transactionally upgrades plaintext legacy values, old `fernet:` values, and
+credentials encrypted with an inactive key. Startup fails if an encrypted value
+cannot be decrypted. It never falls back to plaintext storage.
+
+## Production configuration
+
+Set an active key through the environment when deployment secrets are managed
+outside the application filesystem:
+
+```bash
+export BLOGHUB_SECRET_KEY='<Fernet key>'
+export BLOGHUB_SECRET_KEY_ID='2026-08'
+export BLOGHUB_PREVIOUS_SECRET_KEYS='{"2026-07":"<previous Fernet key>"}'
+```
+
+Generate a Fernet key with:
+
+```bash
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```
+
+`BLOGHUB_CREDENTIAL_KEY_FILE` changes the local keyring location. Integrations
+with KMS, Vault, or another secret manager can implement
+`backend.store.crypto.KeyProvider` and install it with
+`configure_key_provider()` before store initialization.
+
+Do not commit keys, include them in database archives, print them, or return them
+from an API. Back up the database and keyring into separate access-controlled
+systems.
+
+## Rotation
+
+For the local keyring, stop application writes and run:
+
+```bash
+python scripts/bloghub_credentials.py rotate
+```
+
+This creates a new active key and re-encrypts all stored credentials while
+retaining inactive keys for rollback. Restart BlogHub and test each connection.
+After taking a protected keyring backup and verifying the rotation:
+
+```bash
+python scripts/bloghub_credentials.py retire --confirm
+```
+
+For environment or external secret managers, add the old key to
+`BLOGHUB_PREVIOUS_SECRET_KEYS`, deploy the new active key and key id, and restart.
+Startup re-encrypts credentials with the active key. Remove old keys only after
+the database has been migrated and verified.
+
+`python scripts/bloghub_credentials.py migrate` explicitly runs the same legacy
+migration. `status` reports key identifiers and counts, never key material.
+
+## Revocation and recovery
+
+Disconnecting a provider erases its stored credential and leaves only a
+credential-free disconnected marker. Reconnect to replace expired, revoked, or
+otherwise unusable credentials. If a key is lost or ciphertext is corrupt,
+restore the matching key from protected backup or remove the affected connection
+row and reconnect; BlogHub will not silently discard the decryption error.

--- a/docs/credential-storage.md
+++ b/docs/credential-storage.md
@@ -2,8 +2,8 @@
 
 BlogHub encrypts every provider credential before writing it to SQLite. New
 installations create `data/credential-keys.json` with restricted file
-permissions. The key file must be protected separately from database backups;
-losing it makes stored provider credentials unrecoverable.
+permissions. The key file must be protected separately from database backups.
+Losing it makes stored provider credentials unrecoverable.
 
 The ciphertext format is versioned (`enc:v1:<key-id>:...`). On startup, BlogHub
 transactionally upgrades plaintext legacy values, old `fernet:` values, and
@@ -66,4 +66,4 @@ Disconnecting a provider erases its stored credential and leaves only a
 credential-free disconnected marker. Reconnect to replace expired, revoked, or
 otherwise unusable credentials. If a key is lost or ciphertext is corrupt,
 restore the matching key from protected backup or remove the affected connection
-row and reconnect; BlogHub will not silently discard the decryption error.
+row and reconnect. BlogHub will not silently discard the decryption error.

--- a/scripts/bloghub_credentials.py
+++ b/scripts/bloghub_credentials.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Rotate BlogHub's local credential-encryption key."""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from backend.store.backends.sqlite import SQLiteStore  # noqa: E402
+from backend.store.crypto import (  # noqa: E402
+    get_key_provider,
+    retire_inactive_file_keys,
+    rotate_file_key,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "command", choices=("status", "migrate", "rotate", "retire"),
+        help="inspect, migrate, rotate, or retire inactive local keys",
+    )
+    parser.add_argument(
+        "--database",
+        default=os.environ.get("BLOGHUB_DB_PATH", str(ROOT / "data" / "bloghub.db")),
+    )
+    parser.add_argument(
+        "--confirm", action="store_true",
+        help="confirm irreversible retirement of inactive keys",
+    )
+    args = parser.parse_args()
+
+    key_id, _ = get_key_provider().active_key()
+    if args.command == "status":
+        print(f"active key: {key_id}")
+        print(f"available keys: {len(get_key_provider().keys())}")
+        return 0
+
+    if args.command == "retire":
+        if not args.confirm:
+            parser.error("retire requires --confirm after backup and connection verification")
+        print(f"retired keys removed: {retire_inactive_file_keys()}")
+        return 0
+
+    store = SQLiteStore(args.database, str(Path(args.database).parent / "blobs"))
+    if args.command == "migrate":
+        print(f"re-encrypted credentials: {store.reencrypt_connection_credentials()}")
+        return 0
+
+    new_key_id = rotate_file_key()
+    migrated = store.reencrypt_connection_credentials()
+    print(f"active key: {new_key_id}")
+    print(f"re-encrypted credentials: {migrated}")
+    print("inactive keys retained; use 'retire --confirm' after verification")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tests_backend/test_credential_storage.py
+++ b/tests/tests_backend/test_credential_storage.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import logging
+import os
+import stat
+
+import pytest
+from cryptography.fernet import Fernet
+
+from backend.security import SecretRedactionFilter, redact_secrets
+from backend.store.backends.sqlite import SQLiteStore
+from backend.store.crypto import (
+    CredentialConfigurationError,
+    CredentialDecryptionError,
+    configure_key_provider,
+    decrypt_token,
+    encrypt_token,
+    get_key_provider,
+    rotate_file_key,
+)
+
+
+@pytest.fixture
+def credential_environment(tmp_path, monkeypatch):
+    key_file = tmp_path / "keys" / "credential-keys.json"
+    monkeypatch.delenv("BLOGHUB_SECRET_KEY", raising=False)
+    monkeypatch.delenv("BLOGHUB_SECRET_KEY_ID", raising=False)
+    monkeypatch.delenv("BLOGHUB_PREVIOUS_SECRET_KEYS", raising=False)
+    monkeypatch.setenv("BLOGHUB_CREDENTIAL_KEY_FILE", str(key_file))
+    configure_key_provider(None)
+    yield tmp_path, key_file
+    configure_key_provider(None)
+
+
+def _store(tmp_path) -> SQLiteStore:
+    return SQLiteStore(str(tmp_path / "bloghub.db"), str(tmp_path / "blobs"))
+
+
+def test_default_key_file_encrypts_without_plaintext(credential_environment):
+    tmp_path, key_file = credential_environment
+    store = _store(tmp_path)
+    result = store.save_connection(store.SEED_USER_ID, "anthropic", "sk-ant-secret")
+    raw = store._con.execute(
+        "SELECT token FROM connections WHERE platform='anthropic'"
+    ).fetchone()[0]
+
+    assert result.get("token") is None
+    assert raw.startswith("enc:v1:")
+    assert "sk-ant-secret" not in raw
+    assert store.get_connection_token(store.SEED_USER_ID, "anthropic") == "sk-ant-secret"
+    if os.name == "posix":
+        assert stat.S_IMODE(key_file.stat().st_mode) == 0o600
+
+
+def test_startup_migrates_plaintext_and_disconnect_erases_it(credential_environment):
+    tmp_path, _ = credential_environment
+    store = _store(tmp_path)
+    store.save_connection(store.SEED_USER_ID, "devto", "initial")
+    store._con.execute(
+        "UPDATE connections SET token='legacy-secret' WHERE platform='devto'"
+    )
+    store._con.commit()
+    store._con.close()
+
+    reopened = _store(tmp_path)
+    raw = reopened._con.execute(
+        "SELECT token FROM connections WHERE platform='devto'"
+    ).fetchone()[0]
+    assert raw.startswith("enc:v1:")
+    assert "legacy-secret" not in raw
+    assert reopened.get_connection_token(reopened.SEED_USER_ID, "devto") == "legacy-secret"
+
+    reopened.delete_connection(reopened.SEED_USER_ID, "devto")
+    row = reopened._con.execute(
+        "SELECT token, status FROM connections WHERE platform='devto'"
+    ).fetchone()
+    assert tuple(row) == ("", "disconnected")
+
+
+def test_startup_migrates_legacy_fernet_ciphertext(credential_environment):
+    tmp_path, _ = credential_environment
+    store = _store(tmp_path)
+    _, key = get_key_provider().active_key()
+    legacy = "fernet:" + Fernet(key).encrypt(b"legacy-encrypted-secret").decode()
+    store.save_connection(store.SEED_USER_ID, "devto", "initial")
+    store._con.execute(
+        "UPDATE connections SET token=? WHERE platform='devto'", (legacy,)
+    )
+    store._con.commit()
+    store._con.close()
+
+    reopened = _store(tmp_path)
+    raw = reopened._con.execute(
+        "SELECT token FROM connections WHERE platform='devto'"
+    ).fetchone()[0]
+    assert raw.startswith("enc:v1:")
+    assert reopened.get_connection_token(reopened.SEED_USER_ID, "devto") == "legacy-encrypted-secret"
+
+
+def test_rotation_reencrypts_with_new_key(credential_environment):
+    tmp_path, _ = credential_environment
+    store = _store(tmp_path)
+    store.save_connection(store.SEED_USER_ID, "hashnode", "hash-secret")
+    old = store._con.execute(
+        "SELECT token FROM connections WHERE platform='hashnode'"
+    ).fetchone()[0]
+
+    new_key_id = rotate_file_key()
+    assert store.reencrypt_connection_credentials() == 1
+    new = store._con.execute(
+        "SELECT token FROM connections WHERE platform='hashnode'"
+    ).fetchone()[0]
+    assert new != old
+    assert new.startswith(f"enc:v1:{new_key_id}:")
+    assert decrypt_token(new) == "hash-secret"
+
+
+def test_wrong_key_fails_instead_of_returning_empty(credential_environment, monkeypatch):
+    encrypted = encrypt_token("important-secret")
+    monkeypatch.setenv("BLOGHUB_SECRET_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("BLOGHUB_SECRET_KEY_ID", "wrong")
+    configure_key_provider(None)
+    with pytest.raises(CredentialDecryptionError):
+        decrypt_token(encrypted)
+
+
+def test_store_startup_fails_when_encrypted_key_is_unavailable(
+    credential_environment, monkeypatch,
+):
+    tmp_path, _ = credential_environment
+    store = _store(tmp_path)
+    store.save_connection(store.SEED_USER_ID, "openai", "sk-important")
+    store._con.close()
+
+    monkeypatch.setenv("BLOGHUB_SECRET_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("BLOGHUB_SECRET_KEY_ID", "replacement-without-previous")
+    configure_key_provider(None)
+    with pytest.raises(CredentialDecryptionError):
+        _store(tmp_path)
+
+
+def test_invalid_environment_key_fails_configuration(credential_environment, monkeypatch):
+    monkeypatch.setenv("BLOGHUB_SECRET_KEY", "not-a-key")
+    configure_key_provider(None)
+    with pytest.raises(CredentialConfigurationError):
+        get_key_provider()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        'Authorization: Bearer sk-test-secret',
+        'api_key=sk-test-secret',
+        '{"access_token":"oauth-secret","ok":true}',
+        'Cookie: session=private; theme=dark',
+        'auth_code=temporary-code',
+    ],
+)
+def test_redaction_removes_secrets(value):
+    redacted = redact_secrets(value)
+    assert "secret" not in redacted
+    assert "temporary-code" not in redacted
+    assert "private" not in redacted
+    assert "[REDACTED]" in redacted
+
+
+def test_logging_filter_redacts_message_and_arguments():
+    record = logging.LogRecord(
+        "test", logging.INFO, __file__, 1,
+        "request %s", ("Authorization: Bearer sk-log-secret",), None,
+    )
+    assert SecretRedactionFilter().filter(record)
+    assert "sk-log-secret" not in record.getMessage()
+
+    numeric_record = logging.LogRecord(
+        "test", logging.INFO, __file__, 1, "status %d", (200,), None,
+    )
+    assert SecretRedactionFilter().filter(numeric_record)
+    assert numeric_record.getMessage() == "status 200"


### PR DESCRIPTION
## Summary
- encrypt every stored provider credential with a versioned, provider-neutral keyring
- generate a protected local key file by default and support environment/external key providers
- migrate plaintext and legacy Fernet rows transactionally at startup
- add rotation/retirement tooling, operational documentation, and centralized log redaction
- erase credentials on disconnect and remove raw tokens from store return values

## Tests
- `13 passed` in `tests/tests_backend/test_credential_storage.py`
- Python compile checks for changed backend and CLI modules
- `git diff --check`

Closes #13