### PR TITLE
feat: add durable agent web login

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.pytest_cache
+.venv
+__pycache__
+*.pyc
+data
+node_modules
+tests
+tests/results

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,16 +12,21 @@ blog-hub/
     ui/             pytest-playwright — browser tests (require live server)
 ```
 
-**Docker services:** only `cli-runner` runs in Docker. The FastAPI backend runs locally.
+Start the complete development stack:
+```
+cd blog-hub
+python start.py --reload
+```
 
-Start backend:
-```
-cd blog-hub && .venv/Scripts/python.exe -m uvicorn backend.main:app --port 8082
-```
+The launcher reuses a healthy runner, tries Docker Compose, and then falls back
+to a local runner when a provider CLI is installed. Local CLI credentials are
+kept under ignored `data/agent-config/`. Startup fails if no agent provider is
+available; use `--runner off` only when intentionally developing without agents.
 
-Rebuild cli-runner after changes to `cli-runner/main.py` or `cli-runner/Dockerfile`:
+Force a specific runner mode with `--runner docker`, `--runner local`, or
+`--runner external`. Rebuild the Docker runner after changing its image:
 ```
-docker compose build cli-runner && docker compose up -d cli-runner
+docker compose build cli-runner
 ```
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,74 +26,35 @@ docker compose build cli-runner && docker compose up -d cli-runner
 
 ---
 
-## AI Provider Auth — Current State
+## AI Provider Auth
 
-### Anthropic (Claude)
+Anthropic and OpenAI use the durable provider-neutral flow documented in
+`docs/agent-web-login.md`:
 
-**Flow:** Loopback OAuth via `claude auth login` (Claude Code CLI).
+1. `POST /api/connections/{provider}/auth-flows` starts browser or device-code login.
+2. The UI opens `authorizationUrl` and renders either the loopback callback input or
+   `deviceCode` from `flowType`.
+3. Anthropic callbacks are sent to
+   `POST /api/connections/auth-flows/{flowId}/callback`. OpenAI's CLI polls the
+   device-code provider directly.
+4. The UI polls `GET /api/connections/auth-flows/{flowId}`. Active flows resume from
+   `GET /api/connections/auth-flows/active` after navigation or backend restart.
+5. Connected CLI credentials persist in the `claude-config` and `codex-config`
+   volumes; SQLite contains only an encrypted web-session marker.
 
-1. Runner spawns `claude auth login` with `stdin=DEVNULL`.
-2. CLI starts an HTTP server on a random port (e.g. 36403) and prints an auth URL to stderr:
-   `https://claude.ai/oauth/authorize?...&redirect_uri=http://localhost:36403/callback&...`
-3. Runner scans `/proc/net/tcp6` to find the port, then replaces `redirect_uri` in the URL with
-   `http://localhost:{port}/callback` (it's already correct, but we normalise it).
-4. URL returned to frontend with `flow="cli_browser"`.
-5. Browser opens the URL, user authorises on claude.ai.
-6. Browser tries to redirect to `http://localhost:36403/callback?code=X&state=Y` — fails
-   (port is inside Docker, unreachable from host browser). Page shows connection error.
-7. User copies the full address-bar URL and pastes it into the input field in BlogHub.
-8. Frontend POSTs to `POST /api/connections/anthropic/submit-code` with `{ code: "<full URL>" }`.
-9. Backend forwards to runner `POST /auth/anthropic/submit-code`.
-10. Runner parses `code` and `state` from the URL, forwards
-    `GET http://[::1]:{port}/callback?code=X&state=Y` to the CLI's internal server.
-11. CLI does token exchange with `redirect_uri=http://localhost:{port}/callback` — matches
-    what was used in the auth request, so Anthropic accepts.
-12. Credentials saved to `/root/.claude/.claude.json` (persisted in `claude-config` Docker volume).
-13. Frontend polls `GET /api/connections/anthropic/cli-login-status` every 2s until connected.
+The shared states are `waiting_for_authorization`, `connected`, `expired`,
+`rejected`, `timed_out`, `rate_limited`, `failed`, and `canceled`. Callback
+payloads are forwarded directly and never stored or logged.
 
 **Key files:**
-- `cli-runner/main.py` — `auth_login`, `auth_submit_code`, `_find_cli_callback_port`
-- `backend/routers/connections.py` — `_cli_oauth_start`, `cli_login_status`
-- `screens/settings/v2.html` — `_doCliBrowserLogin`, `_showLoginThrobber`, `submitCode`
+- `backend/services/connection_auth.py` - durable flow orchestration
+- `backend/store/connection_auth.py` - encrypted flow persistence
+- `backend/routers/connections.py` - authenticated HTTP contract
+- `cli-runner/main.py` - provider CLI processes and normalized status
+- `screens/settings/v2.html` - no-reload flow UI
 
-**Volume:** `claude-config:/root/.claude`
-
-**Known gotcha:** `CLAUDE_CONFIG_DIR=/root/.claude` must be set in docker-compose env so the CLI
-writes to the volume, not to `/root/.claude.json` (outside the volume).
-
----
-
-### OpenAI (Codex)
-
-**Flow:** Device code OAuth (RFC 8628) via `codex login --device-auth` (OpenAI Codex CLI).
-
-1. Runner spawns `codex login --device-auth`.
-2. CLI prints to stdout:
-   - URL: `https://auth.openai.com/codex/device`
-   - One-time code: e.g. `1NFL-253Z0`
-3. Runner extracts both with ANSI-stripped regex scan.
-4. Returns `{ flow: "device_code", url: "...", device_code: "1NFL-253Z0" }` to frontend.
-5. Browser opens the URL. UI shows the device code prominently so user can copy it.
-6. User logs into ChatGPT on that page and enters the device code.
-7. **No submit step needed** — the CLI polls OpenAI's token endpoint internally until the
-   code is accepted.
-8. Frontend polls `GET /api/connections/openai/cli-login-status` every 2s.
-9. Runner calls `codex login status` — returns exit 0 when authenticated.
-10. Credentials saved to `/root/.codex/` (persisted in `codex-config` Docker volume).
-
-**Key files:**
-- `cli-runner/main.py` — `auth_login` (shared), `auth_status` openai branch
-- `backend/routers/connections.py` — `_cli_oauth_start` detects `device_code` field
-- `backend/schemas/connections.py` — `OAuthStartResponse.device_code`
-- `screens/settings/v2.html` — `_doDeviceCodeLogin`, `_showDeviceCodeThrobber`
-
-**Volume:** `codex-config:/root/.codex`
-
-**Rate limit:** OpenAI limits device code requests per IP. If you see 429 errors from
-`codex login --device-auth`, wait ~15 minutes before retrying.
-
-**Status:** Flow implemented and wired up end-to-end. Not yet validated with a successful
-login due to rate limiting during development. Test when rate limit clears.
+`CLAUDE_CONFIG_DIR=/root/.claude` must remain set in Docker Compose so Claude
+writes credentials into the mounted volume.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,18 +15,23 @@ blog-hub/
 Start the complete development stack:
 ```
 cd blog-hub
-python start.py --reload
+python start.py
 ```
 
-The launcher reuses a healthy runner, tries Docker Compose, and then falls back
-to a local runner when a provider CLI is installed. Local CLI credentials are
-kept under ignored `data/agent-config/`. Startup fails if no agent provider is
-available; use `--runner off` only when intentionally developing without agents.
+Docker Compose starts both the backend and CLI runner, waits for runner health,
+and keeps application data, credential keys, Claude credentials, and Codex
+credentials in separate named volumes. The backend reaches the runner through
+the internal `http://cli-runner:8001` service URL.
 
-Force a specific runner mode with `--runner docker`, `--runner local`, or
-`--runner external`. Rebuild the Docker runner after changing its image:
+There is no implicit host-CLI fallback. If Compose is unavailable, startup fails
+with instructions to install Docker Desktop and enable WSL integration. Use
+`--runner local` only as an explicit troubleshooting mode; its credentials are
+kept under ignored `data/agent-config/`. `--runner external` and `--runner off`
+are also explicit development modes.
+
+Rebuild the stack after changing either image with:
 ```
-docker compose build cli-runner
+docker compose build
 ```
 
 ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -43,6 +43,7 @@ app.add_middleware(AuthMiddleware)
 @app.on_event("startup")
 def startup_cleanup():
     store.delete_expired_sessions()
+    store.expire_connection_auth_flows()
     store.recover_agent_sessions()
     store.cleanup_agent_sessions(
         retention_days=int(os.environ.get("BLOGHUB_AGENT_SESSION_RETENTION_DAYS", "90"))

--- a/backend/routers/articles.py
+++ b/backend/routers/articles.py
@@ -249,7 +249,8 @@ def generate_article(request: Request, body: GenerateArticleRequest):
 
     # Both providers go through the CLI runner — Anthropic via claude -p,
     # OpenAI via codex exec (uses the OAuth session or API key).
-    api_key = store.get_connection_token(user_id, body.provider) if body.provider == "openai" else None
+    token = store.get_connection_token(user_id, body.provider) if body.provider == "openai" else None
+    api_key = runner.api_key_from_connection_token(token)
     try:
         result = runner.run_task(
             provider=body.provider,
@@ -680,7 +681,8 @@ def regenerate_patches(request: Request, article_id: str):
         store.complete_job(user_id, job["job_id"], error="No AI provider connected")
         return AsyncAccepted(jobId=job["job_id"], status=JobStatus.done)
 
-    api_key = store.get_connection_token(user_id, provider) if provider == "openai" else None
+    token = store.get_connection_token(user_id, provider) if provider == "openai" else None
+    api_key = runner.api_key_from_connection_token(token)
     try:
         result = runner.run_task(provider=provider,
                                  task="generate",

--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -29,8 +29,12 @@ from pydantic import BaseModel
 from fastapi.responses import HTMLResponse
 
 import backend.services.cli_runner as runner
+import backend.services.connection_auth as agent_auth
 import backend.store as store
 from backend.schemas.connections import (
+    ActiveAgentAuthFlowsResponse,
+    AgentAuthCallbackRequest,
+    AgentAuthFlowResponse,
     ConnectionInfo,
     ConnectionListResponse,
     DraftContent,
@@ -222,6 +226,63 @@ def list_connections(request: Request):
         connections=[ConnectionInfo(**c) for c in store.list_connections(user_id)])
 
 
+# ── Provider-neutral AI agent authentication ─────────────────────────────────
+
+
+def _auth_call(operation):
+    try:
+        return operation()
+    except agent_auth.ConnectionAuthError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+
+
+@router.post(
+    "/{conn_id}/auth-flows", response_model=AgentAuthFlowResponse, status_code=201,
+)
+def start_agent_auth_flow(request: Request, conn_id: str):
+    user_id: str = request.state.user_id
+    return _auth_call(lambda: agent_auth.start(store, user_id, conn_id))
+
+
+@router.get(
+    "/auth-flows/active", response_model=ActiveAgentAuthFlowsResponse,
+)
+def active_agent_auth_flows(request: Request):
+    user_id: str = request.state.user_id
+    return ActiveAgentAuthFlowsResponse(
+        flows=[
+            AgentAuthFlowResponse(**agent_auth.response_for(flow))
+            for flow in store.list_active_connection_auth_flows(user_id)
+        ]
+    )
+
+
+@router.get("/auth-flows/{flow_id}", response_model=AgentAuthFlowResponse)
+def get_agent_auth_flow(request: Request, flow_id: str):
+    user_id: str = request.state.user_id
+    return _auth_call(lambda: agent_auth.status(store, user_id, flow_id))
+
+
+@router.post(
+    "/auth-flows/{flow_id}/callback", response_model=AgentAuthFlowResponse,
+)
+def submit_agent_auth_callback(
+    request: Request, flow_id: str, body: AgentAuthCallbackRequest,
+):
+    user_id: str = request.state.user_id
+    return _auth_call(
+        lambda: agent_auth.submit_callback(
+            store, user_id, flow_id, body.callback_url
+        )
+    )
+
+
+@router.delete("/auth-flows/{flow_id}", response_model=AgentAuthFlowResponse)
+def cancel_agent_auth_flow(request: Request, flow_id: str):
+    user_id: str = request.state.user_id
+    return _auth_call(lambda: agent_auth.cancel(store, user_id, flow_id))
+
+
 # ── Save token ────────────────────────────────────────────────────────────────
 
 
@@ -262,6 +323,7 @@ def disconnect(request: Request, conn_id: str):
     user_id: str = request.state.user_id
     if conn_id not in _VALID_IDS:
         raise HTTPException(status_code=404, detail=f"Unknown connection: {conn_id}")
+    store.delete_connection_auth_flows(user_id, conn_id)
     store.delete_connection(user_id, conn_id)
     if conn_id in _CLI_IDS:
         # Best-effort: tell the runner to logout; ignore errors

--- a/backend/schemas/connections.py
+++ b/backend/schemas/connections.py
@@ -55,6 +55,30 @@ class OAuthStartResponse(BaseModel):
     device_code: Optional[str] = None  # set when flow == "device_code"
 
 
+class AgentAuthFlowResponse(_CamelModel):
+    flow_id: str
+    provider: str
+    flow_type: str  # "browser_callback" | "device_code"
+    status: str
+    authorization_url: Optional[str] = None
+    device_code: Optional[str] = None
+    username: Optional[str] = None
+    error_code: Optional[str] = None
+    error_message: Optional[str] = None
+    recovery: Optional[str] = None
+    expires_at: datetime
+    created_at: datetime
+    updated_at: datetime
+
+
+class AgentAuthCallbackRequest(_CamelModel):
+    callback_url: str = Field(min_length=1, max_length=4096)
+
+
+class ActiveAgentAuthFlowsResponse(_CamelModel):
+    flows: list[AgentAuthFlowResponse]
+
+
 class TestConnectionResponse(BaseModel):
     ok: bool
     detail: str

--- a/backend/security.py
+++ b/backend/security.py
@@ -9,6 +9,7 @@ _REDACTIONS = (
     re.compile(r'(?i)("(?:access_token|refresh_token|token|code|cookie|api_key|client_secret)"\s*:\s*")[^"]*(")'),
     re.compile(r"(?i)((?:authorization|proxy-authorization)\s*[:=]\s*(?:bearer\s+)?)[^\s,;]+"),
     re.compile(r"(?i)((?:api[-_ ]?key|access[-_ ]?token|refresh[-_ ]?token|auth[-_ ]?code|client[-_ ]?secret|token)\s*[:=]\s*)[^\s,;]+"),
+    re.compile(r"(?i)([?&](?:code|state|token)=)[^&#\s]+"),
     re.compile(r"(?i)(cookie\s*[:=]\s*)[^\r\n]+"),
 )
 

--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -84,7 +84,8 @@ def run_generation(
     if context_text:
         full_prompt += f"\n\nAdditional context:\n{context_text}"
 
-    api_key = store.get_connection_token(user_id, runner_provider) if runner_provider == "openai" else None
+    token = store.get_connection_token(user_id, runner_provider) if runner_provider == "openai" else None
+    api_key = runner.api_key_from_connection_token(token)
 
     try:
         result = runner.run_task(

--- a/backend/services/cli_runner.py
+++ b/backend/services/cli_runner.py
@@ -89,12 +89,28 @@ def login_status(provider: str) -> dict:
     return _get(f"/auth/{provider}/status")
 
 
+def submit_login_callback(provider: str, callback: str) -> dict:
+    """Forward a loopback callback without logging or persisting its payload."""
+    return _post(f"/auth/{provider}/submit-code", code=callback)
+
+
+def cancel_login(provider: str) -> dict:
+    """Cancel an in-progress login without deleting an existing credential."""
+    return _post(f"/auth/{provider}/cancel")
+
+
 def logout(provider: str) -> dict:
     """Clear CLI credentials for a provider. Returns { status: "disconnected" }."""
     return _post(f"/auth/{provider}/logout")
 
 
 _TASK_TIMEOUT = httpx.Timeout(connect=3.0, read=200.0, write=10.0, pool=5.0)
+
+def api_key_from_connection_token(token: str | None) -> str | None:
+    """Return a real API key, leaving persisted CLI sessions to the runner."""
+    if not token or token == "cli_session" or token.startswith("web_session:"):
+        return None
+    return token
 
 
 def run_task(

--- a/backend/services/connection_auth.py
+++ b/backend/services/connection_auth.py
@@ -1,0 +1,194 @@
+"""Provider-neutral orchestration for browser and device-code agent login."""
+from __future__ import annotations
+
+import os
+from urllib.parse import parse_qs, urlparse
+
+import backend.services.cli_runner as runner
+
+SUPPORTED_AGENT_PROVIDERS = {"anthropic", "openai"}
+AUTH_TIMEOUT_SECONDS = max(30, int(os.environ.get("AGENT_AUTH_TIMEOUT_SECONDS", "300")))
+
+_RECOVERY = {
+    "expired": "Start a new login because the authorization request expired.",
+    "rejected": "Start again and approve access on the provider page.",
+    "timed_out": "Start a new login and finish authorization within five minutes.",
+    "rate_limited": "Wait a few minutes before trying to connect again.",
+    "failed": "Retry login. If it fails again, verify the CLI runner is available.",
+    "canceled": "Start a new login when you are ready to continue.",
+}
+
+
+class ConnectionAuthError(RuntimeError):
+    def __init__(self, message: str, *, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _classify_failure(reason: str | None) -> tuple[str, str]:
+    message = (reason or "Provider login failed").strip()[:500]
+    lowered = message.lower()
+    if "rate limit" in lowered or "too many requests" in lowered or "429" in lowered:
+        return "rate_limited", "rate_limited"
+    if "expired" in lowered:
+        return "expired", "authorization_expired"
+    if any(item in lowered for item in ("rejected", "denied", "access_denied")):
+        return "rejected", "authorization_rejected"
+    if "timed out" in lowered or "timeout" in lowered:
+        return "timed_out", "authorization_timeout"
+    return "failed", "provider_error"
+
+
+def response_for(flow: dict) -> dict:
+    status = flow["status"]
+    return {
+        "flow_id": flow["id"],
+        "provider": flow["provider"],
+        "flow_type": flow["flow_type"],
+        "status": status,
+        "authorization_url": flow.get("authorization_url"),
+        "device_code": flow.get("device_code"),
+        "username": flow.get("username"),
+        "error_code": flow.get("error_code"),
+        "error_message": flow.get("error_message"),
+        "recovery": _RECOVERY.get(status),
+        "expires_at": flow["expires_at"],
+        "created_at": flow["created_at"],
+        "updated_at": flow["updated_at"],
+    }
+
+
+def start(storage, user_id: str, provider: str) -> dict:
+    if provider not in SUPPORTED_AGENT_PROVIDERS:
+        raise ConnectionAuthError(
+            f"{provider} does not support agent web login", status_code=404
+        )
+    try:
+        result = runner.login(provider)
+    except runner.RunnerUnavailable as exc:
+        result = {"available": False, "reason": str(exc)}
+
+    device_code = result.get("device_code")
+    flow_type = "device_code" if device_code else "browser_callback"
+    if result.get("available") and result.get("url"):
+        flow = storage.create_connection_auth_flow(
+            user_id,
+            provider,
+            flow_type,
+            authorization_url=result["url"],
+            device_code=device_code,
+            ttl_seconds=AUTH_TIMEOUT_SECONDS,
+        )
+        return response_for(flow)
+
+    status, error_code = _classify_failure(result.get("reason"))
+    flow = storage.create_connection_auth_flow(
+        user_id,
+        provider,
+        flow_type,
+        authorization_url=None,
+        ttl_seconds=AUTH_TIMEOUT_SECONDS,
+        status=status,
+        error_code=error_code,
+        error_message=(result.get("reason") or "Browser login is unavailable")[:500],
+    )
+    return response_for(flow)
+
+
+def status(storage, user_id: str, flow_id: str) -> dict:
+    flow = storage.get_connection_auth_flow(user_id, flow_id)
+    if flow is None:
+        raise ConnectionAuthError("Authentication flow not found", status_code=404)
+    if flow["status"] != "waiting_for_authorization":
+        return response_for(flow)
+
+    try:
+        provider_status = runner.login_status(flow["provider"])
+    except runner.RunnerUnavailable as exc:
+        provider_status = {"status": "error", "reason": str(exc)}
+
+    current = provider_status.get("status", "error")
+    if current in {"pending", "waiting_for_authorization"}:
+        return response_for(flow)
+    if current == "connected":
+        username = provider_status.get("username")
+        storage.save_connection(
+            user_id,
+            flow["provider"],
+            token=f"web_session:{flow['provider']}",
+            status="connected",
+            username=username,
+        )
+        flow = storage.update_connection_auth_flow(
+            user_id, flow_id, "connected", username=username
+        )
+        return response_for(flow)
+
+    if current in {"expired", "rejected", "timed_out", "rate_limited", "failed"}:
+        normalized = current
+        error_code = provider_status.get("error_code") or current
+    else:
+        normalized, error_code = _classify_failure(provider_status.get("reason"))
+    flow = storage.update_connection_auth_flow(
+        user_id,
+        flow_id,
+        normalized,
+        error_code=error_code,
+        error_message=(provider_status.get("reason") or "Provider login failed")[:500],
+    )
+    return response_for(flow)
+
+
+def submit_callback(storage, user_id: str, flow_id: str, callback: str) -> dict:
+    flow = storage.get_connection_auth_flow(user_id, flow_id)
+    if flow is None:
+        raise ConnectionAuthError("Authentication flow not found", status_code=404)
+    if flow["status"] != "waiting_for_authorization":
+        raise ConnectionAuthError("Authentication flow is no longer active", status_code=409)
+    if flow["flow_type"] != "browser_callback":
+        raise ConnectionAuthError("This provider uses device-code login", status_code=409)
+    parsed = urlparse(callback.strip())
+    query = parse_qs(parsed.query)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname not in {"localhost", "127.0.0.1"}
+        or parsed.path != "/callback"
+    ):
+        raise ConnectionAuthError("Callback must use the provider loopback URL")
+    if query.get("error"):
+        provider_error = query["error"][0]
+        status, error_code = _classify_failure(provider_error)
+        if provider_error == "access_denied":
+            status, error_code = "rejected", "authorization_rejected"
+        try:
+            runner.cancel_login(flow["provider"])
+        except runner.RunnerUnavailable:
+            pass
+        flow = storage.update_connection_auth_flow(
+            user_id,
+            flow_id,
+            status,
+            error_code=error_code,
+            error_message="Authorization was not completed by the provider",
+        )
+        return response_for(flow)
+    if not query.get("code") or not query.get("state"):
+        raise ConnectionAuthError("Callback URL is missing code or state")
+    try:
+        runner.submit_login_callback(flow["provider"], callback.strip())
+    except runner.RunnerUnavailable as exc:
+        raise ConnectionAuthError(str(exc), status_code=502) from exc
+    return response_for(flow)
+
+
+def cancel(storage, user_id: str, flow_id: str) -> dict:
+    flow = storage.get_connection_auth_flow(user_id, flow_id)
+    if flow is None:
+        raise ConnectionAuthError("Authentication flow not found", status_code=404)
+    if flow["status"] == "waiting_for_authorization":
+        try:
+            runner.cancel_login(flow["provider"])
+        except runner.RunnerUnavailable:
+            pass
+        flow = storage.update_connection_auth_flow(user_id, flow_id, "canceled")
+    return response_for(flow)

--- a/backend/store/__init__.py
+++ b/backend/store/__init__.py
@@ -96,6 +96,34 @@ def count_connected(user_id: str, *a, **kw):
     return _backend.count_connected(user_id, *a, **kw)
 
 
+def create_connection_auth_flow(user_id: str, *a, **kw):
+    return _backend.create_connection_auth_flow(user_id, *a, **kw)
+
+
+def get_connection_auth_flow(user_id: str, *a, **kw):
+    return _backend.get_connection_auth_flow(user_id, *a, **kw)
+
+
+def get_latest_connection_auth_flow(user_id: str, *a, **kw):
+    return _backend.get_latest_connection_auth_flow(user_id, *a, **kw)
+
+
+def list_active_connection_auth_flows(user_id: str, *a, **kw):
+    return _backend.list_active_connection_auth_flows(user_id, *a, **kw)
+
+
+def update_connection_auth_flow(user_id: str, *a, **kw):
+    return _backend.update_connection_auth_flow(user_id, *a, **kw)
+
+
+def delete_connection_auth_flows(user_id: str, *a, **kw):
+    return _backend.delete_connection_auth_flows(user_id, *a, **kw)
+
+
+def expire_connection_auth_flows(*a, **kw):
+    return _backend.expire_connection_auth_flows(*a, **kw)
+
+
 def create_oauth_state(*a, **kw):
     return _backend.create_oauth_state(*a, **kw)
 

--- a/backend/store/backends/sqlite.py
+++ b/backend/store/backends/sqlite.py
@@ -30,6 +30,7 @@ from backend.store.crypto import (
 )
 from backend.store.locking import WorkspaceLock
 from backend.store.agent_sessions import AgentSessionStoreMixin
+from backend.store.connection_auth import ConnectionAuthStoreMixin
 from backend.store.schema import (
     SEED_USER_EMAIL as DEFAULT_SEED_USER_EMAIL,
     SEED_USER_HASH as DEFAULT_SEED_USER_HASH,
@@ -216,7 +217,7 @@ def _seed_articles() -> list[dict]:
 # ─── SQLiteStore ──────────────────────────────────────────────────────────────
 
 
-class SQLiteStore(AgentSessionStoreMixin):
+class SQLiteStore(ConnectionAuthStoreMixin, AgentSessionStoreMixin):
 
     def __init__(self, db_path: str, blobs_dir: str = "data/blobs") -> None:
         self._db_path = db_path
@@ -966,6 +967,7 @@ class SQLiteStore(AgentSessionStoreMixin):
                 DELETE FROM articles;
                 DELETE FROM jobs;
                 DELETE FROM connections;
+                DELETE FROM connection_auth_flows;
                 DELETE FROM sessions;
                 DELETE FROM users;
             """)

--- a/backend/store/base.py
+++ b/backend/store/base.py
@@ -117,6 +117,30 @@ class ArticleStore(Protocol):
     def count_connected(self, user_id: str) -> int:
         ...
 
+    def create_connection_auth_flow(
+        self, user_id: str, provider: str, flow_type: str, **kwargs: Any,
+    ) -> dict:
+        ...
+
+    def get_connection_auth_flow(self, user_id: str, flow_id: str) -> dict | None:
+        ...
+
+    def get_latest_connection_auth_flow(
+        self, user_id: str, provider: str, *, active_only: bool = False,
+    ) -> dict | None:
+        ...
+
+    def list_active_connection_auth_flows(self, user_id: str) -> list[dict]:
+        ...
+
+    def update_connection_auth_flow(
+        self, user_id: str, flow_id: str, status: str, **kwargs: Any,
+    ) -> dict:
+        ...
+
+    def delete_connection_auth_flows(self, user_id: str, provider: str) -> int:
+        ...
+
     def create_oauth_state(self, conn_id: str) -> str:
         ...
 

--- a/backend/store/connection_auth.py
+++ b/backend/store/connection_auth.py
@@ -1,0 +1,243 @@
+"""Durable provider-neutral authentication flows for agent connections."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from backend.store.crypto import CredentialDecryptionError, decrypt_token, encrypt_token
+
+AUTH_FLOW_STATUSES = {
+    "waiting_for_authorization",
+    "connected",
+    "expired",
+    "rejected",
+    "timed_out",
+    "rate_limited",
+    "failed",
+    "canceled",
+}
+ACTIVE_AUTH_FLOW_STATUSES = {"waiting_for_authorization"}
+TERMINAL_AUTH_FLOW_STATUSES = AUTH_FLOW_STATUSES - ACTIVE_AUTH_FLOW_STATUSES
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _ts(value: datetime) -> str:
+    return value.isoformat()
+
+
+def _decrypt_ephemeral(value: str | None) -> str | None:
+    if not value:
+        return None
+    try:
+        return decrypt_token(value)
+    except CredentialDecryptionError:
+        return None
+
+
+def _flow_row(row) -> dict:
+    result = dict(row)
+    result["authorization_url"] = _decrypt_ephemeral(
+        result.pop("authorization_url_secret")
+    )
+    result["device_code"] = _decrypt_ephemeral(result.pop("device_code_secret"))
+    return result
+
+
+class ConnectionAuthStoreMixin:
+    """Mixin requiring the SQLite connection and workspace lock from SQLiteStore."""
+
+    def create_connection_auth_flow(
+        self,
+        user_id: str,
+        provider: str,
+        flow_type: str,
+        *,
+        authorization_url: str | None,
+        device_code: str | None = None,
+        ttl_seconds: int = 300,
+        status: str = "waiting_for_authorization",
+        error_code: str | None = None,
+        error_message: str | None = None,
+    ) -> dict:
+        if status not in AUTH_FLOW_STATUSES:
+            raise ValueError(f"Unsupported authentication status: {status}")
+        now = _now()
+        now_s = _ts(now)
+        flow_id = f"auth_{uuid.uuid4().hex}"
+        expires_at = _ts(now + timedelta(seconds=max(1, ttl_seconds)))
+        completed_at = now_s if status in TERMINAL_AUTH_FLOW_STATUSES else None
+        with self._workspace_lock.acquire():
+            with self._con:
+                self._con.execute(
+                    """UPDATE connection_auth_flows
+                       SET status='canceled', completed_at=?, updated_at=?
+                       WHERE user_id=? AND provider=?
+                         AND status='waiting_for_authorization'""",
+                    (now_s, now_s, user_id, provider),
+                )
+                self._con.execute(
+                    """INSERT INTO connection_auth_flows
+                       (id, user_id, provider, flow_type, status,
+                        authorization_url_secret, device_code_secret,
+                        error_code, error_message, created_at, updated_at,
+                        expires_at, completed_at)
+                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                    (
+                        flow_id,
+                        user_id,
+                        provider,
+                        flow_type,
+                        status,
+                        encrypt_token(authorization_url) if authorization_url else None,
+                        encrypt_token(device_code) if device_code else None,
+                        error_code,
+                        error_message,
+                        now_s,
+                        now_s,
+                        expires_at,
+                        completed_at,
+                    ),
+                )
+                self._set_connection_auth_state(
+                    user_id, provider, status, error_message=error_message
+                )
+        return self.get_connection_auth_flow(user_id, flow_id)  # type: ignore[return-value]
+
+    def get_connection_auth_flow(self, user_id: str, flow_id: str) -> dict | None:
+        self.expire_connection_auth_flows(user_id=user_id)
+        row = self._con.execute(
+            "SELECT * FROM connection_auth_flows WHERE id=? AND user_id=?",
+            (flow_id, user_id),
+        ).fetchone()
+        return _flow_row(row) if row else None
+
+    def get_latest_connection_auth_flow(
+        self, user_id: str, provider: str, *, active_only: bool = False,
+    ) -> dict | None:
+        self.expire_connection_auth_flows(user_id=user_id)
+        active_clause = " AND status='waiting_for_authorization'" if active_only else ""
+        row = self._con.execute(
+            """SELECT * FROM connection_auth_flows
+               WHERE user_id=? AND provider=?""" + active_clause +
+            " ORDER BY created_at DESC LIMIT 1",
+            (user_id, provider),
+        ).fetchone()
+        return _flow_row(row) if row else None
+
+    def list_active_connection_auth_flows(self, user_id: str) -> list[dict]:
+        self.expire_connection_auth_flows(user_id=user_id)
+        rows = self._con.execute(
+            """SELECT * FROM connection_auth_flows
+               WHERE user_id=? AND status='waiting_for_authorization'
+               ORDER BY created_at DESC""",
+            (user_id,),
+        ).fetchall()
+        return [_flow_row(row) for row in rows]
+
+    def update_connection_auth_flow(
+        self,
+        user_id: str,
+        flow_id: str,
+        status: str,
+        *,
+        username: str | None = None,
+        error_code: str | None = None,
+        error_message: str | None = None,
+    ) -> dict:
+        if status not in AUTH_FLOW_STATUSES:
+            raise ValueError(f"Unsupported authentication status: {status}")
+        now_s = _ts(_now())
+        completed_at = now_s if status in TERMINAL_AUTH_FLOW_STATUSES else None
+        with self._workspace_lock.acquire():
+            with self._con:
+                row = self._con.execute(
+                    "SELECT provider FROM connection_auth_flows WHERE id=? AND user_id=?",
+                    (flow_id, user_id),
+                ).fetchone()
+                if row is None:
+                    raise KeyError(f"Authentication flow {flow_id} not found")
+                self._con.execute(
+                    """UPDATE connection_auth_flows
+                       SET status=?, username=?, error_code=?, error_message=?,
+                           updated_at=?, completed_at=?
+                       WHERE id=? AND user_id=?""",
+                    (
+                        status,
+                        username,
+                        error_code,
+                        error_message,
+                        now_s,
+                        completed_at,
+                        flow_id,
+                        user_id,
+                    ),
+                )
+                self._set_connection_auth_state(
+                    user_id,
+                    row["provider"],
+                    status,
+                    username=username,
+                    error_message=error_message,
+                )
+        return self.get_connection_auth_flow(user_id, flow_id)  # type: ignore[return-value]
+
+    def expire_connection_auth_flows(self, *, user_id: str | None = None) -> int:
+        now_s = _ts(_now())
+        user_clause = " AND user_id=?" if user_id else ""
+        params = (now_s, user_id) if user_id else (now_s,)
+        with self._workspace_lock.acquire():
+            rows = self._con.execute(
+                """SELECT id, user_id, provider FROM connection_auth_flows
+                   WHERE status='waiting_for_authorization' AND expires_at <= ?"""
+                + user_clause,
+                params,
+            ).fetchall()
+            if not rows:
+                return 0
+            with self._con:
+                for row in rows:
+                    self._con.execute(
+                        """UPDATE connection_auth_flows
+                           SET status='timed_out', error_code='authorization_timeout',
+                               error_message='Authorization timed out', updated_at=?,
+                               completed_at=? WHERE id=?""",
+                        (now_s, now_s, row["id"]),
+                    )
+                    self._set_connection_auth_state(
+                        row["user_id"],
+                        row["provider"],
+                        "timed_out",
+                        error_message="Authorization timed out",
+                    )
+        return len(rows)
+
+    def delete_connection_auth_flows(self, user_id: str, provider: str) -> int:
+        with self._con:
+            cursor = self._con.execute(
+                "DELETE FROM connection_auth_flows WHERE user_id=? AND provider=?",
+                (user_id, provider),
+            )
+        return cursor.rowcount
+
+    def _set_connection_auth_state(
+        self,
+        user_id: str,
+        provider: str,
+        status: str,
+        *,
+        username: str | None = None,
+        error_message: str | None = None,
+    ) -> None:
+        self._con.execute(
+            """INSERT INTO connections
+               (platform, token, status, username, connected_at, error_message, user_id)
+               VALUES (?, '', ?, ?, '', ?, ?)
+               ON CONFLICT(platform, user_id) DO UPDATE SET
+                   status=excluded.status,
+                   username=COALESCE(excluded.username, connections.username),
+                   error_message=excluded.error_message""",
+            (provider, status, username, error_message, user_id),
+        )

--- a/backend/store/schema.py
+++ b/backend/store/schema.py
@@ -16,7 +16,7 @@ SEED_USER_HASH = "$2b$12$BJsbJlf3SZUMUISLA8oASeFn.Q3U.Ar6TqoIFtu0F9OlYyev.DZLC"
 # Bump when sql/schema.sql changes in a way that isn't safe to layer onto an
 # existing database (e.g. a dropped/renamed column). Operators reset by
 # deleting the database file; there is no in-place upgrade path.
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 _SCHEMA_SQL_PATH = Path(__file__).resolve().parent / "sql" / "schema.sql"
 

--- a/backend/store/sql/schema.sql
+++ b/backend/store/sql/schema.sql
@@ -66,6 +66,23 @@ CREATE TABLE IF NOT EXISTS connections (
     PRIMARY KEY (platform, user_id)
 );
 
+CREATE TABLE IF NOT EXISTS connection_auth_flows (
+    id                       TEXT PRIMARY KEY,
+    user_id                  TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    provider                 TEXT NOT NULL,
+    flow_type                TEXT NOT NULL,
+    status                   TEXT NOT NULL,
+    authorization_url_secret TEXT,
+    device_code_secret       TEXT,
+    username                 TEXT,
+    error_code               TEXT,
+    error_message            TEXT,
+    created_at               TEXT NOT NULL,
+    updated_at               TEXT NOT NULL,
+    expires_at               TEXT NOT NULL,
+    completed_at             TEXT
+);
+
 CREATE TABLE IF NOT EXISTS jobs (
     job_id       TEXT PRIMARY KEY,
     kind         TEXT NOT NULL,
@@ -213,6 +230,12 @@ CREATE INDEX IF NOT EXISTS idx_sessions_expires
 
 CREATE INDEX IF NOT EXISTS idx_jobs_user_status
     ON jobs(user_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_connection_auth_user_provider
+    ON connection_auth_flows(user_id, provider, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_connection_auth_active
+    ON connection_auth_flows(status, expires_at);
 
 CREATE INDEX IF NOT EXISTS idx_article_timeline_article
     ON article_timeline(article_id);

--- a/cli-runner/main.py
+++ b/cli-runner/main.py
@@ -33,6 +33,8 @@ from pydantic import BaseModel
 
 app = FastAPI(title="BlogHub CLI Runner", version="0.1.0")
 
+_RUNNER_HOME = os.environ.get("RUNNER_HOME", "/root")
+
 # ── Provider config ────────────────────────────────────────────────────────────
 
 _PROVIDERS: dict[str, dict] = {
@@ -44,7 +46,9 @@ _PROVIDERS: dict[str, dict] = {
         # URL is printed to stderr: "If the browser didn't open, visit: https://…"
         "url_stream":    "stderr",
         "url_prefix":    "https://",
-        "config_dir":    os.environ.get("CLAUDE_CONFIG_DIR", "/root/.claude"),
+        "config_dir":    os.environ.get(
+            "CLAUDE_CONFIG_DIR", os.path.join(_RUNNER_HOME, ".claude")
+        ),
         "callback_port": int(os.environ.get("CLAUDE_CALLBACK_PORT", "54322")),
     },
     # OpenAI Codex CLI — device code OAuth (RFC 8628).
@@ -58,7 +62,9 @@ _PROVIDERS: dict[str, dict] = {
         "logout_args":  ["codex", "logout"],
         "url_stream":   "stdout",
         "url_prefix":   "https://",
-        "config_dir":   os.environ.get("CODEX_CONFIG_DIR", "/root/.codex"),
+        "config_dir":   os.environ.get(
+            "CODEX_CONFIG_DIR", os.path.join(_RUNNER_HOME, ".codex")
+        ),
     },
 }
 
@@ -79,7 +85,7 @@ def _build_env(provider: str, api_key: str | None = None) -> dict[str, str]:
     """Return a clean env for CLI subprocesses — never pass os.environ wholesale."""
     cfg = _PROVIDERS[provider]
     env: dict[str, str] = {
-        "HOME": "/root",
+        "HOME": _RUNNER_HOME,
         "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
         "CLAUDE_CONFIG_DIR": _PROVIDERS["anthropic"]["config_dir"],
         "CODEX_HOME": _PROVIDERS["openai"]["config_dir"],
@@ -766,6 +772,18 @@ def _cancel_login(provider: str) -> None:
         proc = session.get("proc")
         if proc and proc.poll() is None:
             proc.terminate()
+            try:
+                proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=3)
+
+
+@app.on_event("shutdown")
+def shutdown_login_processes() -> None:
+    """Do not leave provider login subprocesses behind after runner shutdown."""
+    for provider in tuple(_login_sessions):
+        _cancel_login(provider)
 
 
 def _get_proc_socket_inodes(pid: int) -> set[str]:

--- a/cli-runner/main.py
+++ b/cli-runner/main.py
@@ -25,6 +25,8 @@ import uuid
 from typing import Optional
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+_DEVICE_CODE_RE = re.compile(r"\b[A-Z0-9]{4}-[A-Z0-9]{4,6}\b")
+_URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
@@ -145,9 +147,35 @@ class LoginResponse(BaseModel):
 
 
 class StatusResponse(BaseModel):
-    status: str              # "connected" | "pending" | "error"
+    status: str
     username: Optional[str] = None
     reason: Optional[str] = None
+    error_code: Optional[str] = None
+
+
+def _safe_reason(value: str | None) -> str:
+    """Return an actionable error with auth URLs and one-time codes removed."""
+    cleaned = _ANSI_RE.sub("", value or "Provider login failed")
+    cleaned = _URL_RE.sub("[redacted-url]", cleaned)
+    cleaned = _DEVICE_CODE_RE.sub("[redacted-code]", cleaned)
+    cleaned = re.sub(
+        r"(?i)((?:code|state|token)=)[^\s&#]+", r"\1[redacted]", cleaned
+    )
+    return " ".join(cleaned.split())[:300]
+
+
+def _failure_status(reason: str | None) -> tuple[str, str]:
+    safe = _safe_reason(reason)
+    lowered = safe.lower()
+    if "rate limit" in lowered or "too many requests" in lowered or "429" in lowered:
+        return "rate_limited", safe
+    if "expired" in lowered:
+        return "expired", safe
+    if any(item in lowered for item in ("rejected", "denied", "access_denied")):
+        return "rejected", safe
+    if "timed out" in lowered or "timeout" in lowered:
+        return "timed_out", safe
+    return "failed", safe
 
 
 class TaskRequest(BaseModel):
@@ -156,6 +184,7 @@ class TaskRequest(BaseModel):
     article_md: str
     context_md: Optional[str] = None
     args:       list[str] = []
+    api_key:    Optional[str] = None
 
 
 class TaskResponse(BaseModel):
@@ -180,7 +209,7 @@ def health():
 
 @app.get("/debug/session/{provider}")
 def debug_session(provider: str):
-    """Expose session internals for debugging — not for production use."""
+    """Expose process health without returning authorization material."""
     session = _login_sessions.get(provider)
     if not session:
         return {"session": None}
@@ -201,8 +230,6 @@ def debug_session(provider: str):
                         listen_ports.append(int(cols[1].split(":")[1], 16))
         except FileNotFoundError:
             pass
-    stdout_lines = session.get("stdout", [])
-    stderr_lines = session.get("stderr", [])
     return {
         "pid": pid,
         "poll": poll,
@@ -211,9 +238,7 @@ def debug_session(provider: str):
         "listen_ports": listen_ports,
         "callback_port": session.get("callback_port"),
         "started_at": session.get("started_at"),
-        "url_prefix": session.get("url", "")[:60],
-        "stdout": "".join(stdout_lines)[-2000:],
-        "stderr": "".join(stderr_lines)[-2000:],
+        "flow": "device_code" if session.get("device_code") else "browser_callback",
     }
 
 
@@ -257,8 +282,6 @@ def auth_login(provider: str):
     collected_stdout: list[str] = []
 
     # Device code pattern: e.g. "1N2M-HJRYD" (4 alphanum + hyphen + 4-6 alphanum)
-    _DEVICE_CODE_RE = re.compile(r"\b([A-Z0-9]{4}-[A-Z0-9]{4,6})\b")
-
     def _scan(stream, lines: list[str]) -> None:
         nonlocal url, device_code
         for raw in stream:
@@ -273,7 +296,7 @@ def auth_login(provider: str):
             if device_code is None:
                 m = _DEVICE_CODE_RE.search(clean)
                 if m:
-                    device_code = m.group(1)
+                    device_code = m.group(0)
 
     t_out = threading.Thread(target=_scan, args=(proc.stdout, collected_stdout), daemon=True)
     t_err = threading.Thread(target=_scan, args=(proc.stderr, collected_stderr), daemon=True)
@@ -286,7 +309,12 @@ def auth_login(provider: str):
     if not url:
         proc.terminate()
         reason = "".join(collected_stderr + collected_stdout).strip() or "CLI did not print a login URL"
-        return LoginResponse(available=False, reason=reason[:300])
+        return LoginResponse(available=False, reason=_safe_reason(reason))
+
+    if provider == "openai":
+        code_deadline = min(deadline, time.time() + 2)
+        while time.time() < code_deadline and device_code is None and proc.poll() is None:
+            time.sleep(0.1)
 
     # For device-code flows (OpenAI Codex), the CLI polls internally — no loopback port.
     # For loopback flows (Claude), scan for the callback port the CLI is listening on.
@@ -441,6 +469,13 @@ def auth_status(provider: str):
 
     if provider == "openai":
         cfg = _PROVIDERS["openai"]
+        session = _login_sessions.get(provider)
+        if session and time.time() - session["started_at"] > LOGIN_TIMEOUT:
+            _cancel_login(provider)
+            return StatusResponse(
+                status="timed_out", reason="Login timed out",
+                error_code="authorization_timeout",
+            )
         env = _build_env("openai")
         try:
             result = subprocess.run(
@@ -448,15 +483,22 @@ def auth_status(provider: str):
                 capture_output=True, text=True, env=env, timeout=10,
             )
         except (OSError, subprocess.TimeoutExpired) as exc:
-            return StatusResponse(status="error", reason=str(exc))
+            status, reason = _failure_status(str(exc))
+            return StatusResponse(status=status, reason=reason, error_code=status)
+        clean = _ANSI_RE.sub("", result.stdout + result.stderr).strip()
         if result.returncode == 0:
             # Parse email/username from output if present
-            clean = _ANSI_RE.sub("", result.stdout + result.stderr).strip()
             username = next((l.strip() for l in clean.splitlines() if "@" in l or l.strip()), None)
             _cancel_login(provider)
             return StatusResponse(status="connected", username=username)
-        return StatusResponse(status="pending" if _login_sessions.get(provider) else "error",
-                              reason="not authenticated")
+        if session and session.get("proc") and session["proc"].poll() is None:
+            return StatusResponse(status="pending")
+        output = clean
+        if session:
+            output += " " + "".join(session.get("stderr", []) + session.get("stdout", []))
+            _cancel_login(provider)
+        status, reason = _failure_status(output or "not authenticated")
+        return StatusResponse(status=status, reason=reason, error_code=status)
 
     cfg     = _PROVIDERS[provider]
     session = _login_sessions.get(provider)
@@ -464,7 +506,10 @@ def auth_status(provider: str):
     # TTL check
     if session and time.time() - session["started_at"] > LOGIN_TIMEOUT:
         _cancel_login(provider)
-        return StatusResponse(status="error", reason="Login timed out")
+        return StatusResponse(
+            status="timed_out", reason="Login timed out",
+            error_code="authorization_timeout",
+        )
 
     env = _build_env(provider)
 
@@ -479,7 +524,8 @@ def auth_status(provider: str):
     except subprocess.TimeoutExpired:
         return StatusResponse(status="pending")
     except OSError as exc:
-        return StatusResponse(status="error", reason=str(exc))
+        status, reason = _failure_status(str(exc))
+        return StatusResponse(status=status, reason=reason, error_code=status)
 
     # Parse output — claude auth status returns JSON on stderr
     raw = (result.stdout + result.stderr).strip()
@@ -500,9 +546,27 @@ def auth_status(provider: str):
         return StatusResponse(status="connected", username=username)
 
     if session:
-        return StatusResponse(status="pending")
+        proc = session.get("proc")
+        if proc and proc.poll() is None:
+            return StatusResponse(status="pending")
+        output = raw + " " + "".join(
+            session.get("stderr", []) + session.get("stdout", [])
+        )
+        _cancel_login(provider)
+        status, reason = _failure_status(output)
+        return StatusResponse(status=status, reason=reason, error_code=status)
 
-    return StatusResponse(status="error", reason="not authenticated")
+    return StatusResponse(
+        status="failed", reason="not authenticated", error_code="not_authenticated"
+    )
+
+
+@app.post("/auth/{provider}/cancel")
+def auth_cancel(provider: str):
+    if provider not in _PROVIDERS:
+        raise HTTPException(status_code=404, detail=f"Unknown provider: {provider}")
+    _cancel_login(provider)
+    return {"status": "canceled"}
 
 
 # ── Auth: logout ───────────────────────────────────────────────────────────────
@@ -613,7 +677,7 @@ def tasks_run(req: TaskRequest):
             raise HTTPException(422, f"Disallowed arg: {arg}")
 
     # Verify authenticated
-    env = _build_env(req.provider)
+    env = _build_env(req.provider, req.api_key)
     cfg = _PROVIDERS[req.provider]
     try:
         probe = subprocess.run(cfg["whoami_args"], env=env, capture_output=True, timeout=10)

--- a/cli-runner/requirements.txt
+++ b/cli-runner/requirements.txt
@@ -1,3 +1,4 @@
 fastapi>=0.111.0
+httpx>=0.27.0
 uvicorn[standard]>=0.29.0
 pydantic>=2.7.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,61 @@
 services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: uvicorn backend.main:app --host 0.0.0.0 --port 8000 --reload
+    ports:
+      - "${BLOGHUB_PORT:-8082}:8000"
+    volumes:
+      - .:/app
+      - bloghub-data:/app/data
+      - bloghub-previews:/app/generated_previews
+      - bloghub-credential-keys:/run/bloghub-keys
+    environment:
+      CLI_RUNNER_URL: http://cli-runner:8001
+      BLOGHUB_DB_PATH: /app/data/bloghub.db
+      BLOGHUB_BLOBS_DIR: /app/data/blobs
+      BLOGHUB_CREDENTIAL_KEY_FILE: /run/bloghub-keys/credential-keys.json
+    depends_on:
+      cli-runner:
+        condition: service_healthy
+    init: true
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
   cli-runner:
     build: ./cli-runner
     ports:
-      - "8001:8001"      # runner REST API (BlogHub backend talks here)
-      - "54322:54322"    # claude login loopback callback
-      - "54323:54323"    # openai login loopback callback
+      - "8001:8001"
     volumes:
       - claude-config:/root/.claude
       - codex-config:/root/.codex
     environment:
-      - RUNNER_TASK_TIMEOUT=180
-      - RUNNER_LOGIN_TIMEOUT=300
-      - RUNNER_MAX_OUTPUT_BYTES=524288
-      - CLAUDE_CALLBACK_PORT=54322
-      - CLAUDE_CONFIG_DIR=/root/.claude
+      RUNNER_HOME: /root
+      RUNNER_TASK_TIMEOUT: "180"
+      RUNNER_LOGIN_TIMEOUT: "300"
+      RUNNER_MAX_OUTPUT_BYTES: "524288"
+      CLAUDE_CALLBACK_PORT: "54322"
+      CLAUDE_CONFIG_DIR: /root/.claude
+      CODEX_CONFIG_DIR: /root/.codex
+    init: true
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
 volumes:
+  bloghub-data:
+  bloghub-previews:
+  bloghub-credential-keys:
   claude-config:
   codex-config:

--- a/docs/agent-web-login.md
+++ b/docs/agent-web-login.md
@@ -48,11 +48,13 @@ the same value.
 
 ## Development startup
 
-Run `python start.py --reload` to start both the runner and backend. The launcher
-first reuses a healthy runner, then tries Docker Compose, and finally starts the
-runner locally when an installed `claude` or `codex` binary is available. Local
-runner credentials persist under ignored `data/agent-config/` by default.
+Run `python start.py` for the canonical development stack. Docker Compose starts
+the backend and runner together, waits for runner health, and stores application
+data, encryption keys, Claude credentials, and Codex credentials in separate
+named volumes. The backend uses the internal `http://cli-runner:8001` service
+address.
 
-Use `--runner docker`, `--runner local`, or `--runner external` to require one
-mode. `--runner off` deliberately disables agent features. Normal startup fails
-instead of silently serving a broken login UI when no provider CLI is available.
+There is no implicit local fallback. Missing Docker Compose or disabled WSL
+integration fails startup with an actionable error. `--runner local` remains an
+explicit troubleshooting mode and stores credentials under ignored
+`data/agent-config/`; `--runner external` and `--runner off` are also explicit.

--- a/docs/agent-web-login.md
+++ b/docs/agent-web-login.md
@@ -1,0 +1,47 @@
+# Agent web login
+
+BlogHub connects Anthropic and OpenAI CLI agents through one durable web-login
+contract. Anthropic currently uses a loopback browser callback; OpenAI currently
+uses a device code. The settings UI renders either mechanism from the flow
+response and polls the same status endpoint without reloading the page.
+
+## API contract
+
+Start a flow with `POST /api/connections/{provider}/auth-flows`. Active flows can
+be recovered after navigation or a backend restart with
+`GET /api/connections/auth-flows/active`. Poll one flow at
+`GET /api/connections/auth-flows/{flowId}`.
+
+For a browser callback, send the complete localhost callback URL directly to
+`POST /api/connections/auth-flows/{flowId}/callback` as:
+
+```json
+{"callbackUrl":"http://localhost:54322/callback?code=...&state=..."}
+```
+
+For device-code login, open `authorizationUrl`, enter `deviceCode` at the
+provider, and continue polling. `DELETE /api/connections/auth-flows/{flowId}`
+cancels an unfinished attempt without logging out an already connected agent.
+Deleting the connection logs the provider out and removes its flow history.
+
+Flow statuses are `waiting_for_authorization`, `connected`, `expired`,
+`rejected`, `timed_out`, `rate_limited`, `failed`, and `canceled`. Terminal error
+responses include an `errorCode`, a display-safe `errorMessage`, and recovery
+guidance.
+
+## Persistence and secrets
+
+Flow metadata is stored in SQLite. Authorization URLs and device codes are
+encrypted with the credential keyring; callback payloads are forwarded directly
+to the CLI runner and are never stored. Query credentials are redacted from
+application and runner error logs.
+
+After authorization, SQLite stores only an encrypted web-session marker. The
+actual CLI credentials live in the runner's `claude-config` and `codex-config`
+Docker volumes, outside article workspaces. Back up those volumes if agent login
+must survive moving the deployment to a new host. A normal container or backend
+restart retains both the durable connection state and the CLI credentials.
+
+Set `AGENT_AUTH_TIMEOUT_SECONDS` for the backend flow expiry and
+`RUNNER_LOGIN_TIMEOUT` for the runner process timeout. They should normally have
+the same value.

--- a/docs/agent-web-login.md
+++ b/docs/agent-web-login.md
@@ -45,3 +45,14 @@ restart retains both the durable connection state and the CLI credentials.
 Set `AGENT_AUTH_TIMEOUT_SECONDS` for the backend flow expiry and
 `RUNNER_LOGIN_TIMEOUT` for the runner process timeout. They should normally have
 the same value.
+
+## Development startup
+
+Run `python start.py --reload` to start both the runner and backend. The launcher
+first reuses a healthy runner, then tries Docker Compose, and finally starts the
+runner locally when an installed `claude` or `codex` binary is available. Local
+runner credentials persist under ignored `data/agent-config/` by default.
+
+Use `--runner docker`, `--runner local`, or `--runner external` to require one
+mode. `--runner off` deliberately disables agent features. Normal startup fails
+instead of silently serving a broken login UI when no provider CLI is available.

--- a/docs/credential-storage.md
+++ b/docs/credential-storage.md
@@ -67,3 +67,7 @@ credential-free disconnected marker. Reconnect to replace expired, revoked, or
 otherwise unusable credentials. If a key is lost or ciphertext is corrupt,
 restore the matching key from protected backup or remove the affected connection
 row and reconnect. BlogHub will not silently discard the decryption error.
+
+Browser-authenticated agents store only an encrypted `web_session:<provider>`
+marker in SQLite. Their CLI credential material is retained in the protected
+runner configuration volumes described in [Agent web login](agent-web-login.md).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+bcrypt>=4.1.0
+cryptography>=42.0.0
+email-validator>=2.1.0
+fastapi>=0.111.0
+httpx>=0.27.0
+python-multipart>=0.0.9
+PyYAML>=6.0.0
+requests>=2.31.0
+uvicorn[standard]>=0.29.0

--- a/screens/login/v1.html
+++ b/screens/login/v1.html
@@ -298,6 +298,13 @@ body {
 var mode = 'login'; // 'login' | 'register'
 var loading = false;
 
+function postLoginDestination() {
+  var next = new URLSearchParams(window.location.search).get('next');
+  return next && next.startsWith('/') && !next.startsWith('//')
+    ? next
+    : '/screens/overview/v3.html';
+}
+
 // ── Mode switch ───────────────────────────────────────────────────────────
 function switchMode(e) {
   e.preventDefault();
@@ -436,8 +443,7 @@ function handleSubmit(e) {
   .then(function(r) {
     stopLoading();
     if (r.status === 200 || r.status === 201) {
-      // Redirect to overview
-      window.location.href = '/screens/overview/v3.html';
+      window.location.href = postLoginDestination();
     } else if (r.status === 401) {
       showError('Incorrect email or password');
     } else if (r.status === 409) {
@@ -539,7 +545,7 @@ function clearErrors() {
 // ── Redirect if already logged in ─────────────────────────────────────────
 (function checkSession() {
   fetch('/api/auth/me', { credentials: 'same-origin' })
-    .then(function(r) { if (r.ok) window.location.href = '/screens/overview/v3.html'; })
+    .then(function(r) { if (r.ok) window.location.href = postLoginDestination(); })
     .catch(function() {});
 })();
 </script>

--- a/screens/settings/v2.html
+++ b/screens/settings/v2.html
@@ -610,12 +610,23 @@ async function doOAuth(id) {
     else providerTab?.close();
     collapseKey(id);
     closeAllExpand();
+    syncAgentConnection(flow);
     renderAgentAuthFlow(flow);
     if (flow.status === 'waiting_for_authorization') pollAgentAuthFlow(flow);
   } catch (error) {
     providerTab?.close();
     renderAgentAuthFailure(id, error.message, 'Retry login after checking the CLI runner.');
   }
+}
+
+function syncAgentConnection(flow) {
+  const conn = _connections.find(item => item.id === flow.provider);
+  const wrap = document.getElementById('ai-wrap-' + flow.provider);
+  if (!conn || !wrap) return;
+  conn.status = flow.status;
+  conn.username = flow.username || null;
+  conn.errorMessage = flow.errorMessage || null;
+  wrap.outerHTML = aiCard(conn);
 }
 
 async function resumeActiveAuthFlows() {

--- a/screens/settings/v2.html
+++ b/screens/settings/v2.html
@@ -145,7 +145,7 @@
           <h2 class="text-bright font-semibold text-sm mb-1">Publishing Platforms</h2>
           <p class="text-xs mb-7" style="color:#5a6080; line-height:1.6;">
             Connect your blog accounts to enable one-click publishing.<br/>
-            Tokens are stored in memory — reconnect after a server restart.
+            Credentials are encrypted and stored outside article workspaces.
           </p>
           <div id="platform-list" class="flex flex-col gap-2">
             <div class="text-xs text-muted">Loading…</div>
@@ -156,7 +156,7 @@
         <div id="section-ai" style="display:none;">
           <h2 class="text-bright font-semibold text-sm mb-1">AI Providers</h2>
           <p class="text-xs mb-7" style="color:#5a6080; line-height:1.6;">
-            Add API keys to enable AI-assisted drafting, suggestions, and review.
+            Sign in with a provider or add an API key for AI-assisted drafting and review.
           </p>
           <div id="ai-list" class="flex flex-col gap-3">
             <div class="text-xs text-muted">Loading…</div>
@@ -198,6 +198,24 @@ const ICON_STYLE = {
 };
 
 let _connections = [];
+const _authTimers = new Map();
+
+const AUTH_STATES = {
+  disconnected:              { label: 'Not configured', color: '#5a6080' },
+  waiting_for_authorization: { label: 'Waiting for authorization', color: '#fbbf24' },
+  expired:                   { label: 'Authorization expired', color: '#fbbf24' },
+  rejected:                  { label: 'Authorization rejected', color: '#f87171' },
+  timed_out:                 { label: 'Login timed out', color: '#fbbf24' },
+  rate_limited:              { label: 'Rate limited', color: '#f87171' },
+  failed:                    { label: 'Login failed', color: '#f87171' },
+  canceled:                  { label: 'Login canceled', color: '#5a6080' },
+};
+
+function esc(value) {
+  const node = document.createElement('div');
+  node.textContent = value == null ? '' : String(value);
+  return node.innerHTML;
+}
 
 // ─── Section nav ───────────────────────────────────────────────────────────────
 function showSection(name, btn) {
@@ -222,6 +240,7 @@ async function loadConnections() {
   renderPlatforms(_connections.filter(c => c.type === 'blog'));
   renderAI(_connections.filter(c => c.type === 'ai'));
   updateCount(_connections);
+  await resumeActiveAuthFlows();
 }
 
 function buildStaticConns() {
@@ -356,6 +375,7 @@ function aiCard(conn) {
   const ic   = ICON_STYLE[conn.id] || { bg: '#13172a', color: '#5a6080', letter: '?' };
   const meta = CONN_META[conn.id] || {};
   const ok   = conn.status === 'connected';
+  const waiting = conn.status === 'waiting_for_authorization';
 
   // Icon col is always dark — visual direction adds a 3px green accent bar when authenticated
   const accentBar = ok
@@ -364,7 +384,7 @@ function aiCard(conn) {
   const iconColor = ok ? ic.color : '#5a6080';
 
   // Not-configured: whole card at opacity 0.75
-  const cardStyle = ok ? '' : 'opacity:0.75;';
+  const cardStyle = ok || waiting ? '' : 'opacity:0.82;';
 
   // Body content differs between authenticated and not-configured (Decision C)
   let bodyHtml = '';
@@ -395,20 +415,27 @@ function aiCard(conn) {
         </div>
       </div>`;
   } else {
-    // Not-configured: flex-column space-between — description top, button bottom (Decision C)
+    const state = AUTH_STATES[conn.status] || AUTH_STATES.disconnected;
+    const helper = conn.errorMessage
+      ? esc(conn.errorMessage)
+      : waiting
+      ? 'Finish signing in on the provider page.'
+      : `${meta.tokenLabel || 'API key'} or provider login required.`;
+    const actionLabel = waiting ? 'Continue login' :
+      conn.status === 'disconnected' ? 'Login with browser' : 'Reconnect';
     bodyHtml = `
       <div class="ai-body-empty">
         <div>
           <div style="font-size:13px;font-weight:600;color:#e8eaf2;margin-bottom:2px;">${conn.label}</div>
           <div style="display:flex;align-items:center;gap:4px;margin-bottom:8px;">
-            <span style="width:5px;height:5px;border-radius:50%;background:#5a6080;"></span>
-            <span style="font-size:11px;color:#5a6080;">Not configured</span>
+            <span style="width:5px;height:5px;border-radius:50%;background:${state.color};"></span>
+            <span style="font-size:11px;color:${state.color};">${state.label}</span>
           </div>
-          <div style="font-size:11px;color:#3a3f52;line-height:1.4;">${meta.tokenLabel || 'API key'} required.</div>
+          <div style="font-size:11px;color:#5a6080;line-height:1.4;">${helper}</div>
         </div>
         <div style="display:flex;align-items:center;gap:8px;margin-top:10px;">
           ${meta.oauth ? `<button onclick="doOAuth('${conn.id}')"
-            style="font-size:11px;font-weight:500;padding:4px 12px;border-radius:4px;background:#6366f1;color:#fff;border:none;cursor:pointer;font-family:inherit;">Login with browser</button>` : ''}
+            style="font-size:11px;font-weight:500;padding:4px 12px;border-radius:4px;background:#6366f1;color:#fff;border:none;cursor:pointer;font-family:inherit;">${actionLabel}</button>` : ''}
           <button onclick="expandKey('${conn.id}')"
             style="font-size:11px;font-weight:500;padding:4px 12px;border-radius:4px;${meta.oauth ? 'background:transparent;color:#5a6080;border:1px solid #252a38;' : 'background:#6366f1;color:#fff;border:none;'}cursor:pointer;font-family:inherit;">Add API key</button>
         </div>
@@ -556,187 +583,165 @@ async function testConn(id) {
   }
 }
 
-// ─── Browser login dispatcher ──────────────────────────────────────────────────
-// Three flows depending on what the server returns:
-//
-//   flow === "cli_browser"  (Anthropic)
-//     Loopback OAuth. Browser opens auth URL, redirect fails, user copies the
-//     full address-bar URL and pastes it back. We forward it to the CLI server.
-//
-//   flow === "device_code"  (OpenAI Codex)
-//     RFC 8628 device auth. Browser opens the URL, user logs in and enters the
-//     one-time code shown in the UI. CLI polls internally — no submit needed.
-//
-//   flow === undefined / "oauth_popup"  (Medium)
-//     Standard Authorization Code popup. Backend handles the code exchange.
-
-async function doOAuth(id) {
-  const meta = CONN_META[id];
-  if (!meta?.oauth) return;
-  try {
-    const res  = await fetch(`/api/connections/${id}/oauth-start`);
-    const data = await res.json();
-    if (!data.available || !data.url) {
-      alert('Browser login not available — paste an API token instead.');
-      expandKey(id);
-      return;
-    }
-    if (data.flow === 'device_code') {
-      _doDeviceCodeLogin(id, data.url, data.device_code);
-    } else if (data.flow === 'cli_browser') {
-      _doCliBrowserLogin(id, data.url);
-    } else {
-      _doOAuthPopup(id, data.url);
-    }
-  } catch (e) {
-    alert('Login error: ' + e.message);
-  }
-}
-
-// Device code login — open URL, show code, poll until CLI completes internally
-function _doDeviceCodeLogin(id, url, deviceCode) {
-  window.open(url, '_blank');
-  collapseKey(id);
-  closeAllExpand();
-  _showDeviceCodeThrobber(id, deviceCode);
-
-  const MAX_POLLS = 150;
-  let polls = 0;
-  const timer = setInterval(async () => {
-    polls++;
-    try {
-      const res  = await fetch(`/api/connections/${id}/cli-login-status`);
-      const data = await res.json();
-      if (data.status === 'connected') {
-        clearInterval(timer);
-        _hideLoginThrobber(id);
-        await loadConnections();
-      } else if (polls >= MAX_POLLS) {
-        // Device code flow: codex polls OpenAI internally regardless of our session,
-        // so keep polling on 'error' until MAX_POLLS — only give up after time is up.
-        clearInterval(timer);
-        _hideLoginThrobber(id);
-        alert('Login timed out — please try again.');
-      }
-    } catch { /* network blip */ }
-  }, 2000);
-}
-
-// CLI browser login — open tab, show throbber, poll until connected
-function _doCliBrowserLogin(id, url) {
-  window.open(url, '_blank');
-  collapseKey(id);        // close API key expand row if open
-  closeAllExpand();
-  _showLoginThrobber(id);
-
-  const MAX_POLLS = 150; // 5 min at 2 s each
-  let polls = 0;
-  const timer = setInterval(async () => {
-    polls++;
-    try {
-      const res  = await fetch(`/api/connections/${id}/cli-login-status`);
-      const data = await res.json();
-      if (data.status === 'connected') {
-        clearInterval(timer);
-        _hideLoginThrobber(id);
-        await loadConnections();
-      } else if (data.status === 'error' || polls >= MAX_POLLS) {
-        clearInterval(timer);
-        _hideLoginThrobber(id);
-        if (data.errorMessage) alert('Login failed: ' + data.errorMessage);
-        else if (polls >= MAX_POLLS) alert('Login timed out — please try again.');
-      }
-    } catch { /* network blip — keep polling */ }
-  }, 2000);
-}
-
+// ─── Provider-neutral agent login ─────────────────────────────────────────────
 const _SPINNER_SVG = `<svg class="spin" width="13" height="13" viewBox="0 0 24 24" fill="none">
   <circle cx="12" cy="12" r="10" stroke="#5a6080" stroke-width="2.5" stroke-dasharray="16 48"/>
 </svg>`;
 
-function _showLoginThrobber(id) {
-  const wrap = document.getElementById('ai-wrap-' + id) || document.getElementById('plat-card-' + id);
-  if (!wrap || document.getElementById('throbber-row-' + id)) return;
-  const row = document.createElement('div');
-  row.id = 'throbber-row-' + id;
-  row.style.cssText = 'border-top:1px solid #252a38;padding:10px 16px;';
-  row.innerHTML = `
-    <div id="throbber-status-${id}" style="display:flex;align-items:center;gap:8px;margin-bottom:10px;">
-      ${_SPINNER_SVG}
-      <span id="throbber-msg-${id}" style="font-size:11px;color:#5a6080;">Authorize in the tab that opened. The browser will show a connection error — that is expected. Copy the full URL from the address bar (<code style="font-size:10px;">http://localhost:…/callback?code=…</code>) and paste it below:</span>
-    </div>
-    <div id="code-area-${id}" style="display:flex;gap:6px;">
-      <input id="code-input-${id}" type="text" autocomplete="off" placeholder="http://localhost:…/callback?code=…&state=…"
-        style="flex:1;background:#0f1117;border:1px solid #6366f1;border-radius:5px;
-               padding:6px 10px;font-size:12px;color:#e8eaf2;font-family:'JetBrains Mono',monospace;"
-        onkeydown="if(event.key==='Enter') submitCode('${id}')" />
-      <button onclick="submitCode('${id}')"
-        style="font-size:12px;font-weight:500;padding:6px 14px;border-radius:5px;
-               background:#6366f1;color:#fff;border:none;cursor:pointer;font-family:inherit;">Submit</button>
-    </div>`;
-  wrap.appendChild(row);
-  setTimeout(() => document.getElementById('code-input-' + id)?.focus(), 50);
-}
-
-function _hideLoginThrobber(id) {
-  document.getElementById('throbber-row-' + id)?.remove();
-}
-
-function _showDeviceCodeThrobber(id, deviceCode) {
-  const wrap = document.getElementById('ai-wrap-' + id) || document.getElementById('plat-card-' + id);
-  if (!wrap || document.getElementById('throbber-row-' + id)) return;
-  const row = document.createElement('div');
-  row.id = 'throbber-row-' + id;
-  row.style.cssText = 'border-top:1px solid #252a38;padding:10px 16px;';
-  const codeHtml = deviceCode
-    ? `<div style="margin-top:8px;font-size:11px;color:#5a6080;">
-         Enter this code on the page that just opened:
-         <code style="font-size:13px;font-weight:700;color:#e8eaf2;letter-spacing:2px;margin-left:6px;">${deviceCode}</code>
-       </div>`
-    : '';
-  row.innerHTML = `
-    <div id="throbber-status-${id}" style="display:flex;flex-direction:column;gap:4px;">
-      <div style="display:flex;align-items:center;gap:8px;">
-        ${_SPINNER_SVG}
-        <span id="throbber-msg-${id}" style="font-size:11px;color:#5a6080;">Sign in on the tab that just opened, then enter the code below.</span>
-      </div>
-      ${codeHtml}
-    </div>`;
-  wrap.appendChild(row);
-}
-
-async function submitCode(id) {
-  const inp  = document.getElementById('code-input-' + id);
-  const code = inp?.value.trim();
-  if (!code) { inp?.focus(); return; }
-
-  inp.disabled = true;
-  const btn = inp.nextElementSibling;
-  if (btn) btn.disabled = true;
-
-  try {
-    const res = await fetch(`/api/connections/${id}/submit-code`, {
-      method:  'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body:    JSON.stringify({ code }),
-    });
-    if (!res.ok) {
-      const err = await res.json().catch(() => ({}));
-      alert('Submit failed: ' + (err.detail || res.statusText || res.status));
-      inp.disabled = false;
-      if (btn) btn.disabled = false;
-      return;
-    }
-    // Code accepted: hide code area, update message, keep polling
-    const area = document.getElementById('code-area-' + id);
-    if (area) area.remove();
-    const msg = document.getElementById('throbber-msg-' + id);
-    if (msg) msg.textContent = 'Completing sign-in…';
-  } catch (e) {
-    alert('Submit error: ' + e.message);
-    inp.disabled = false;
-    if (btn) btn.disabled = false;
+async function doOAuth(id) {
+  const meta = CONN_META[id];
+  if (!meta?.oauth) return;
+  if (!['anthropic', 'openai'].includes(id)) {
+    const res = await fetch(`/api/connections/${id}/oauth-start`);
+    const data = await res.json();
+    if (!data.available || !data.url) { expandKey(id); return; }
+    _doOAuthPopup(id, data.url);
+    return;
   }
+
+  const providerTab = window.open('about:blank', '_blank');
+  if (providerTab) providerTab.opener = null;
+  try {
+    const res = await fetch(`/api/connections/${id}/auth-flows`, { method: 'POST' });
+    const flow = await res.json();
+    if (!res.ok) throw new Error(flow.detail || `HTTP ${res.status}`);
+    if (flow.authorizationUrl && providerTab) providerTab.location.href = flow.authorizationUrl;
+    else if (flow.authorizationUrl) window.open(flow.authorizationUrl, '_blank');
+    else providerTab?.close();
+    collapseKey(id);
+    closeAllExpand();
+    renderAgentAuthFlow(flow);
+    if (flow.status === 'waiting_for_authorization') pollAgentAuthFlow(flow);
+  } catch (error) {
+    providerTab?.close();
+    renderAgentAuthFailure(id, error.message, 'Retry login after checking the CLI runner.');
+  }
+}
+
+async function resumeActiveAuthFlows() {
+  try {
+    const res = await fetch('/api/connections/auth-flows/active');
+    if (!res.ok) return;
+    const data = await res.json();
+    for (const flow of data.flows || []) {
+      renderAgentAuthFlow(flow);
+      pollAgentAuthFlow(flow);
+    }
+  } catch { /* Connections still render when the runner is temporarily unavailable. */ }
+}
+
+function pollAgentAuthFlow(flow) {
+  if (_authTimers.has(flow.flowId)) return;
+  const timer = setInterval(async () => {
+    try {
+      const res = await fetch(`/api/connections/auth-flows/${flow.flowId}`);
+      const current = await res.json();
+      if (!res.ok) throw new Error(current.detail || `HTTP ${res.status}`);
+      renderAgentAuthFlow(current);
+      if (current.status !== 'waiting_for_authorization') {
+        clearInterval(timer);
+        _authTimers.delete(flow.flowId);
+        await loadConnections();
+        if (current.status !== 'connected') renderAgentAuthFlow(current);
+      }
+    } catch (error) {
+      const msg = document.getElementById('auth-message-' + flow.provider);
+      if (msg) msg.textContent = 'Connection interrupted. Retrying…';
+    }
+  }, 2000);
+  _authTimers.set(flow.flowId, timer);
+}
+
+function renderAgentAuthFlow(flow) {
+  const id = flow.provider;
+  const wrap = document.getElementById('ai-wrap-' + id);
+  if (!wrap) return;
+  document.getElementById('auth-flow-row-' + id)?.remove();
+  const row = document.createElement('div');
+  row.id = 'auth-flow-row-' + id;
+  row.dataset.flowId = flow.flowId;
+  row.dataset.status = flow.status;
+  row.style.cssText = 'border-top:1px solid #252a38;padding:12px 16px;';
+
+  if (flow.status !== 'waiting_for_authorization') {
+    const state = AUTH_STATES[flow.status] || AUTH_STATES.failed;
+    row.innerHTML = `<div style="display:flex;align-items:flex-start;justify-content:space-between;gap:12px;">
+      <div>
+        <div style="font-size:11px;color:${state.color};margin-bottom:4px;">${state.label}</div>
+        ${flow.errorMessage ? `<div style="font-size:11px;color:#c9cfe0;">${esc(flow.errorMessage)}</div>` : ''}
+        ${flow.recovery ? `<div style="font-size:11px;color:#5a6080;margin-top:3px;">${esc(flow.recovery)}</div>` : ''}
+      </div>
+      <button onclick="doOAuth('${id}')" style="font-size:11px;padding:4px 10px;border-radius:4px;background:#6366f1;color:#fff;border:none;cursor:pointer;">Retry</button>
+    </div>`;
+    wrap.appendChild(row);
+    return;
+  }
+
+  const callbackInput = flow.flowType === 'browser_callback'
+    ? `<div id="callback-area-${id}" style="display:flex;gap:6px;margin-top:10px;">
+         <input id="callback-input-${id}" type="text" autocomplete="off"
+           placeholder="Paste the localhost callback URL"
+           style="flex:1;background:#0f1117;border:1px solid #6366f1;border-radius:5px;padding:6px 10px;font-size:12px;color:#e8eaf2;font-family:'JetBrains Mono',monospace;"
+           onkeydown="if(event.key==='Enter')submitAgentCallback('${id}')" />
+         <button onclick="submitAgentCallback('${id}')" style="font-size:11px;padding:5px 11px;border-radius:4px;background:#6366f1;color:#fff;border:none;cursor:pointer;">Submit</button>
+       </div>` : '';
+  const deviceCode = flow.flowType === 'device_code' && flow.deviceCode
+    ? `<div style="font-size:11px;color:#5a6080;margin-top:7px;">Enter code
+         <code style="font-size:13px;font-weight:700;color:#e8eaf2;letter-spacing:2px;margin-left:6px;">${esc(flow.deviceCode)}</code>
+       </div>` : '';
+  const instruction = flow.flowType === 'device_code'
+    ? 'Authorize in the provider tab and enter the device code.'
+    : 'Authorize in the provider tab, then paste its localhost callback URL.';
+  row.innerHTML = `<div style="display:flex;align-items:center;justify-content:space-between;gap:10px;">
+      <div style="display:flex;align-items:center;gap:8px;">${_SPINNER_SVG}
+        <span id="auth-message-${id}" style="font-size:11px;color:#c9cfe0;">${instruction}</span>
+      </div>
+      <button onclick="cancelAgentAuth('${id}')" style="font-size:11px;color:#f87171;background:transparent;border:none;cursor:pointer;">Cancel</button>
+    </div>${deviceCode}${callbackInput}`;
+  wrap.appendChild(row);
+}
+
+function renderAgentAuthFailure(id, message, recovery) {
+  renderAgentAuthFlow({
+    flowId: 'local-error', provider: id, status: 'failed',
+    errorMessage: message, recovery,
+  });
+}
+
+async function submitAgentCallback(id) {
+  const row = document.getElementById('auth-flow-row-' + id);
+  const input = document.getElementById('callback-input-' + id);
+  const callbackUrl = input?.value.trim();
+  if (!row || !callbackUrl) { input?.focus(); return; }
+  input.disabled = true;
+  try {
+    const res = await fetch(`/api/connections/auth-flows/${row.dataset.flowId}/callback`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ callbackUrl }),
+    });
+    const flow = await res.json();
+    if (!res.ok) throw new Error(flow.detail || `HTTP ${res.status}`);
+    document.getElementById('callback-area-' + id)?.remove();
+    const msg = document.getElementById('auth-message-' + id);
+    if (msg) msg.textContent = 'Completing sign-in…';
+  } catch (error) {
+    input.disabled = false;
+    const msg = document.getElementById('auth-message-' + id);
+    if (msg) msg.textContent = error.message;
+  }
+}
+
+async function cancelAgentAuth(id) {
+  const row = document.getElementById('auth-flow-row-' + id);
+  if (!row) return;
+  const flowId = row.dataset.flowId;
+  const timer = _authTimers.get(flowId);
+  if (timer) clearInterval(timer);
+  _authTimers.delete(flowId);
+  const res = await fetch(`/api/connections/auth-flows/${flowId}`, { method: 'DELETE' });
+  const flow = await res.json();
+  await loadConnections();
+  renderAgentAuthFlow(flow);
 }
 
 // Medium OAuth popup — wait for postMessage from callback page

--- a/screens/settings/v2.html
+++ b/screens/settings/v2.html
@@ -653,7 +653,10 @@ function pollAgentAuthFlow(flow) {
       const res = await fetch(`/api/connections/auth-flows/${flow.flowId}`);
       const current = await res.json();
       if (!res.ok) throw new Error(current.detail || `HTTP ${res.status}`);
-      renderAgentAuthFlow(current);
+      const row = document.getElementById('auth-flow-row-' + flow.provider);
+      if (!row || row.dataset.status !== current.status) {
+        renderAgentAuthFlow(current);
+      }
       if (current.status !== 'waiting_for_authorization') {
         clearInterval(timer);
         _authTimers.delete(flow.flowId);

--- a/screens/settings/v2.html
+++ b/screens/settings/v2.html
@@ -603,6 +603,11 @@ async function doOAuth(id) {
   if (providerTab) providerTab.opener = null;
   try {
     const res = await fetch(`/api/connections/${id}/auth-flows`, { method: 'POST' });
+    if (res.status === 401) {
+      providerTab?.close();
+      redirectToLogin();
+      return;
+    }
     const flow = await res.json();
     if (!res.ok) throw new Error(flow.detail || `HTTP ${res.status}`);
     if (flow.authorizationUrl && providerTab) providerTab.location.href = flow.authorizationUrl;
@@ -777,7 +782,23 @@ document.addEventListener('click', (e) => {
 });
 
 // ─── Init ──────────────────────────────────────────────────────────────────────
-loadConnections();
+function redirectToLogin() {
+  const next = window.location.pathname + window.location.search + window.location.hash;
+  window.location.replace('/screens/login/v1.html?next=' + encodeURIComponent(next));
+}
+
+async function initSettings() {
+  try {
+    const res = await fetch('/api/auth/me', { credentials: 'same-origin' });
+    if (res.status === 401) {
+      redirectToLogin();
+      return;
+    }
+  } catch { /* loadConnections renders its offline fallback. */ }
+  await loadConnections();
+}
+
+initSettings();
 </script>
 </body>
 </html>

--- a/start.py
+++ b/start.py
@@ -27,7 +27,6 @@ class LauncherError(RuntimeError):
 class RunnerHandle:
     kind: str
     process: subprocess.Popen | None = None
-    compose_command: list[str] | None = None
 
 
 def find_free_port(start: int = 8082, end: int = 8090) -> int:
@@ -93,13 +92,16 @@ def find_compose_command() -> list[str] | None:
     return None
 
 
-def start_docker_runner(compose_command: list[str]) -> RunnerHandle:
+def run_compose_stack(compose_command: list[str], port: int) -> int:
+    env = dict(os.environ)
+    env["BLOGHUB_PORT"] = str(port)
     result = subprocess.run(
-        [*compose_command, "up", "-d", "cli-runner"], cwd=ROOT, check=False
+        [*compose_command, "up", "--build"],
+        cwd=ROOT,
+        env=env,
+        check=False,
     )
-    if result.returncode != 0:
-        raise LauncherError("Docker Compose could not start cli-runner")
-    return RunnerHandle(kind="docker", compose_command=compose_command)
+    return result.returncode
 
 
 def local_runner_environment(base: dict[str, str] | None = None) -> dict[str, str]:
@@ -156,12 +158,6 @@ def stop_runner(handle: RunnerHandle | None) -> None:
             except subprocess.TimeoutExpired:
                 handle.process.kill()
                 handle.process.wait(timeout=5)
-    elif handle.kind == "docker" and handle.compose_command:
-        subprocess.run(
-            [*handle.compose_command, "stop", "cli-runner"],
-            cwd=ROOT,
-            check=False,
-        )
 
 
 def ensure_runner(runner_url: str, mode: str) -> tuple[RunnerHandle | None, dict | None]:
@@ -173,19 +169,8 @@ def ensure_runner(runner_url: str, mode: str) -> tuple[RunnerHandle | None, dict
         return RunnerHandle(kind="external"), health
     if mode == "external":
         raise LauncherError(f"No CLI runner is reachable at {runner_url}")
-
-    if mode in {"auto", "docker"}:
-        compose_command = find_compose_command()
-        if compose_command:
-            handle = start_docker_runner(compose_command)
-            try:
-                return handle, wait_for_runner(runner_url)
-            except LauncherError:
-                stop_runner(handle)
-                if mode == "docker":
-                    raise
-        elif mode == "docker":
-            raise LauncherError("Docker Compose is not available")
+    if mode != "local":
+        raise LauncherError("Local runner startup requires --runner local")
 
     handle = start_local_runner(runner_url)
     try:
@@ -200,10 +185,11 @@ def parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
     parser.add_argument("--port", type=int, help="backend port (default: first free from 8082)")
     parser.add_argument(
         "--runner",
-        choices=("auto", "docker", "local", "external", "off"),
+        choices=("auto", "compose", "docker", "local", "external", "off"),
         default=os.environ.get("BLOGHUB_RUNNER_MODE", "auto"),
-        help="runner startup mode (default: auto)",
+        help="stack mode; auto, compose, and docker use Docker Compose (default: auto)",
     )
+    parser.add_argument("--reload", action="store_true", help="reload a local backend")
     return parser.parse_known_args(argv)
 
 
@@ -212,6 +198,22 @@ def main(argv: list[str] | None = None) -> int:
     runner_url = os.environ.get("CLI_RUNNER_URL", DEFAULT_RUNNER_URL).rstrip("/")
     handle: RunnerHandle | None = None
     try:
+        if args.runner in {"auto", "compose", "docker"}:
+            if uvicorn_args:
+                raise LauncherError(
+                    "Uvicorn arguments are only supported with local, external, or off mode"
+                )
+            compose_command = find_compose_command()
+            if not compose_command:
+                raise LauncherError(
+                    "Docker Compose is required for common startup. Install Docker Desktop "
+                    "and enable integration for this WSL distribution"
+                )
+            port = args.port or 8082
+            print(f"\n  BlogHub stack: http://127.0.0.1:{port}/screens/settings/v2.html")
+            print("  Runtime:       Docker Compose (backend + cli-runner)\n")
+            return run_compose_stack(compose_command, port)
+
         handle, health = ensure_runner(runner_url, args.runner)
         providers = available_providers(health)
         if args.runner != "off" and not providers:
@@ -227,18 +229,21 @@ def main(argv: list[str] | None = None) -> int:
 
         backend_env = dict(os.environ)
         backend_env["CLI_RUNNER_URL"] = runner_url
+        command = [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "backend.main:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ]
+        if args.reload:
+            command.append("--reload")
+        command.extend(uvicorn_args)
         result = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "uvicorn",
-                "backend.main:app",
-                "--host",
-                "127.0.0.1",
-                "--port",
-                str(port),
-                *uvicorn_args,
-            ],
+            command,
             cwd=ROOT,
             env=backend_env,
             check=False,
@@ -246,7 +251,11 @@ def main(argv: list[str] | None = None) -> int:
         return result.returncode
     except LauncherError as exc:
         print(f"BlogHub startup failed: {exc}", file=sys.stderr)
-        print("Use --runner off only when agent features are intentionally disabled.", file=sys.stderr)
+        print(
+            "Use --runner local only for explicit host-CLI troubleshooting, or "
+            "--runner off when agent features are intentionally disabled.",
+            file=sys.stderr,
+        )
         return 1
     except KeyboardInterrupt:
         return 130

--- a/start.py
+++ b/start.py
@@ -210,7 +210,10 @@ def main(argv: list[str] | None = None) -> int:
                     "and enable integration for this WSL distribution"
                 )
             port = args.port or 8082
-            print(f"\n  BlogHub stack: http://127.0.0.1:{port}/screens/settings/v2.html")
+            print(
+                f"\n  BlogHub stack: http://127.0.0.1:{port}/screens/login/v1.html"
+                "?next=%2Fscreens%2Fsettings%2Fv2.html"
+            )
             print("  Runtime:       Docker Compose (backend + cli-runner)\n")
             return run_compose_stack(compose_command, port)
 
@@ -222,7 +225,10 @@ def main(argv: list[str] | None = None) -> int:
             )
 
         port = args.port or find_free_port()
-        page_url = f"http://127.0.0.1:{port}/screens/settings/v2.html"
+        page_url = (
+            f"http://127.0.0.1:{port}/screens/login/v1.html"
+            "?next=%2Fscreens%2Fsettings%2Fv2.html"
+        )
         runner_summary = "disabled" if args.runner == "off" else ", ".join(providers)
         print(f"\n  CLI runner: {runner_url} ({runner_summary})")
         print(f"  BlogHub:    {page_url}\n")

--- a/start.py
+++ b/start.py
@@ -1,26 +1,258 @@
-"""
-BlogHub dev launcher.
-Finds the first free port starting at 8082 and starts uvicorn there.
-Pass any extra uvicorn flags as arguments, e.g.:  python start.py --reload
-"""
+"""Start the BlogHub backend and the CLI runner as one development stack."""
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
 import socket
 import subprocess
 import sys
+import time
+from urllib.error import URLError
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+
+ROOT = Path(__file__).resolve().parent
+DEFAULT_RUNNER_URL = "http://127.0.0.1:8001"
+
+
+class LauncherError(RuntimeError):
+    pass
+
+
+@dataclass
+class RunnerHandle:
+    kind: str
+    process: subprocess.Popen | None = None
+    compose_command: list[str] | None = None
 
 
 def find_free_port(start: int = 8082, end: int = 8090) -> int:
     for port in range(start, end):
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             try:
-                s.bind(("127.0.0.1", port))
+                sock.bind(("127.0.0.1", port))
                 return port
             except OSError:
                 continue
-    raise RuntimeError(f"No free port found in range {start}-{end}")
+    raise LauncherError(f"No free backend port found in range {start}-{end - 1}")
 
 
-port = find_free_port()
-print(f"\n  BlogHub: http://localhost:{port}/screens/overview/v3.html\n")
-subprocess.run(
-    [sys.executable, "-m", "uvicorn", "backend.main:app", "--port", str(port), *sys.argv[1:]]
-)
+def runner_health(runner_url: str, *, timeout: float = 0.75) -> dict | None:
+    try:
+        with urlopen(f"{runner_url.rstrip('/')}/health", timeout=timeout) as response:
+            if response.status != 200:
+                return None
+            return json.loads(response.read().decode("utf-8"))
+    except (OSError, URLError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def available_providers(health: dict | None) -> list[str]:
+    providers = (health or {}).get("providers", {})
+    return sorted(name for name, status in providers.items() if status == "available")
+
+
+def wait_for_runner(
+    runner_url: str,
+    *,
+    process: subprocess.Popen | None = None,
+    timeout: float = 15.0,
+) -> dict:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        health = runner_health(runner_url)
+        if health:
+            return health
+        if process is not None and process.poll() is not None:
+            raise LauncherError(
+                f"CLI runner exited during startup with code {process.returncode}"
+            )
+        time.sleep(0.25)
+    raise LauncherError(f"CLI runner did not become healthy at {runner_url}")
+
+
+def find_compose_command() -> list[str] | None:
+    for command in (["docker", "compose"], ["docker-compose"]):
+        try:
+            result = subprocess.run(
+                [*command, "version"],
+                cwd=ROOT,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+                check=False,
+            )
+        except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+            continue
+        if result.returncode == 0:
+            return command
+    return None
+
+
+def start_docker_runner(compose_command: list[str]) -> RunnerHandle:
+    result = subprocess.run(
+        [*compose_command, "up", "-d", "cli-runner"], cwd=ROOT, check=False
+    )
+    if result.returncode != 0:
+        raise LauncherError("Docker Compose could not start cli-runner")
+    return RunnerHandle(kind="docker", compose_command=compose_command)
+
+
+def local_runner_environment(base: dict[str, str] | None = None) -> dict[str, str]:
+    env = dict(os.environ if base is None else base)
+    config_root = Path(
+        env.get("BLOGHUB_AGENT_CONFIG_DIR", ROOT / "data" / "agent-config")
+    ).resolve()
+    defaults = {
+        "RUNNER_HOME": config_root / "home",
+        "CLAUDE_CONFIG_DIR": config_root / "claude",
+        "CODEX_CONFIG_DIR": config_root / "codex",
+    }
+    for name, default in defaults.items():
+        path = Path(env.get(name, default)).expanduser().resolve()
+        path.mkdir(parents=True, exist_ok=True)
+        env[name] = str(path)
+    return env
+
+
+def start_local_runner(runner_url: str) -> RunnerHandle:
+    parsed = urlparse(runner_url)
+    if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost"}:
+        raise LauncherError(
+            "A local runner requires CLI_RUNNER_URL to use http://localhost"
+        )
+    port = parsed.port or 8001
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "main:app",
+            "--app-dir",
+            str(ROOT / "cli-runner"),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        cwd=ROOT,
+        env=local_runner_environment(),
+    )
+    return RunnerHandle(kind="local", process=process)
+
+
+def stop_runner(handle: RunnerHandle | None) -> None:
+    if handle is None:
+        return
+    if handle.kind == "local" and handle.process is not None:
+        if handle.process.poll() is None:
+            handle.process.terminate()
+            try:
+                handle.process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                handle.process.kill()
+                handle.process.wait(timeout=5)
+    elif handle.kind == "docker" and handle.compose_command:
+        subprocess.run(
+            [*handle.compose_command, "stop", "cli-runner"],
+            cwd=ROOT,
+            check=False,
+        )
+
+
+def ensure_runner(runner_url: str, mode: str) -> tuple[RunnerHandle | None, dict | None]:
+    if mode == "off":
+        return None, None
+
+    health = runner_health(runner_url)
+    if health:
+        return RunnerHandle(kind="external"), health
+    if mode == "external":
+        raise LauncherError(f"No CLI runner is reachable at {runner_url}")
+
+    if mode in {"auto", "docker"}:
+        compose_command = find_compose_command()
+        if compose_command:
+            handle = start_docker_runner(compose_command)
+            try:
+                return handle, wait_for_runner(runner_url)
+            except LauncherError:
+                stop_runner(handle)
+                if mode == "docker":
+                    raise
+        elif mode == "docker":
+            raise LauncherError("Docker Compose is not available")
+
+    handle = start_local_runner(runner_url)
+    try:
+        return handle, wait_for_runner(runner_url, process=handle.process)
+    except LauncherError:
+        stop_runner(handle)
+        raise
+
+
+def parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, help="backend port (default: first free from 8082)")
+    parser.add_argument(
+        "--runner",
+        choices=("auto", "docker", "local", "external", "off"),
+        default=os.environ.get("BLOGHUB_RUNNER_MODE", "auto"),
+        help="runner startup mode (default: auto)",
+    )
+    return parser.parse_known_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args, uvicorn_args = parse_args(list(argv if argv is not None else sys.argv[1:]))
+    runner_url = os.environ.get("CLI_RUNNER_URL", DEFAULT_RUNNER_URL).rstrip("/")
+    handle: RunnerHandle | None = None
+    try:
+        handle, health = ensure_runner(runner_url, args.runner)
+        providers = available_providers(health)
+        if args.runner != "off" and not providers:
+            raise LauncherError(
+                "CLI runner is healthy, but neither claude nor codex is installed"
+            )
+
+        port = args.port or find_free_port()
+        page_url = f"http://127.0.0.1:{port}/screens/settings/v2.html"
+        runner_summary = "disabled" if args.runner == "off" else ", ".join(providers)
+        print(f"\n  CLI runner: {runner_url} ({runner_summary})")
+        print(f"  BlogHub:    {page_url}\n")
+
+        backend_env = dict(os.environ)
+        backend_env["CLI_RUNNER_URL"] = runner_url
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "uvicorn",
+                "backend.main:app",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                *uvicorn_args,
+            ],
+            cwd=ROOT,
+            env=backend_env,
+            check=False,
+        )
+        return result.returncode
+    except LauncherError as exc:
+        print(f"BlogHub startup failed: {exc}", file=sys.stderr)
+        print("Use --runner off only when agent features are intentionally disabled.", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        return 130
+    finally:
+        stop_runner(handle)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/start.py
+++ b/start.py
@@ -75,7 +75,11 @@ def wait_for_runner(
 
 
 def find_compose_command() -> list[str] | None:
-    for command in (["docker", "compose"], ["docker-compose"]):
+    for command in (
+        ["docker", "compose"],
+        ["docker-compose"],
+        ["docker.exe", "compose"],
+    ):
         try:
             result = subprocess.run(
                 [*command, "version"],
@@ -206,8 +210,8 @@ def main(argv: list[str] | None = None) -> int:
             compose_command = find_compose_command()
             if not compose_command:
                 raise LauncherError(
-                    "Docker Compose is required for common startup. Install Docker Desktop "
-                    "and enable integration for this WSL distribution"
+                    "Docker Compose is required for common startup. Install the Compose "
+                    "plugin or start Docker Desktop"
                 )
             port = args.port or 8082
             print(

--- a/start.sh
+++ b/start.sh
@@ -1,74 +1,28 @@
 #!/usr/bin/env bash
-# start.sh — start BlogHub backend on a free port and bring up the cli-runner.
-#
-# Usage:
-#   ./start.sh            # auto-picks a free port
-#   ./start.sh 8080       # use a specific port
-#
-# The backend URL is printed at startup so you can open it in a browser.
-# Press Ctrl+C to stop everything.
-
+# Start the complete BlogHub development stack through the shared Python launcher.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-# ── Pick a port ───────────────────────────────────────────────────────────────
-if [[ "${1:-}" =~ ^[0-9]+$ ]]; then
-  PORT="$1"
-else
-  # Find a free TCP port
-  PORT=$(python3 -c "
-import socket
-s = socket.socket()
-s.bind(('127.0.0.1', 0))
-print(s.getsockname()[1])
-s.close()
-")
-fi
-
-# ── Start cli-runner ──────────────────────────────────────────────────────────
-echo "Starting cli-runner..."
-docker compose up -d cli-runner
-
-# Wait up to 15 s for it to be healthy
-for i in $(seq 1 30); do
-  if curl -sf http://localhost:8001/health >/dev/null 2>&1; then
-    echo "cli-runner ready on :8001"
-    break
-  fi
-  sleep 0.5
-  if [[ $i -eq 30 ]]; then
-    echo "WARNING: cli-runner did not become healthy within 15 s — continuing anyway"
-  fi
-done
-
-# ── Start backend ─────────────────────────────────────────────────────────────
-echo ""
-echo "Starting backend on http://127.0.0.1:${PORT}"
-echo "Open: http://127.0.0.1:${PORT}/screens/overview/v3.html"
-echo ""
-echo "Press Ctrl+C to stop."
-echo ""
-
-# Activate venv if present
 if [[ -f ".venv/Scripts/activate" ]]; then
-  # Windows venv via Git Bash
   source .venv/Scripts/activate
 elif [[ -f ".venv/bin/activate" ]]; then
   source .venv/bin/activate
 fi
 
-# Trap Ctrl+C to also stop docker
-cleanup() {
-  echo ""
-  echo "Stopping cli-runner..."
-  docker compose stop cli-runner 2>/dev/null || true
-  exit 0
-}
-trap cleanup INT TERM
+if command -v python >/dev/null 2>&1; then
+  PYTHON=python
+elif command -v python3 >/dev/null 2>&1; then
+  PYTHON=python3
+else
+  echo "BlogHub startup failed: Python is not available" >&2
+  exit 1
+fi
 
-python -m uvicorn backend.main:app \
-  --host 127.0.0.1 \
-  --port "$PORT" \
-  --reload
+ARGS=("$@")
+if [[ "${1:-}" =~ ^[0-9]+$ ]]; then
+  ARGS=(--port "$1" "${@:2}")
+fi
+
+exec "$PYTHON" start.py "${ARGS[@]}"

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_compose_wires_backend_to_healthy_runner_and_separate_storage():
+    compose = yaml.safe_load((ROOT / "docker-compose.yml").read_text(encoding="utf-8"))
+    services = compose["services"]
+    backend = services["backend"]
+
+    assert backend["environment"]["CLI_RUNNER_URL"] == "http://cli-runner:8001"
+    assert backend["depends_on"]["cli-runner"]["condition"] == "service_healthy"
+    assert "bloghub-data:/app/data" in backend["volumes"]
+    assert "bloghub-credential-keys:/run/bloghub-keys" in backend["volumes"]
+    assert services["cli-runner"]["healthcheck"]
+    assert services["backend"]["healthcheck"]

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -17,3 +17,11 @@ def test_compose_wires_backend_to_healthy_runner_and_separate_storage():
     assert "bloghub-credential-keys:/run/bloghub-keys" in backend["volumes"]
     assert services["cli-runner"]["healthcheck"]
     assert services["backend"]["healthcheck"]
+
+
+def test_cli_runner_installs_callback_http_client():
+    requirements = (ROOT / "cli-runner" / "requirements.txt").read_text(
+        encoding="utf-8"
+    ).splitlines()
+
+    assert any(requirement.startswith("httpx") for requirement in requirements)

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -32,11 +32,10 @@ def test_auto_mode_reuses_a_healthy_runner(monkeypatch):
     assert result == health
 
 
-def test_auto_mode_falls_back_to_local_runner(monkeypatch):
+def test_local_mode_starts_local_runner(monkeypatch):
     handle = start.RunnerHandle(kind="local", process=SimpleNamespace())
     health = {"status": "ok", "providers": {"openai": "available"}}
     monkeypatch.setattr(start, "runner_health", lambda url: None)
-    monkeypatch.setattr(start, "find_compose_command", lambda: None)
     monkeypatch.setattr(start, "start_local_runner", lambda url: handle)
     monkeypatch.setattr(
         start,
@@ -45,11 +44,68 @@ def test_auto_mode_falls_back_to_local_runner(monkeypatch):
     )
 
     result_handle, result_health = start.ensure_runner(
-        start.DEFAULT_RUNNER_URL, "auto"
+        start.DEFAULT_RUNNER_URL, "local"
     )
 
     assert result_handle is handle
     assert result_health == health
+
+
+def test_common_startup_requires_compose_without_local_fallback(monkeypatch):
+    monkeypatch.setattr(start, "find_compose_command", lambda: None)
+    monkeypatch.setattr(
+        start,
+        "ensure_runner",
+        lambda *args: (_ for _ in ()).throw(AssertionError("local fallback used")),
+    )
+
+    assert start.main([]) == 1
+
+
+def test_runner_orchestrator_rejects_implicit_local_fallback(monkeypatch):
+    monkeypatch.setattr(start, "runner_health", lambda url: None)
+    monkeypatch.setattr(
+        start,
+        "start_local_runner",
+        lambda *args: (_ for _ in ()).throw(AssertionError("local fallback used")),
+    )
+
+    try:
+        start.ensure_runner(start.DEFAULT_RUNNER_URL, "auto")
+    except start.LauncherError as exc:
+        assert "--runner local" in str(exc)
+    else:
+        raise AssertionError("implicit local fallback was accepted")
+
+
+def test_common_startup_runs_complete_compose_stack(monkeypatch):
+    command = ["docker", "compose"]
+    calls = []
+    monkeypatch.setattr(start, "find_compose_command", lambda: command)
+    monkeypatch.setattr(
+        start,
+        "run_compose_stack",
+        lambda compose, port: calls.append((compose, port)) or 0,
+    )
+
+    assert start.main(["--port", "8090"]) == 0
+    assert calls == [(command, 8090)]
+
+
+def test_compose_stack_passes_port_to_compose(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        start.subprocess,
+        "run",
+        lambda command, **kwargs: calls.append((command, kwargs))
+        or SimpleNamespace(returncode=0),
+    )
+
+    assert start.run_compose_stack(["docker", "compose"], 8090) == 0
+    command, kwargs = calls[0]
+    assert command == ["docker", "compose", "up", "--build"]
+    assert kwargs["env"]["BLOGHUB_PORT"] == "8090"
+    assert kwargs["cwd"] == start.ROOT
 
 
 def test_main_fails_before_backend_when_runner_has_no_provider(monkeypatch):
@@ -69,5 +125,5 @@ def test_main_fails_before_backend_when_runner_has_no_provider(monkeypatch):
         lambda *args, **kwargs: backend_started.append(args) or SimpleNamespace(returncode=0),
     )
 
-    assert start.main([]) == 1
+    assert start.main(["--runner", "external"]) == 1
     assert backend_started == []

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import start
+
+
+def test_local_runner_environment_creates_persistent_config_dirs(tmp_path):
+    env = start.local_runner_environment(
+        {"BLOGHUB_AGENT_CONFIG_DIR": str(tmp_path / "agent-config")}
+    )
+
+    assert env["RUNNER_HOME"] == str((tmp_path / "agent-config" / "home").resolve())
+    assert env["CLAUDE_CONFIG_DIR"].endswith("agent-config/claude")
+    assert env["CODEX_CONFIG_DIR"].endswith("agent-config/codex")
+    assert all(
+        start.Path(env[name]).is_dir()
+        for name in ("RUNNER_HOME", "CLAUDE_CONFIG_DIR", "CODEX_CONFIG_DIR")
+    )
+
+
+def test_auto_mode_reuses_a_healthy_runner(monkeypatch):
+    health = {"status": "ok", "providers": {"openai": "available"}}
+    monkeypatch.setattr(start, "runner_health", lambda url: health)
+    monkeypatch.setattr(
+        start, "start_local_runner", lambda url: (_ for _ in ()).throw(AssertionError())
+    )
+
+    handle, result = start.ensure_runner(start.DEFAULT_RUNNER_URL, "auto")
+
+    assert handle.kind == "external"
+    assert result == health
+
+
+def test_auto_mode_falls_back_to_local_runner(monkeypatch):
+    handle = start.RunnerHandle(kind="local", process=SimpleNamespace())
+    health = {"status": "ok", "providers": {"openai": "available"}}
+    monkeypatch.setattr(start, "runner_health", lambda url: None)
+    monkeypatch.setattr(start, "find_compose_command", lambda: None)
+    monkeypatch.setattr(start, "start_local_runner", lambda url: handle)
+    monkeypatch.setattr(
+        start,
+        "wait_for_runner",
+        lambda url, process=None: health,
+    )
+
+    result_handle, result_health = start.ensure_runner(
+        start.DEFAULT_RUNNER_URL, "auto"
+    )
+
+    assert result_handle is handle
+    assert result_health == health
+
+
+def test_main_fails_before_backend_when_runner_has_no_provider(monkeypatch):
+    health = {
+        "status": "ok",
+        "providers": {"anthropic": "missing", "openai": "missing"},
+    }
+    monkeypatch.setattr(
+        start,
+        "ensure_runner",
+        lambda url, mode: (start.RunnerHandle(kind="external"), health),
+    )
+    backend_started = []
+    monkeypatch.setattr(
+        start.subprocess,
+        "run",
+        lambda *args, **kwargs: backend_started.append(args) or SimpleNamespace(returncode=0),
+    )
+
+    assert start.main([]) == 1
+    assert backend_started == []

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -62,6 +62,19 @@ def test_common_startup_requires_compose_without_local_fallback(monkeypatch):
     assert start.main([]) == 1
 
 
+def test_compose_discovery_uses_windows_docker_from_wsl(monkeypatch):
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append(command)
+        return SimpleNamespace(returncode=0 if command[0] == "docker.exe" else 1)
+
+    monkeypatch.setattr(start.subprocess, "run", run)
+
+    assert start.find_compose_command() == ["docker.exe", "compose"]
+    assert calls[-1] == ["docker.exe", "compose", "version"]
+
+
 def test_runner_orchestrator_rejects_implicit_local_fallback(monkeypatch):
     monkeypatch.setattr(start, "runner_health", lambda url: None)
     monkeypatch.setattr(

--- a/tests/tests_backend/test_cli_runner.py
+++ b/tests/tests_backend/test_cli_runner.py
@@ -1,0 +1,11 @@
+from backend.services.cli_runner import api_key_from_connection_token
+
+
+def test_real_api_key_is_forwarded_to_runner():
+    assert api_key_from_connection_token("sk-openai-secret") == "sk-openai-secret"
+
+
+def test_persisted_cli_session_markers_do_not_override_runner_login():
+    assert api_key_from_connection_token("web_session:openai") is None
+    assert api_key_from_connection_token("cli_session") is None
+    assert api_key_from_connection_token(None) is None

--- a/tests/tests_backend/test_cli_runner_auth.py
+++ b/tests/tests_backend/test_cli_runner_auth.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+def _runner_module():
+    path = Path(__file__).resolve().parents[2] / "cli-runner" / "main.py"
+    spec = importlib.util.spec_from_file_location("bloghub_cli_runner", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_runner_redacts_callback_secrets_and_device_codes():
+    runner = _runner_module()
+    reason = runner._safe_reason(
+        "failed https://localhost/callback?code=secret&state=temporary ABCD-EFGH"
+    )
+    assert "secret" not in reason
+    assert "temporary" not in reason
+    assert "ABCD-EFGH" not in reason
+
+
+def test_runner_normalizes_actionable_failure_states():
+    runner = _runner_module()
+    assert runner._failure_status("access denied")[0] == "rejected"
+    assert runner._failure_status("429 too many requests")[0] == "rate_limited"
+    assert runner._failure_status("authorization expired")[0] == "expired"
+    assert runner._failure_status("login timed out")[0] == "timed_out"
+
+
+def test_task_request_accepts_an_ephemeral_api_key():
+    runner = _runner_module()
+    request = runner.TaskRequest(
+        provider="openai", task="generate", article_md="prompt", api_key="secret"
+    )
+    assert request.api_key == "secret"

--- a/tests/tests_backend/test_connection_auth.py
+++ b/tests/tests_backend/test_connection_auth.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.services import connection_auth
+from backend.store.backends.sqlite import SQLiteStore
+from backend.store.crypto import configure_key_provider
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "BLOGHUB_CREDENTIAL_KEY_FILE", str(tmp_path / "credential-keys.json")
+    )
+    configure_key_provider(None)
+    instance = SQLiteStore(str(tmp_path / "bloghub.db"), str(tmp_path / "blobs"))
+    yield instance
+    instance.close()
+    configure_key_provider(None)
+
+
+def test_anthropic_callback_flow_connects_without_persisting_callback(
+    store, monkeypatch,
+):
+    monkeypatch.setattr(
+        connection_auth.runner,
+        "login",
+        lambda provider: {
+            "available": True,
+            "url": "https://claude.example/authorize?state=temporary",
+        },
+    )
+    submitted = []
+    monkeypatch.setattr(
+        connection_auth.runner,
+        "submit_login_callback",
+        lambda provider, callback: submitted.append((provider, callback)) or {
+            "status": "submitted"
+        },
+    )
+    statuses = iter(
+        [
+            {"status": "pending"},
+            {"status": "connected", "username": "writer@example.com"},
+        ]
+    )
+    monkeypatch.setattr(connection_auth.runner, "login_status", lambda provider: next(statuses))
+
+    started = connection_auth.start(store, store.SEED_USER_ID, "anthropic")
+    assert started["flow_type"] == "browser_callback"
+    callback = "http://localhost:54322/callback?code=secret-code&state=secret-state"
+    connection_auth.submit_callback(store, store.SEED_USER_ID, started["flow_id"], callback)
+    assert submitted == [("anthropic", callback)]
+    database_dump = " ".join(
+        str(value)
+        for row in store._con.iterdump()
+        for value in (row,)
+    )
+    assert "secret-code" not in database_dump
+    assert "secret-state" not in database_dump
+    assert connection_auth.status(store, store.SEED_USER_ID, started["flow_id"])["status"] == "waiting_for_authorization"
+    completed = connection_auth.status(store, store.SEED_USER_ID, started["flow_id"])
+    assert completed["status"] == "connected"
+    assert completed["username"] == "writer@example.com"
+    assert store.get_connection_token(store.SEED_USER_ID, "anthropic") == "web_session:anthropic"
+
+
+def test_openai_device_code_flow_and_rate_limit_state(store, monkeypatch):
+    monkeypatch.setattr(
+        connection_auth.runner,
+        "login",
+        lambda provider: {
+            "available": True,
+            "url": "https://openai.example/device",
+            "device_code": "ABCD-EFGH",
+        },
+    )
+    monkeypatch.setattr(
+        connection_auth.runner,
+        "login_status",
+        lambda provider: {
+            "status": "rate_limited",
+            "reason": "Too many requests",
+            "error_code": "rate_limited",
+        },
+    )
+
+    started = connection_auth.start(store, store.SEED_USER_ID, "openai")
+    assert started["flow_type"] == "device_code"
+    assert started["device_code"] == "ABCD-EFGH"
+    failed = connection_auth.status(store, store.SEED_USER_ID, started["flow_id"])
+    assert failed["status"] == "rate_limited"
+    assert "Wait a few minutes" in failed["recovery"]
+
+
+def test_cancel_stops_runner_without_logging_out_existing_session(store, monkeypatch):
+    monkeypatch.setattr(
+        connection_auth.runner,
+        "login",
+        lambda provider: {"available": True, "url": "https://openai.example/device"},
+    )
+    canceled = []
+    monkeypatch.setattr(
+        connection_auth.runner, "cancel_login", lambda provider: canceled.append(provider)
+    )
+    started = connection_auth.start(store, store.SEED_USER_ID, "openai")
+    result = connection_auth.cancel(store, store.SEED_USER_ID, started["flow_id"])
+    assert result["status"] == "canceled"
+    assert canceled == ["openai"]
+
+
+def test_provider_rejection_callback_becomes_explicit_state(store, monkeypatch):
+    monkeypatch.setattr(
+        connection_auth.runner,
+        "login",
+        lambda provider: {"available": True, "url": "https://claude.example/auth"},
+    )
+    canceled = []
+    monkeypatch.setattr(
+        connection_auth.runner, "cancel_login", lambda provider: canceled.append(provider)
+    )
+    started = connection_auth.start(store, store.SEED_USER_ID, "anthropic")
+
+    rejected = connection_auth.submit_callback(
+        store,
+        store.SEED_USER_ID,
+        started["flow_id"],
+        "http://localhost:54322/callback?error=access_denied&state=temporary",
+    )
+
+    assert rejected["status"] == "rejected"
+    assert rejected["error_code"] == "authorization_rejected"
+    assert canceled == ["anthropic"]

--- a/tests/tests_backend/test_connection_auth_api.py
+++ b/tests/tests_backend/test_connection_auth_api.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+import backend.services.connection_auth as connection_auth
+
+
+def test_browser_callback_flow_uses_shared_api_contract(
+    client: TestClient, monkeypatch,
+):
+    monkeypatch.setattr(
+        connection_auth.runner,
+        "login",
+        lambda provider: {
+            "available": True,
+            "url": "https://claude.example/authorize?state=temporary",
+        },
+    )
+    callbacks = []
+    monkeypatch.setattr(
+        connection_auth.runner,
+        "submit_login_callback",
+        lambda provider, callback: callbacks.append((provider, callback)),
+    )
+    monkeypatch.setattr(
+        connection_auth.runner,
+        "login_status",
+        lambda provider: {"status": "connected", "username": "writer@example.com"},
+    )
+
+    started = client.post("/api/connections/anthropic/auth-flows")
+    assert started.status_code == 201
+    flow = started.json()
+    assert flow["provider"] == "anthropic"
+    assert flow["flowType"] == "browser_callback"
+    assert flow["status"] == "waiting_for_authorization"
+
+    callback = "http://localhost:54322/callback?code=secret-code&state=secret-state"
+    submitted = client.post(
+        f"/api/connections/auth-flows/{flow['flowId']}/callback",
+        json={"callbackUrl": callback},
+    )
+    assert submitted.status_code == 200
+    assert callbacks == [("anthropic", callback)]
+
+    completed = client.get(f"/api/connections/auth-flows/{flow['flowId']}")
+    assert completed.status_code == 200
+    assert completed.json()["status"] == "connected"
+    assert completed.json()["username"] == "writer@example.com"
+
+
+def test_device_code_flow_uses_same_status_endpoint(
+    client: TestClient, monkeypatch,
+):
+    monkeypatch.setattr(
+        connection_auth.runner,
+        "login",
+        lambda provider: {
+            "available": True,
+            "url": "https://openai.example/device",
+            "device_code": "ABCD-EFGH",
+        },
+    )
+    monkeypatch.setattr(
+        connection_auth.runner,
+        "login_status",
+        lambda provider: {"status": "pending"},
+    )
+
+    started = client.post("/api/connections/openai/auth-flows")
+    assert started.status_code == 201
+    flow = started.json()
+    assert flow["flowType"] == "device_code"
+    assert flow["deviceCode"] == "ABCD-EFGH"
+
+    active = client.get("/api/connections/auth-flows/active")
+    assert active.status_code == 200
+    assert [item["flowId"] for item in active.json()["flows"]] == [flow["flowId"]]
+
+    pending = client.get(f"/api/connections/auth-flows/{flow['flowId']}")
+    assert pending.status_code == 200
+    assert pending.json()["status"] == "waiting_for_authorization"
+
+
+def test_callback_flow_requires_authentication(anon_client: TestClient):
+    response = anon_client.post("/api/connections/anthropic/auth-flows")
+    assert response.status_code == 401

--- a/tests/tests_backend/test_credential_storage.py
+++ b/tests/tests_backend/test_credential_storage.py
@@ -154,6 +154,7 @@ def test_invalid_environment_key_fails_configuration(credential_environment, mon
         '{"access_token":"oauth-secret","ok":true}',
         'Cookie: session=private; theme=dark',
         'auth_code=temporary-code',
+        'callbackUrl=http://localhost/callback?code=temporary-code&state=temporary-state',
     ],
 )
 def test_redaction_removes_secrets(value):

--- a/tests/tests_backend/test_store/test_connection_auth_flows.py
+++ b/tests/tests_backend/test_store/test_connection_auth_flows.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import backend.store.connection_auth as connection_auth
+from backend.store.backends.sqlite import SQLiteStore
+from backend.store.crypto import configure_key_provider
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "BLOGHUB_CREDENTIAL_KEY_FILE", str(tmp_path / "credential-keys.json")
+    )
+    configure_key_provider(None)
+    instance = SQLiteStore(str(tmp_path / "bloghub.db"), str(tmp_path / "blobs"))
+    yield instance
+    instance.close()
+    configure_key_provider(None)
+
+
+def test_auth_flow_secrets_are_encrypted_and_survive_restart(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "BLOGHUB_CREDENTIAL_KEY_FILE", str(tmp_path / "credential-keys.json")
+    )
+    configure_key_provider(None)
+    database = tmp_path / "bloghub.db"
+    blobs = tmp_path / "blobs"
+    first = SQLiteStore(str(database), str(blobs))
+    flow = first.create_connection_auth_flow(
+        first.SEED_USER_ID,
+        "openai",
+        "device_code",
+        authorization_url="https://provider.example/device",
+        device_code="ABCD-EFGH",
+    )
+    raw = first._con.execute(
+        """SELECT authorization_url_secret, device_code_secret
+           FROM connection_auth_flows WHERE id=?""",
+        (flow["id"],),
+    ).fetchone()
+    assert raw[0].startswith("enc:v1:")
+    assert raw[1].startswith("enc:v1:")
+    assert "provider.example" not in raw[0]
+    assert "ABCD-EFGH" not in raw[1]
+    first.close()
+
+    reopened = SQLiteStore(str(database), str(blobs))
+    restored = reopened.get_connection_auth_flow(reopened.SEED_USER_ID, flow["id"])
+    assert restored["authorization_url"] == "https://provider.example/device"
+    assert restored["device_code"] == "ABCD-EFGH"
+    assert restored["status"] == "waiting_for_authorization"
+    reopened.close()
+    configure_key_provider(None)
+
+
+def test_new_flow_cancels_previous_flow_for_same_provider(store):
+    first = store.create_connection_auth_flow(
+        store.SEED_USER_ID,
+        "anthropic",
+        "browser_callback",
+        authorization_url="https://provider.example/first",
+    )
+    second = store.create_connection_auth_flow(
+        store.SEED_USER_ID,
+        "anthropic",
+        "browser_callback",
+        authorization_url="https://provider.example/second",
+    )
+    assert store.get_connection_auth_flow(store.SEED_USER_ID, first["id"])["status"] == "canceled"
+    assert store.get_latest_connection_auth_flow(
+        store.SEED_USER_ID, "anthropic", active_only=True
+    )["id"] == second["id"]
+
+
+def test_expired_flow_becomes_timed_out_with_connection_state(store, monkeypatch):
+    start = datetime(2026, 8, 10, tzinfo=timezone.utc)
+    monkeypatch.setattr(connection_auth, "_now", lambda: start)
+    flow = store.create_connection_auth_flow(
+        store.SEED_USER_ID,
+        "openai",
+        "device_code",
+        authorization_url="https://provider.example/device",
+        ttl_seconds=30,
+    )
+    monkeypatch.setattr(
+        connection_auth, "_now", lambda: start + timedelta(seconds=31)
+    )
+    expired = store.get_connection_auth_flow(store.SEED_USER_ID, flow["id"])
+    connection = next(
+        item for item in store.list_connections(store.SEED_USER_ID)
+        if item["id"] == "openai"
+    )
+    assert expired["status"] == "timed_out"
+    assert expired["error_code"] == "authorization_timeout"
+    assert connection["status"] == "timed_out"
+
+
+def test_flow_is_scoped_to_its_owner(store):
+    flow = store.create_connection_auth_flow(
+        store.SEED_USER_ID,
+        "openai",
+        "device_code",
+        authorization_url="https://provider.example/device",
+    )
+    assert store.get_connection_auth_flow("another-user", flow["id"]) is None

--- a/tests/tests_backend/test_store/test_schema.py
+++ b/tests/tests_backend/test_store/test_schema.py
@@ -21,6 +21,7 @@ def test_fresh_database_has_current_schema_and_seed_user(tmp_path):
             "article_destinations",
             "article_timeline",
             "connections",
+            "connection_auth_flows",
             "jobs",
             "article_assets",
             "article_comments",

--- a/tests/tests_ui/conftest.py
+++ b/tests/tests_ui/conftest.py
@@ -114,6 +114,15 @@ def requests_session():
 @pytest.fixture
 def settings_page(page):
     """Navigate to the settings screen and return the page."""
+    response = page.request.post(
+        f"{BASE_URL}/api/auth/login",
+        data={
+            "email": "seed@example.com",
+            "password": "seed1234",
+            "remember_me": False,
+        },
+    )
+    assert response.ok
     page.goto(f"{BASE_URL}/screens/settings/v2.html")
     return page
 

--- a/tests/tests_ui/screens/test_login.py
+++ b/tests/tests_ui/screens/test_login.py
@@ -114,6 +114,18 @@ class TestLoginHappyPath:
         page.wait_for_url("**/overview/v3.html", timeout=6000)
         assert "/overview/v3.html" in page.url
 
+    def test_login_returns_to_requested_local_page(self, page):
+        page.goto(f"{LOGIN_URL}?next=%2Fscreens%2Fsettings%2Fv2.html")
+        _fill_login(page, _SEED_EMAIL, _SEED_PASSWORD)
+        _submit(page)
+        page.wait_for_url("**/screens/settings/v2.html", timeout=8000)
+
+    def test_login_rejects_external_return_destination(self, page):
+        page.goto(f"{LOGIN_URL}?next=https%3A%2F%2Fexample.com")
+        _fill_login(page, _SEED_EMAIL, _SEED_PASSWORD)
+        _submit(page)
+        page.wait_for_url("**/screens/overview/v3.html", timeout=8000)
+
 
 # ── Happy path — Register ─────────────────────────────────────────────────────
 

--- a/tests/tests_ui/screens/test_settings.py
+++ b/tests/tests_ui/screens/test_settings.py
@@ -213,6 +213,45 @@ def test_callback_flow_uses_shared_contract_and_updates_without_reload(page):
     assert state["polls"] >= 1
 
 
+def test_callback_poll_does_not_erase_pasted_url(page):
+    waiting = {
+        "flowId": "auth_callback_1", "provider": "anthropic",
+        "flowType": "browser_callback", "status": "waiting_for_authorization",
+        "authorizationUrl": "https://provider.example/authorize", "deviceCode": None,
+        "username": None, "errorCode": None, "errorMessage": None, "recovery": None,
+        "expiresAt": "2026-08-10T10:05:00Z", "createdAt": "2026-08-10T10:00:00Z",
+        "updatedAt": "2026-08-10T10:00:00Z",
+    }
+    page.route(
+        f"{BASE_URL}/api/connections",
+        lambda route: route.fulfill(json=_connection_payload()),
+    )
+    page.route(
+        f"{BASE_URL}/api/connections/auth-flows/active",
+        lambda route: route.fulfill(json={"flows": []}),
+    )
+    page.route(
+        f"{BASE_URL}/api/connections/anthropic/auth-flows",
+        lambda route: route.fulfill(status=201, json=waiting),
+    )
+    page.route(
+        f"{BASE_URL}/api/connections/auth-flows/auth_callback_1",
+        lambda route: route.fulfill(json=waiting),
+    )
+
+    page.goto(SETTINGS_URL)
+    page.get_by_role("button", name="AI Providers").click()
+    page.evaluate("window.open = () => null")
+    page.locator("#ai-wrap-anthropic").get_by_role(
+        "button", name="Login with browser"
+    ).click()
+    callback = page.locator("#callback-input-anthropic")
+    callback.fill("http://localhost:54322/callback?code=secret&state=temporary")
+    page.wait_for_timeout(2500)
+
+    assert callback.input_value().endswith("code=secret&state=temporary")
+
+
 def test_device_code_flow_shows_code_and_updates_without_reload(page):
     state = {"connected": False}
 

--- a/tests/tests_ui/screens/test_settings.py
+++ b/tests/tests_ui/screens/test_settings.py
@@ -26,6 +26,14 @@ pytestmark = pytest.mark.browser
 # ── 1. Initial load ────────────────────────────────────────────────────────────
 
 
+def test_unauthenticated_settings_redirects_to_login(page):
+    page.goto(SETTINGS_URL)
+    page.wait_for_url("**/screens/login/v1.html?next=**")
+    assert page.url.endswith(
+        "/screens/login/v1.html?next=%2Fscreens%2Fsettings%2Fv2.html"
+    )
+
+
 def test_renders_platforms_section_by_default(settings_page):
     settings_page.get_by_role("heading", name="Publishing Platforms").wait_for()
 

--- a/tests/tests_ui/screens/test_settings.py
+++ b/tests/tests_ui/screens/test_settings.py
@@ -10,8 +10,8 @@ Claude browser login test:
         https://claude.ai/oauth/authorize?...&redirect_uri=http://localhost:{PORT}/callback&...
     After the user authorizes, the browser tries to redirect to that localhost
     URL — which fails (port is inside Docker). The callback URL with code+state
-    is captured from the failed network request and submitted to
-    POST /api/connections/anthropic/submit-code. The runner forwards it to the
+    is captured from the failed network request and submitted to the durable,
+    provider-neutral auth-flow callback endpoint. The runner forwards it to the
     CLI's internal server, token exchange succeeds, and the card shows Connected.
 """
 import re
@@ -70,8 +70,8 @@ def test_claude_browser_login_full_loopback_flow(page, context):
     3. Authorize — claude.ai redirects to the loopback callback URL.
     4. Redirect fails (port is inside Docker); callback URL is captured from
        the failed network request via Playwright's request listener.
-    5. Submit the full callback URL to POST /api/connections/anthropic/submit-code.
-    6. Poll cli-login-status until connected.
+    5. Submit the full callback URL to the provider-neutral auth-flow endpoint.
+    6. Poll the durable auth flow until connected.
     7. Assert the card shows Connected.
     """
     page.goto(SETTINGS_URL)
@@ -118,24 +118,17 @@ def test_claude_browser_login_full_loopback_flow(page, context):
     assert "code=" in callback_url
     assert "state=" in callback_url
 
-    # Submit the callback URL to the backend
-    res = requests.post(
-        f"{BASE_URL}/api/connections/anthropic/submit-code",
-        json={"code": callback_url},
-    )
-    assert res.status_code == 200
-
-    # Poll the backend's cli-login-status until connected (up to 20 s)
-    import time
-    deadline = time.time() + 20
-    backend_status = None
-    while time.time() < deadline:
-        r = requests.get(f"{BASE_URL}/api/connections/anthropic/cli-login-status")
-        backend_status = r.json().get("status")
-        if backend_status == "connected":
-            break
-        time.sleep(1)
-    assert backend_status == "connected", f"Backend status: {backend_status}"
+    page.bring_to_front()
+    callback_input = page.locator("#callback-input-anthropic")
+    callback_input.fill(callback_url)
+    with page.expect_request(
+        lambda req: "/api/connections/auth-flows/" in req.url
+        and req.url.endswith("/callback") and req.method == "POST"
+    ) as callback_request:
+        page.locator("#callback-area-anthropic").get_by_role(
+            "button", name="Submit"
+        ).click()
+    assert callback_request.value.post_data_json["callbackUrl"] == callback_url
 
     # Verify the CLI itself is authenticated via the runner (not just the in-memory store)
     runner_status = requests.get(f"{RUNNER_URL}/auth/anthropic/status").json()
@@ -143,8 +136,138 @@ def test_claude_browser_login_full_loopback_flow(page, context):
         f"CLI runner reports not authenticated: {runner_status}")
 
     # UI should reflect Connected
-    page.bring_to_front()
     page.locator("#ai-wrap-anthropic").get_by_text("Connected").wait_for(timeout=10_000)
+
+
+def _connection_payload(anthropic="disconnected", openai="disconnected"):
+    def item(conn_id, status):
+        return {
+            "id": conn_id,
+            "label": "Anthropic" if conn_id == "anthropic" else "OpenAI",
+            "type": "ai",
+            "authMethod": "oauth_or_token",
+            "status": status,
+            "username": "writer@example.com" if status == "connected" else None,
+            "connectedAt": "2026-08-10T10:00:00Z" if status == "connected" else None,
+            "errorMessage": None,
+        }
+    return {"connections": [item("anthropic", anthropic), item("openai", openai)]}
+
+
+def test_callback_flow_uses_shared_contract_and_updates_without_reload(page):
+    state = {"connected": False, "polls": 0}
+
+    def connections(route):
+        status = "connected" if state["connected"] else "disconnected"
+        route.fulfill(json=_connection_payload(anthropic=status))
+
+    def flow_status(route):
+        state["polls"] += 1
+        state["connected"] = True
+        route.fulfill(json={
+            "flowId": "auth_callback_1", "provider": "anthropic",
+            "flowType": "browser_callback", "status": "connected",
+            "username": "writer@example.com", "authorizationUrl": None,
+            "deviceCode": None, "errorCode": None, "errorMessage": None,
+            "recovery": None, "expiresAt": "2026-08-10T10:05:00Z",
+            "createdAt": "2026-08-10T10:00:00Z", "updatedAt": "2026-08-10T10:01:00Z",
+        })
+
+    page.route(f"{BASE_URL}/api/connections", connections)
+    page.route(f"{BASE_URL}/api/connections/auth-flows/active", lambda route: route.fulfill(json={"flows": []}))
+    page.route(f"{BASE_URL}/api/connections/anthropic/auth-flows", lambda route: route.fulfill(status=201, json={
+        "flowId": "auth_callback_1", "provider": "anthropic",
+        "flowType": "browser_callback", "status": "waiting_for_authorization",
+        "authorizationUrl": "https://provider.example/authorize", "deviceCode": None,
+        "username": None, "errorCode": None, "errorMessage": None, "recovery": None,
+        "expiresAt": "2026-08-10T10:05:00Z", "createdAt": "2026-08-10T10:00:00Z",
+        "updatedAt": "2026-08-10T10:00:00Z",
+    }))
+    page.route(f"{BASE_URL}/api/connections/auth-flows/auth_callback_1/callback", lambda route: route.fulfill(json={
+        "flowId": "auth_callback_1", "provider": "anthropic",
+        "flowType": "browser_callback", "status": "waiting_for_authorization",
+        "authorizationUrl": None, "deviceCode": None, "username": None,
+        "errorCode": None, "errorMessage": None, "recovery": None,
+        "expiresAt": "2026-08-10T10:05:00Z", "createdAt": "2026-08-10T10:00:00Z",
+        "updatedAt": "2026-08-10T10:00:10Z",
+    }))
+    page.route(f"{BASE_URL}/api/connections/auth-flows/auth_callback_1", flow_status)
+
+    page.goto(SETTINGS_URL)
+    page.get_by_role("button", name="AI Providers").click()
+    page.evaluate("window.open = () => null")
+    page.locator("#ai-wrap-anthropic").get_by_role("button", name="Login with browser").click()
+    page.locator("#callback-input-anthropic").fill(
+        "http://localhost:54322/callback?code=secret&state=temporary"
+    )
+    page.locator("#callback-area-anthropic").get_by_role("button", name="Submit").click()
+    page.locator("#ai-wrap-anthropic").get_by_text("Connected").wait_for(timeout=7000)
+    assert state["polls"] >= 1
+
+
+def test_device_code_flow_shows_code_and_updates_without_reload(page):
+    state = {"connected": False}
+
+    def connections(route):
+        status = "connected" if state["connected"] else "disconnected"
+        route.fulfill(json=_connection_payload(openai=status))
+
+    def flow_status(route):
+        state["connected"] = True
+        route.fulfill(json={
+            "flowId": "auth_device_1", "provider": "openai", "flowType": "device_code",
+            "status": "connected", "username": "writer@example.com",
+            "authorizationUrl": None, "deviceCode": None, "errorCode": None,
+            "errorMessage": None, "recovery": None, "expiresAt": "2026-08-10T10:05:00Z",
+            "createdAt": "2026-08-10T10:00:00Z", "updatedAt": "2026-08-10T10:01:00Z",
+        })
+
+    page.route(f"{BASE_URL}/api/connections", connections)
+    page.route(f"{BASE_URL}/api/connections/auth-flows/active", lambda route: route.fulfill(json={"flows": []}))
+    page.route(f"{BASE_URL}/api/connections/openai/auth-flows", lambda route: route.fulfill(status=201, json={
+        "flowId": "auth_device_1", "provider": "openai", "flowType": "device_code",
+        "status": "waiting_for_authorization", "authorizationUrl": "https://provider.example/device",
+        "deviceCode": "ABCD-EFGH", "username": None, "errorCode": None,
+        "errorMessage": None, "recovery": None, "expiresAt": "2026-08-10T10:05:00Z",
+        "createdAt": "2026-08-10T10:00:00Z", "updatedAt": "2026-08-10T10:00:00Z",
+    }))
+    page.route(f"{BASE_URL}/api/connections/auth-flows/auth_device_1", flow_status)
+
+    page.goto(SETTINGS_URL)
+    page.get_by_role("button", name="AI Providers").click()
+    page.evaluate("window.open = () => null")
+    page.locator("#ai-wrap-openai").get_by_role("button", name="Login with browser").click()
+    page.locator("#auth-flow-row-openai").get_by_text("ABCD-EFGH").wait_for()
+    page.locator("#ai-wrap-openai").get_by_text("Connected").wait_for(timeout=7000)
+
+
+@pytest.mark.parametrize(
+    ("status", "label"),
+    [
+        ("expired", "Authorization expired"),
+        ("rejected", "Authorization rejected"),
+        ("timed_out", "Login timed out"),
+        ("rate_limited", "Rate limited"),
+        ("failed", "Login failed"),
+    ],
+)
+def test_agent_login_failure_states_are_explicit(page, status, label):
+    payload = _connection_payload(anthropic=status)
+    payload["connections"][0]["errorMessage"] = "Provider authorization did not complete"
+    page.route(
+        f"{BASE_URL}/api/connections",
+        lambda route: route.fulfill(json=payload),
+    )
+    page.route(
+        f"{BASE_URL}/api/connections/auth-flows/active",
+        lambda route: route.fulfill(json={"flows": []}),
+    )
+
+    page.goto(SETTINGS_URL)
+    page.get_by_role("button", name="AI Providers").click()
+    card = page.locator("#ai-wrap-anthropic")
+    card.get_by_text(label, exact=True).wait_for()
+    card.get_by_text("Provider authorization did not complete", exact=True).wait_for()
 
 
 # ── 4. Disconnect ──────────────────────────────────────────────────────────────

--- a/tests/tests_ui/screens/test_settings.py
+++ b/tests/tests_ui/screens/test_settings.py
@@ -209,7 +209,7 @@ def test_device_code_flow_shows_code_and_updates_without_reload(page):
     state = {"connected": False}
 
     def connections(route):
-        status = "connected" if state["connected"] else "disconnected"
+        status = "connected" if state["connected"] else "timed_out"
         route.fulfill(json=_connection_payload(openai=status))
 
     def flow_status(route):
@@ -236,8 +236,10 @@ def test_device_code_flow_shows_code_and_updates_without_reload(page):
     page.goto(SETTINGS_URL)
     page.get_by_role("button", name="AI Providers").click()
     page.evaluate("window.open = () => null")
-    page.locator("#ai-wrap-openai").get_by_role("button", name="Login with browser").click()
-    page.locator("#auth-flow-row-openai").get_by_text("ABCD-EFGH").wait_for()
+    card = page.locator("#ai-wrap-openai")
+    card.get_by_role("button", name="Reconnect").click()
+    card.get_by_text("Waiting for authorization", exact=True).wait_for()
+    card.locator("#auth-flow-row-openai").get_by_text("ABCD-EFGH").wait_for()
     page.locator("#ai-wrap-openai").get_by_text("Connected").wait_for(timeout=7000)
 
 


### PR DESCRIPTION
Closes #7

## What changed

- adds one provider-neutral API for Anthropic loopback callbacks and OpenAI device-code login
- persists auth flows in SQLite, encrypting authorization URLs and device codes
- resumes active flows across backend restarts and keeps CLI credentials in protected runner volumes
- adds explicit expired, rejected, timed-out, rate-limited, failed, and canceled states with recovery guidance
- updates Settings without a page reload and supports disconnect/reconnect
- preserves callback input while auth status polling is active
- redacts callback query secrets and removes auth output from the runner debug response
- preserves manual API-key execution while allowing persisted CLI web sessions
- makes Docker Compose the canonical startup path, including Docker Desktop discovery from WSL

## Validation

- focused backend, store, runner, schema, redaction, Compose, and Settings tests pass
- live Playwright flow confirms Anthropic callback input survives repeated polling
- Docker Compose reports healthy backend and CLI runner services
- Anthropic and OpenAI web-login sessions were both manually verified as connected
- callback, device-code, restart, ownership, cancellation, and terminal UI-state browser coverage is included

## Follow-up

Editor chat will be implemented as separate work after this provider-login foundation is merged.
