### PR TITLE
feat: add durable editor agent chat

### DIFF
--- a/backend/middleware/auth.py
+++ b/backend/middleware/auth.py
@@ -1,11 +1,14 @@
 """Auth middleware — enforces session cookie on all /api/* routes."""
 from __future__ import annotations
 
+import os
+
 from fastapi import Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
 import backend.store as store
+from backend.store.schema import SEED_USER_ID
 
 _COOKIE = "bloghub_session"
 
@@ -15,6 +18,15 @@ _PUBLIC_PATHS = {
     "/api/auth/login",
     "/api/dev/reset",
 }
+
+
+def _auth_disabled() -> bool:
+    return os.environ.get("BLOGHUB_DISABLE_AUTH", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 
 def _is_public(path: str) -> bool:
@@ -27,6 +39,10 @@ def _is_public(path: str) -> bool:
 
 class AuthMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
+        if _auth_disabled():
+            request.state.user_id = SEED_USER_ID
+            return await call_next(request)
+
         if _is_public(request.url.path):
             return await call_next(request)
 

--- a/backend/routers/agent_sessions.py
+++ b/backend/routers/agent_sessions.py
@@ -1,14 +1,17 @@
 """Lifecycle and recovery API for durable agent sessions."""
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Query, Request, Response
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Query, Request, Response
 from fastapi.responses import JSONResponse
 
 import backend.store as store
+import backend.services.agent_chat as agent_chat
+import backend.services.cli_runner as runner
 from backend.schemas.agent_sessions import (
     AddCheckpointRequest,
     AddMessageRequest,
     AddOutputRequest,
+    ChatTurnRequest,
     CompleteToolCallRequest,
     CreateAgentSessionRequest,
     RecordToolCallRequest,
@@ -71,6 +74,40 @@ def add_message(request: Request, session_id: str, body: AddMessageRequest):
         raise _not_found(exc) from exc
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.post("/{session_id}/turns", status_code=202)
+def run_chat_turn(
+    request: Request, session_id: str, body: ChatTurnRequest,
+    background_tasks: BackgroundTasks,
+):
+    user_id = request.state.user_id
+    session = store.get_agent_session(user_id, session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Agent session not found")
+    if session["provider"] not in {"anthropic", "openai"}:
+        raise HTTPException(status_code=422, detail="Select Anthropic or OpenAI")
+    connection = next(
+        (item for item in store.list_connections(user_id)
+         if item["id"] == session["provider"]), None
+    )
+    if not connection or connection["status"] != "connected":
+        raise HTTPException(status_code=409, detail="Selected provider is not connected")
+    if session["status"] in {"waiting_for_input", "waiting_for_resume", "failed"}:
+        store.resume_agent_session(user_id, session_id)
+    elif session["status"] != "running":
+        raise HTTPException(
+            status_code=409, detail=f"Session is {session['status'].replace('_', ' ')}"
+        )
+    if any(event["kind"] == "turn_started" for event in session.get("events", [])[-2:]):
+        raise HTTPException(status_code=409, detail="A response is already running")
+
+    message = store.add_agent_message(user_id, session_id, "user", body.content)
+    store.add_agent_event(user_id, session_id, "turn_started", {"message_id": message["id"]})
+    background_tasks.add_task(
+        agent_chat.run_turn, user_id=user_id, session_id=session_id
+    )
+    return {"sessionId": session_id, "status": "running", "message": message}
 
 
 @router.post("/{session_id}/tool-calls")
@@ -176,6 +213,10 @@ def resume_session(request: Request, session_id: str):
 @router.post("/{session_id}/cancel")
 def cancel_session(request: Request, session_id: str):
     try:
+        try:
+            runner.cancel_chat(session_id)
+        except runner.RunnerUnavailable:
+            pass
         return store.cancel_agent_session(request.state.user_id, session_id)
     except KeyError as exc:
         raise _not_found(exc) from exc

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -109,13 +109,10 @@ def logout(request: Request, response: Response):
 
 @router.get("/me")
 def me(request: Request):
-    token = request.cookies.get(_COOKIE)
-    if not token:
+    user_id = getattr(request.state, "user_id", None)
+    if not user_id:
         raise HTTPException(status_code=401, detail="Authentication required")
-    session = store.get_session(token)
-    if not session:
-        raise HTTPException(status_code=401, detail="Session expired")
-    user = store.get_user_by_id(session["user_id"])
+    user = store.get_user_by_id(user_id)
     if not user:
         raise HTTPException(status_code=401, detail="User not found")
     return {"id": user["id"], "email": user["email"], "created_at": user["created_at"]}

--- a/backend/schemas/agent_sessions.py
+++ b/backend/schemas/agent_sessions.py
@@ -27,6 +27,10 @@ class AddMessageRequest(CamelModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 
+class ChatTurnRequest(CamelModel):
+    content: str = Field(min_length=1, max_length=20_000)
+
+
 class RecordToolCallRequest(CamelModel):
     idempotency_key: str = Field(min_length=1, max_length=240)
     name: str = Field(min_length=1, max_length=160)

--- a/backend/services/agent_chat.py
+++ b/backend/services/agent_chat.py
@@ -1,0 +1,88 @@
+"""Execute provider chat turns and persist their observable event stream."""
+from __future__ import annotations
+
+import backend.services.cli_runner as runner
+import backend.store as store
+
+
+def _connection_api_key(user_id: str, provider: str) -> str | None:
+    token = store.get_connection_token(user_id, provider) if provider == "openai" else None
+    return runner.api_key_from_connection_token(token)
+
+
+def run_turn(*, user_id: str, session_id: str) -> None:
+    session = store.get_agent_session(user_id, session_id)
+    if session is None:
+        return
+    article = store.get_article(user_id, session["article_id"])
+    if article is None:
+        store.update_agent_session_status(user_id, session_id, "failed", "Article not found")
+        return
+
+    messages = [
+        {"role": message["role"], "content": message["content"]}
+        for message in session["messages"] if message["role"] in {"user", "assistant"}
+    ]
+    tools: dict[str, str] = {}
+    final_text = ""
+    try:
+        for event in runner.stream_chat(
+            provider=session["provider"], session_id=session_id,
+            article_md=article.get("body", ""), messages=messages,
+            model=session.get("model"),
+            api_key=_connection_api_key(user_id, session["provider"]),
+        ):
+            kind = event.get("type", "provider_event")
+            if kind == "assistant_delta":
+                store.add_agent_event(
+                    user_id, session_id, kind, {"text": event.get("text", "")}
+                )
+            elif kind == "assistant_message":
+                final_text = event.get("text", "").strip() or final_text
+            elif kind == "tool_started":
+                provider_id = event.get("toolId") or f"tool-{len(tools) + 1}"
+                tool, _ = store.record_agent_tool_call(
+                    user_id, session_id,
+                    idempotency_key=f"{session_id}:{provider_id}",
+                    name=event.get("name", "tool"),
+                    arguments=event.get("arguments") or {},
+                )
+                store.claim_agent_tool_call(user_id, session_id, tool["id"])
+                tools[provider_id] = tool["id"]
+            elif kind == "tool_completed":
+                tool_id = tools.get(event.get("toolId"))
+                if tool_id:
+                    failed = event.get("status") in {"failed", "error"}
+                    store.complete_agent_tool_call(
+                        user_id, session_id, tool_id,
+                        result={
+                            "status": event.get("status"),
+                            "output": event.get("result"),
+                        },
+                        error="Provider tool failed" if failed else None,
+                    )
+            elif kind == "approval_required":
+                store.request_agent_approval(
+                    user_id, session_id, event.get("request") or {}
+                )
+            elif kind == "checkpoint":
+                store.add_agent_checkpoint(user_id, session_id, event)
+            elif kind == "error":
+                raise runner.RunnerUnavailable(
+                    event.get("message", "Provider chat failed")
+                )
+
+        if final_text:
+            store.add_agent_message(user_id, session_id, "assistant", final_text)
+        store.add_agent_event(user_id, session_id, "turn_completed")
+        current = store.get_agent_session(user_id, session_id)
+        if current and current["status"] == "running":
+            store.update_agent_session_status(
+                user_id, session_id, "waiting_for_input"
+            )
+    except Exception as exc:
+        current = store.get_agent_session(user_id, session_id)
+        if current and current["status"] not in {"canceled", "waiting_for_approval"}:
+            store.update_agent_session_status(
+                user_id, session_id, "failed", str(exc)[:500]
+            )

--- a/backend/services/cli_runner.py
+++ b/backend/services/cli_runner.py
@@ -11,7 +11,7 @@ Callers convert that to an appropriate HTTP response (503).
 from __future__ import annotations
 
 import os
-from typing import Optional
+from typing import Iterator, Optional
 
 import httpx
 
@@ -111,6 +111,34 @@ def api_key_from_connection_token(token: str | None) -> str | None:
     if not token or token == "cli_session" or token.startswith("web_session:"):
         return None
     return token
+
+
+def stream_chat(
+    *, provider: str, session_id: str, article_md: str,
+    messages: list[dict[str, str]], model: str | None = None,
+    api_key: str | None = None,
+) -> Iterator[dict]:
+    payload = {
+        "provider": provider, "session_id": session_id,
+        "article_md": article_md, "messages": messages,
+        "model": model, "api_key": api_key,
+    }
+    try:
+        with _client() as client:
+            with client.stream(
+                "POST", "/chat/stream", json=payload,
+                timeout=httpx.Timeout(connect=3, read=300, write=10, pool=5),
+            ) as response:
+                response.raise_for_status()
+                for line in response.iter_lines():
+                    if line:
+                        yield __import__("json").loads(line)
+    except (httpx.ConnectError, httpx.HTTPStatusError, httpx.ReadTimeout) as exc:
+        raise RunnerUnavailable(f"Chat runner unavailable: {exc}") from exc
+
+
+def cancel_chat(session_id: str) -> None:
+    _post(f"/chat/{session_id}/cancel")
 
 
 def run_task(

--- a/backend/store/__init__.py
+++ b/backend/store/__init__.py
@@ -173,6 +173,10 @@ def add_agent_message(user_id: str, *a, **kw):
     return _backend.add_agent_message(user_id, *a, **kw)
 
 
+def add_agent_event(user_id: str, *a, **kw):
+    return _backend.add_agent_event(user_id, *a, **kw)
+
+
 def record_agent_tool_call(user_id: str, *a, **kw):
     return _backend.record_agent_tool_call(user_id, *a, **kw)
 

--- a/backend/store/agent_sessions.py
+++ b/backend/store/agent_sessions.py
@@ -101,6 +101,19 @@ class AgentSessionStoreMixin:
             "WHERE id=?", (now, now, session_id),
         )
 
+    def add_agent_event(
+        self, user_id: str, session_id: str, kind: str, data: Any = None,
+    ) -> dict:
+        self._require_session(user_id, session_id)
+        with self._con:
+            self._event(session_id, kind, data)
+            self._touch_session(session_id)
+        row = self._con.execute(
+            "SELECT * FROM agent_session_events WHERE session_id=? ORDER BY id DESC LIMIT 1",
+            (session_id,),
+        ).fetchone()
+        return _row(row)
+
     def create_agent_session(
         self, user_id: str, *, provider: str, model: str | None = None,
         article_id: str | None = None, workspace_id: str = "default",

--- a/backend/store/base.py
+++ b/backend/store/base.py
@@ -180,6 +180,11 @@ class ArticleStore(Protocol):
     ) -> dict:
         ...
 
+    def add_agent_event(
+        self, user_id: str, session_id: str, kind: str, data: Any = None,
+    ) -> dict:
+        ...
+
     def record_agent_tool_call(
         self, user_id: str, session_id: str, **kwargs: Any,
     ) -> tuple[dict, bool]:

--- a/cli-runner/main.py
+++ b/cli-runner/main.py
@@ -22,13 +22,14 @@ import threading
 import time
 import urllib.parse
 import uuid
-from typing import Optional
+from typing import Iterator, Optional
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 _DEVICE_CODE_RE = re.compile(r"\b[A-Z0-9]{4}-[A-Z0-9]{4,6}\b")
 _URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
 
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 app = FastAPI(title="BlogHub CLI Runner", version="0.1.0")
@@ -198,6 +199,18 @@ class TaskResponse(BaseModel):
     stdout:    str
     stderr:    str
     truncated: bool
+
+
+class ChatRequest(BaseModel):
+    provider: str
+    session_id: str
+    article_md: str
+    messages: list[dict[str, str]] = []
+    model: Optional[str] = None
+    api_key: Optional[str] = None
+
+
+_chat_processes: dict[str, subprocess.Popen] = {}
 
 
 # ── Health ─────────────────────────────────────────────────────────────────────
@@ -628,6 +641,174 @@ def openai_save_key(body: SaveKeyRequest):
 
 
 # ── Tasks: run ─────────────────────────────────────────────────────────────────
+
+def _chat_prompt(
+    provider: str, article_path: str, article_md: str,
+    messages: list[dict[str, str]],
+) -> str:
+    history = "\n".join(
+        f"{item.get('role', 'user').upper()}: {item.get('content', '')}"
+        for item in messages[-20:]
+    )
+    article_instruction = (
+        f"Before answering, inspect {article_path} with an available read tool."
+        if provider == "anthropic" else
+        "BlogHub already loaded the article through its audited read_article tool. "
+        "Do not invoke command execution or file tools; use the supplied article text."
+    )
+    supplied_article = "" if provider == "anthropic" else f"\n\n<article>\n{article_md}\n</article>"
+    return (
+        "You are BlogHub's article editing agent. Work only inside this isolated "
+        f"directory. {article_instruction} "
+        "Discuss the draft precisely and explain any proposed change. Do not modify "
+        "article.md unless a later turn explicitly says BlogHub recorded user approval.\n\n"
+        f"Article path: {article_path}{supplied_article}\n\nConversation:\n{history}"
+    )
+
+
+def _chat_command(req: ChatRequest, article_path: str) -> list[str]:
+    prompt = _chat_prompt(req.provider, article_path, req.article_md, req.messages)
+    if req.provider == "anthropic":
+        command = [
+            "claude", "-p", prompt, "--output-format", "stream-json", "--verbose",
+            "--include-partial-messages", "--permission-mode", "dontAsk",
+            "--allowedTools", "Read,Grep,Glob",
+        ]
+        if req.model:
+            command.extend(["--model", req.model])
+        return command
+    command = [
+        "codex", "exec", "--json", "--sandbox", "read-only",
+        "--skip-git-repo-check", "--ephemeral",
+    ]
+    if req.model:
+        command.extend(["--model", req.model])
+    command.append(prompt)
+    return command
+
+
+def _json_line(payload: dict) -> str:
+    return _json.dumps(payload, separators=(",", ":")) + "\n"
+
+
+def _normalize_chat_event(provider: str, raw: dict) -> list[dict]:
+    events: list[dict] = []
+    if provider == "anthropic":
+        if raw.get("type") == "stream_event":
+            event = raw.get("event", {})
+            block = event.get("content_block", {})
+            delta = event.get("delta", {})
+            if event.get("type") == "content_block_start" and block.get("type") == "tool_use":
+                events.append({"type": "tool_started", "toolId": block.get("id"),
+                               "name": block.get("name", "tool"), "arguments": block.get("input", {})})
+            elif event.get("type") == "content_block_delta" and delta.get("type") == "text_delta":
+                events.append({"type": "assistant_delta", "text": delta.get("text", "")})
+        elif raw.get("type") == "result":
+            if raw.get("result"):
+                events.append({"type": "assistant_message", "text": raw["result"]})
+            for denial in raw.get("permission_denials", []):
+                events.append({"type": "approval_required", "request": denial})
+            if raw.get("session_id"):
+                events.append({"type": "checkpoint", "nativeSessionId": raw["session_id"]})
+        elif raw.get("type") == "user":
+            for block in raw.get("message", {}).get("content", []):
+                if block.get("type") == "tool_result":
+                    events.append({
+                        "type": "tool_completed", "toolId": block.get("tool_use_id"),
+                        "status": "failed" if block.get("is_error") else "completed",
+                        "result": block.get("content"),
+                    })
+    else:
+        event_type = raw.get("type", "")
+        item = raw.get("item") or {}
+        item_type = item.get("type", "")
+        if event_type == "thread.started":
+            events.append({"type": "checkpoint", "nativeSessionId": raw.get("thread_id")})
+        elif event_type == "item.started" and item_type not in {"agent_message", "reasoning"}:
+            arguments = {
+                key: value for key, value in {
+                    "command": item.get("command"), "query": item.get("query")
+                }.items() if value is not None
+            }
+            events.append({"type": "tool_started", "toolId": item.get("id"),
+                           "name": item_type or "tool", "arguments": arguments})
+        elif event_type == "item.completed" and item_type == "agent_message":
+            events.append({"type": "assistant_message", "text": item.get("text", "")})
+        elif event_type == "item.completed" and item_type not in {"reasoning"}:
+            events.append({"type": "tool_completed", "toolId": item.get("id"),
+                           "name": item_type or "tool", "status": item.get("status", "completed"),
+                           "result": item.get("aggregated_output") or item.get("result")})
+        elif event_type in {"error", "turn.failed"}:
+            events.append({"type": "error", "message": raw.get("message") or str(raw.get("error", "Provider failed"))})
+    return events
+
+
+@app.post("/chat/stream")
+def chat_stream(req: ChatRequest):
+    if req.provider not in _PROVIDERS:
+        raise HTTPException(422, f"Unknown provider: {req.provider}")
+    env = _build_env(req.provider, req.api_key)
+    work_dir = tempfile.mkdtemp(prefix="bloghub_chat_")
+    article_path = os.path.join(work_dir, "article.md")
+    with open(article_path, "w", encoding="utf-8") as article_file:
+        article_file.write(req.article_md)
+
+    def generate() -> Iterator[str]:
+        stderr: list[str] = []
+        try:
+            proc = subprocess.Popen(
+                _chat_command(req, article_path), stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, env=env, cwd=work_dir, text=True, bufsize=1,
+            )
+            _chat_processes[req.session_id] = proc
+            yield _json_line({"type": "status", "status": "running"})
+            if req.provider == "openai":
+                yield _json_line({
+                    "type": "tool_started", "toolId": "bloghub-read-article",
+                    "name": "read_article", "arguments": {"path": "article.md"},
+                })
+                yield _json_line({
+                    "type": "tool_completed", "toolId": "bloghub-read-article",
+                    "name": "read_article", "status": "completed",
+                    "result": {"characters": len(req.article_md)},
+                })
+
+            def read_stderr() -> None:
+                assert proc.stderr is not None
+                for line in proc.stderr:
+                    stderr.append(line)
+
+            stderr_thread = threading.Thread(target=read_stderr, daemon=True)
+            stderr_thread.start()
+            assert proc.stdout is not None
+            for line in proc.stdout:
+                try:
+                    raw = _json.loads(line)
+                except _json.JSONDecodeError:
+                    continue
+                for event in _normalize_chat_event(req.provider, raw):
+                    yield _json_line(event)
+            proc.wait(timeout=TASK_TIMEOUT)
+            stderr_thread.join(timeout=2)
+            if proc.returncode:
+                yield _json_line({"type": "error", "message": _safe_reason("".join(stderr))})
+            yield _json_line({"type": "done", "exitCode": proc.returncode})
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            yield _json_line({"type": "error", "message": _safe_reason(str(exc))})
+            yield _json_line({"type": "done", "exitCode": 1})
+        finally:
+            _chat_processes.pop(req.session_id, None)
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+    return StreamingResponse(generate(), media_type="application/x-ndjson")
+
+
+@app.post("/chat/{session_id}/cancel")
+def cancel_chat(session_id: str):
+    proc = _chat_processes.get(session_id)
+    if proc and proc.poll() is None:
+        proc.terminate()
+    return {"status": "canceled"}
 
 # Allow-listed task slugs and their CLI invocation templates.
 # {article_path} is substituted with the path to article.md in the task dir.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - bloghub-credential-keys:/run/bloghub-keys
     environment:
       CLI_RUNNER_URL: http://cli-runner:8001
+      BLOGHUB_DISABLE_AUTH: "true"
       BLOGHUB_DB_PATH: /app/data/bloghub.db
       BLOGHUB_BLOBS_DIR: /app/data/blobs
       BLOGHUB_CREDENTIAL_KEY_FILE: /run/bloghub-keys/credential-keys.json

--- a/docs/editor-agent-chat.md
+++ b/docs/editor-agent-chat.md
@@ -1,0 +1,37 @@
+# Editor agent chat
+
+The editor chat uses the authenticated Claude Code and Codex CLI sessions from
+the CLI runner. Each conversation is an `agent_session` scoped to its owner and
+article. Messages, provider events, tool calls, approvals, and native provider
+checkpoints survive page and backend restarts.
+
+## Turn lifecycle
+
+1. The editor creates or resumes a session for the selected connected provider.
+2. `POST /api/agent-sessions/{id}/turns` persists the user message and starts a
+   background turn.
+3. The backend consumes normalized NDJSON from `POST /chat/stream` on the runner.
+4. The editor polls session detail while the turn is running and renders partial
+   text, tool state, errors, and approvals.
+5. The final assistant message is persisted and the session moves to
+   `waiting_for_input`.
+
+Canceling a turn terminates the provider process and marks the durable session
+as canceled. Reloading the editor restores the latest thread for each provider.
+Legacy `article_chat_log` messages remain readable but new model turns are stored
+only in the agent-session tables.
+
+## Isolation and approvals
+
+Every turn receives a temporary directory containing only `article.md`. Claude
+uses its structured stream and read-only permission policy, so denied operations
+become visible approval requests. Codex cannot use its nested Bubblewrap sandbox
+inside the Docker runner. BlogHub therefore performs an allowlisted
+`read_article` operation, records it as a tool call, and supplies that content to
+Codex while instructing it not to invoke shell or file tools. The runner is not
+granted bypass-sandbox privileges.
+
+Approval decisions are recorded against the requesting user and session. The
+current tool policy is read-only, so chat never updates canonical Markdown.
+Write-capable tools must produce reviewable article patches before they can be
+enabled in this surface.

--- a/screens/editor/v2.html
+++ b/screens/editor/v2.html
@@ -54,6 +54,11 @@
     .chat-msg.user .bubble{background:#1a1f38;border:1px solid #2a2e50;color:#e8eaf2;align-self:flex-end;border-radius:7px 7px 2px 7px}
     .chat-msg.bot  .bubble{background:#181c27;border:1px solid #252a38;color:#c9cfe0;font-family:'JetBrains Mono',monospace;font-size:11px;align-self:flex-start;border-radius:7px 7px 7px 2px}
     .chat-label{font-size:10px;color:#5a6080;padding:0 3px}
+    .agent-tool{border:1px solid #30364a;background:#131722;border-radius:6px;padding:7px 8px;margin:6px 0;font-size:10px;font-family:'JetBrains Mono',monospace}
+    .agent-tool-head{display:flex;align-items:center;gap:6px;color:#aab2cc}
+    .agent-tool-dot{width:6px;height:6px;border-radius:50%;background:#6366f1;flex-shrink:0}
+    .agent-tool.completed .agent-tool-dot{background:#4ade80}.agent-tool.failed .agent-tool-dot{background:#f87171}
+    .approval-card{border:1px solid #5b4a1f;background:#211d12;border-radius:6px;padding:8px;margin:7px 0;font-size:11px}
 
     input[type=text]{font-family:'JetBrains Mono',monospace}
     .diff-removed{background:#2d1a1a;color:#f87171;padding:7px 10px}
@@ -62,7 +67,7 @@
     #left-panel{flex-shrink:0;border-right:1px solid #252a38;background:#181c27;display:flex;flex-direction:row;overflow:hidden}
     #panel-strip{width:12px;flex-shrink:0;border-left:1px solid #252a38;display:flex;align-items:center;justify-content:center;cursor:pointer;background:#181c27;transition:background 100ms;}
     #panel-strip:hover{background:#1e2235}
-    #panel-content{width:260px;flex-shrink:0;overflow-y:auto;}
+    #panel-content{width:320px;flex-shrink:0;overflow-y:auto;}
 
     #preview-pane{display:flex;flex-direction:row;overflow:hidden;background:#0d1019;flex:1;min-width:12px;}
     #preview-strip{width:12px;flex-shrink:0;border-right:1px solid #252a38;display:flex;align-items:center;justify-content:center;cursor:pointer;background:#0d1019;transition:background 100ms;}
@@ -277,6 +282,9 @@ let PATCHES  = [];
 
 let CHAT_HISTORY = [];
 let AGENT_SESSION = null;
+let CONNECTED_PROVIDERS = [];
+let CHAT_PROVIDER = localStorage.getItem('bloghub-chat-provider') || 'anthropic';
+let CHAT_POLL = null;
 
 
 
@@ -328,6 +336,7 @@ function onInput() {
   // update word count
   const words = ta.value.trim().split(/\s+/).filter(Boolean).length;
   document.getElementById('word-count').textContent = words.toLocaleString() + ' words';
+  renderPreview();
 
   saveTimer = setTimeout(async () => {
     setSave('saving');
@@ -395,6 +404,7 @@ async function _pollJob(jobId) {
 // ── Left panel accordion ─────────────────────────────────────────────────────
 function toggleSection(id) {
   accOpen[id] = !accOpen[id];
+  if (id === 'chat' && accOpen[id]) collapseOtherSections(id);
   const body = document.getElementById('abody-' + id);
   const chev = document.getElementById('achev-' + id);
   body.style.display = accOpen[id] ? '' : 'none';
@@ -404,6 +414,7 @@ function toggleSection(id) {
 
 function openSection(id) {
   if (!leftOpen) toggleLeft();
+  if (id === 'chat') collapseOtherSections(id);
   if (!accOpen[id]) {
     accOpen[id] = true;
     document.getElementById('abody-' + id).style.display = '';
@@ -411,6 +422,17 @@ function openSection(id) {
   }
   renderSection(id);
   document.getElementById('abody-' + id).parentElement.scrollIntoView({ behavior:'smooth', block:'nearest' });
+}
+
+function collapseOtherSections(activeId) {
+  Object.keys(accOpen).forEach(id => {
+    if (id === activeId) return;
+    accOpen[id] = false;
+    const body = document.getElementById('abody-' + id);
+    const chev = document.getElementById('achev-' + id);
+    if (body) body.style.display = 'none';
+    if (chev) chev.classList.add('closed');
+  });
 }
 
 function renderSection(id) {
@@ -463,20 +485,19 @@ function renderPreview() {
   } else {
     extLink.style.display = 'none';
   }
-  const core = `<div class="rendered-preview">
-    <h1>Zero-downtime Postgres Migration</h1>
-    <p>Migrating a production Postgres database without downtime requires careful coordination between schema changes, application deployments, and traffic routing.</p>
-    <h2>Phase 1 — Baseline and snapshot</h2>
-    <p>Before touching any schema, capture a full logical backup and establish your rollback threshold.</p>
-    <blockquote><p>A dry run in staging is mandatory. Skipping this has caused three incidents in our post-mortem history.</p></blockquote>
-    <h2>Phase 2 — Schema expansion</h2>
-    <pre><code><span class="cm-c">-- Safe: add nullable column first</span>
-<span class="kw">ALTER TABLE</span> orders <span class="kw">ADD COLUMN</span> retry_count <span class="kw">INTEGER</span>;
-<span class="kw">UPDATE</span> orders <span class="kw">SET</span> retry_count = 0 <span class="kw">WHERE</span> retry_count <span class="kw">IS NULL</span>;</code></pre>
-    <h2>Phase 3 — Cutover</h2>
-    <p>Health checks must run before and after each migration step. Lock timeout: 5 seconds.</p>
-    <pre><code><span class="kw">CREATE INDEX CONCURRENTLY</span> idx_orders_retry <span class="kw">ON</span> orders(retry_count);</code></pre>
-  </div>`;
+  const source = document.getElementById('raw-editor').value;
+  const blocks = source.split(/\n{2,}/).map(block => {
+    const value = block.trim();
+    if (!value) return '';
+    if (value.startsWith('```')) {
+      return `<pre><code>${esc(value.replace(/^```[^\n]*\n?/, '').replace(/```$/, ''))}</code></pre>`;
+    }
+    if (value.startsWith('# ')) return `<h1>${esc(value.slice(2))}</h1>`;
+    if (value.startsWith('## ')) return `<h2>${esc(value.slice(3))}</h2>`;
+    if (value.startsWith('> ')) return `<blockquote><p>${esc(value.replace(/^> ?/gm, ''))}</p></blockquote>`;
+    return `<p>${esc(value).replace(/\n/g, '<br>')}</p>`;
+  }).join('');
+  const core = `<div class="rendered-preview">${blocks}</div>`;
   const body = document.getElementById('preview-body');
   if (platform === 'rendered') { body.innerHTML = core; return; }
   const name = { medium:'Medium', hashnode:'Hashnode', devto:'Dev.to' }[platform];
@@ -563,24 +584,44 @@ function buildChat() {
       <div class="chat-label">${m.role === 'user' ? 'You' : 'bloghub'}</div>
       <div class="bubble">${esc(m.text)}</div>
     </div>`).join('');
-  const status = AGENT_SESSION ? AGENT_SESSION.status.replaceAll('_', ' ') : 'new session';
-  const resumable = AGENT_SESSION && ['waiting_for_input','waiting_for_resume','failed'].includes(AGENT_SESSION.status);
-  const cancelable = AGENT_SESSION && ['running','waiting_for_input','waiting_for_approval','waiting_for_resume'].includes(AGENT_SESSION.status);
+  const tools = (AGENT_SESSION?.tool_calls || []).map(tool => `
+    <div class="agent-tool ${esc(tool.status)}">
+      <div class="agent-tool-head"><span class="agent-tool-dot"></span><span>${esc(tool.name)}</span><span style="margin-left:auto;color:#5a6080;">${esc(tool.status)}</span></div>
+      ${tool.arguments && Object.values(tool.arguments).some(Boolean) ? `<div style="color:#69718d;margin-top:5px;white-space:pre-wrap;overflow-wrap:anywhere;">${esc(JSON.stringify(tool.arguments, null, 2))}</div>` : ''}
+    </div>`).join('');
+  const approvals = (AGENT_SESSION?.approvals || []).map(approval => `
+    <div class="approval-card">
+      <div style="color:#f5d06f;margin-bottom:6px;">Approval requested</div>
+      <div style="color:#aab2cc;font-family:'JetBrains Mono',monospace;font-size:10px;white-space:pre-wrap;overflow-wrap:anywhere;">${esc(JSON.stringify(approval.request, null, 2))}</div>
+      ${approval.status === 'pending' ? `<div style="display:flex;gap:6px;margin-top:8px;"><button onclick="resolveAgentApproval('${approval.id}',true)" class="ai-btn hl">Approve</button><button onclick="resolveAgentApproval('${approval.id}',false)" class="ai-btn">Deny</button></div>` : `<div style="margin-top:6px;color:#737b98;">${esc(approval.status)}</div>`}
+    </div>`).join('');
+  const sessionEvents = AGENT_SESSION?.events || [];
+  const lastTurnId = sessionEvents.filter(event => event.kind === 'turn_started').at(-1)?.id || 0;
+  const deltas = sessionEvents.filter(
+    event => event.kind === 'assistant_delta' && event.id > lastTurnId
+  ).map(event => event.data?.text || '').join('');
+  const status = AGENT_SESSION ? AGENT_SESSION.status.replaceAll('_', ' ') : 'new thread';
+  const resumable = AGENT_SESSION && ['waiting_for_resume','failed'].includes(AGENT_SESSION.status);
+  const cancelable = AGENT_SESSION && AGENT_SESSION.status === 'running';
+  const options = CONNECTED_PROVIDERS.map(provider => `<option value="${provider.id}" ${provider.id === CHAT_PROVIDER ? 'selected' : ''}>${esc(provider.label)}</option>`).join('');
   return `<div>
+    <div style="display:flex;align-items:center;gap:6px;margin-bottom:9px;">
+      <select id="chat-provider" onchange="switchChatProvider(this.value)" aria-label="Chat provider" style="flex:1;min-width:0;background:#111520;border:1px solid #343a50;border-radius:5px;color:#c9cfe0;padding:5px 7px;font-size:11px;outline:none;">${options || '<option>No provider connected</option>'}</select>
+      <button onclick="newAgentThread()" class="icon-btn" title="New chat" style="width:27px;height:27px;">+</button>
+    </div>
     <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:8px;font-size:10px;color:#737b98;font-family:'JetBrains Mono',monospace;">
-      <span>${esc(status)}</span>
+      <span><span style="color:${status === 'running' ? '#a5b4fc' : '#737b98'}">●</span> ${esc(status)}</span>
       <span style="display:flex;gap:5px;">
         ${resumable ? `<button onclick="resumeAgentSession()" style="font-size:10px;padding:2px 7px;border:1px solid #343a50;border-radius:4px;background:transparent;color:#c9cfe0;cursor:pointer;">Resume</button>` : ''}
         ${cancelable ? `<button onclick="cancelAgentSession()" style="font-size:10px;padding:2px 7px;border:1px solid #343a50;border-radius:4px;background:transparent;color:#737b98;cursor:pointer;">Cancel</button>` : ''}
       </span>
     </div>
-    <div id="chat-msgs" style="max-height:200px;overflow-y:auto;margin-bottom:8px;">${msgs}</div>
+    <div id="chat-msgs" style="max-height:310px;overflow-y:auto;margin-bottom:8px;">${tools}${approvals}${msgs}${deltas && AGENT_SESSION?.status === 'running' ? `<div class="chat-msg bot"><div class="chat-label">${esc(CHAT_PROVIDER)} · streaming</div><div class="bubble">${esc(deltas)}</div></div>` : ''}</div>
     <div style="border-top:1px solid #252a38;padding-top:8px;display:flex;gap:6px;align-items:center;">
-      <span style="font-size:11px;color:#6366f1;font-family:'JetBrains Mono',monospace;flex-shrink:0;">$</span>
-      <input id="chat-input" type="text" placeholder="type a command…"
+      <input id="chat-input" type="text" placeholder="Ask about this article…" ${!CONNECTED_PROVIDERS.length || cancelable ? 'disabled' : ''}
         onkeydown="if(event.key==='Enter')sendChat()"
         style="flex:1;background:transparent;border:none;outline:none;color:#e8eaf2;font-size:12px;min-width:0;"/>
-      <button onclick="sendChat()" style="font-size:11px;padding:3px 9px;border-radius:4px;border:1px solid #252a38;background:transparent;color:#5a6080;cursor:pointer;flex-shrink:0;">↵</button>
+      <button onclick="sendChat()" class="icon-btn" title="Send" style="width:27px;height:27px;color:#a5b4fc;">↑</button>
     </div>
   </div>`;
 }
@@ -597,32 +638,18 @@ async function sendChat() {
     return;
   }
   CHAT_HISTORY.push({ role:'user', text });
-  if (AGENT_SESSION) {
-    await fetch(`/api/agent-sessions/${AGENT_SESSION.id}/messages`, {
-      method: 'POST', headers: {'Content-Type':'application/json'},
-      body: JSON.stringify({ role:'user', content:text })
-    });
-  }
+  AGENT_SESSION.status = 'running';
   renderSection('chat');
   try {
-    const r = await fetch(`/api/articles/${ARTICLE_ID}/chat`, {
+    const r = await fetch(`/api/agent-sessions/${AGENT_SESSION.id}/turns`, {
       method: 'POST', headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({ command: text })
+      body: JSON.stringify({ content: text })
     });
-    if (r.ok) {
-      const data = await r.json();
-      CHAT_HISTORY.push({ role:'bot', text: data.reply });
-      if (AGENT_SESSION) {
-        await fetch(`/api/agent-sessions/${AGENT_SESSION.id}/messages`, {
-          method: 'POST', headers: {'Content-Type':'application/json'},
-          body: JSON.stringify({ role:'assistant', content:data.reply })
-        });
-      }
-    } else {
-      CHAT_HISTORY.push({ role:'bot', text: 'Error: server returned ' + r.status });
-    }
+    if (!r.ok) throw new Error((await r.json()).detail || `HTTP ${r.status}`);
+    startChatPolling();
   } catch (e) {
     CHAT_HISTORY.push({ role:'bot', text: 'Error: ' + e.message });
+    AGENT_SESSION.status = 'failed';
   }
   renderSection('chat');
 }
@@ -642,12 +669,56 @@ async function ensureAgentSession() {
   const r = await fetch('/api/agent-sessions', {
     method: 'POST', headers: {'Content-Type':'application/json'},
     body: JSON.stringify({
-      provider:'bloghub', articleId:ARTICLE_ID, title:'Editor chat',
+      provider:CHAT_PROVIDER, articleId:ARTICLE_ID, title:'Editor chat',
       metadata:{ surface:'editor' }
     })
   });
   if (r.ok) AGENT_SESSION = await r.json();
   return AGENT_SESSION;
+}
+
+async function refreshAgentSession() {
+  if (!AGENT_SESSION) return;
+  const response = await fetch(`/api/agent-sessions/${AGENT_SESSION.id}`);
+  if (!response.ok) return;
+  AGENT_SESSION = await response.json();
+  AGENT_SESSION_HISTORY = AGENT_SESSION.messages
+    .filter(m => m.role === 'user' || m.role === 'assistant')
+    .map(m => ({ role:m.role === 'assistant' ? 'bot' : 'user', text:m.content, created_at:m.created_at }));
+  mergeChatHistory();
+  renderSection('chat');
+}
+
+function startChatPolling() {
+  clearInterval(CHAT_POLL);
+  CHAT_POLL = setInterval(async () => {
+    await refreshAgentSession();
+    if (!AGENT_SESSION || AGENT_SESSION.status !== 'running') {
+      clearInterval(CHAT_POLL); CHAT_POLL = null;
+    }
+  }, 700);
+}
+
+async function switchChatProvider(provider) {
+  CHAT_PROVIDER = provider;
+  localStorage.setItem('bloghub-chat-provider', provider);
+  AGENT_SESSION = null; AGENT_SESSION_HISTORY = [];
+  await loadAgentSession();
+  renderSection('chat');
+}
+
+function newAgentThread() {
+  AGENT_SESSION = null; AGENT_SESSION_HISTORY = [];
+  mergeChatHistory(); renderSection('chat');
+}
+
+async function resolveAgentApproval(approvalId, approved) {
+  if (!AGENT_SESSION) return;
+  await fetch(`/api/agent-sessions/${AGENT_SESSION.id}/approvals/${approvalId}/resolve`, {
+    method:'POST', headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({approved, response:{surface:'editor'}})
+  });
+  await refreshAgentSession();
 }
 
 async function resumeAgentSession() {
@@ -852,6 +923,7 @@ async function loadArticle() {
     await loadComments();
     await loadPatches();
     await loadChat();
+    await loadConnectedProviders();
     await loadAgentSession();
   } catch (_e) {
     console.error('Failed to load article', _e);
@@ -908,12 +980,13 @@ async function loadChat() {
 async function loadAgentSession() {
   try {
     const listResponse = await fetch(
-      `/api/agent-sessions?articleId=${encodeURIComponent(ARTICLE_ID)}&includeArchived=true&limit=1`
+      `/api/agent-sessions?articleId=${encodeURIComponent(ARTICLE_ID)}&includeArchived=true&limit=50`
     );
     if (!listResponse.ok) return;
     const list = await listResponse.json();
-    if (!list.sessions.length) return;
-    const detailResponse = await fetch(`/api/agent-sessions/${list.sessions[0].id}`);
+    const selected = list.sessions.find(session => session.provider === CHAT_PROVIDER);
+    if (!selected) return;
+    const detailResponse = await fetch(`/api/agent-sessions/${selected.id}`);
     if (!detailResponse.ok) return;
     AGENT_SESSION = await detailResponse.json();
     AGENT_SESSION_HISTORY = AGENT_SESSION.messages
@@ -921,7 +994,22 @@ async function loadAgentSession() {
       .map(m => ({ role: m.role === 'assistant' ? 'bot' : 'user', text: m.content, created_at: m.created_at }));
     mergeChatHistory();
     renderSection('chat');
+    if (AGENT_SESSION.status === 'running') startChatPolling();
   } catch (_e) { /* silently ignore */ }
+}
+
+async function loadConnectedProviders() {
+  try {
+    const response = await fetch('/api/connections');
+    if (!response.ok) return;
+    const data = await response.json();
+    CONNECTED_PROVIDERS = data.connections.filter(
+      item => ['anthropic','openai'].includes(item.id) && item.status === 'connected'
+    );
+    if (!CONNECTED_PROVIDERS.some(item => item.id === CHAT_PROVIDER) && CONNECTED_PROVIDERS.length) {
+      CHAT_PROVIDER = CONNECTED_PROVIDERS[0].id;
+    }
+  } catch (_e) { /* surfaced as an empty provider selector */ }
 }
 
 async function triggerInspect() {

--- a/screens/editor/v2.html
+++ b/screens/editor/v2.html
@@ -925,6 +925,10 @@ async function loadArticle() {
     await loadChat();
     await loadConnectedProviders();
     await loadAgentSession();
+    if (new URLSearchParams(location.search).get('panel') === 'chat') {
+      openSection('chat');
+      document.getElementById('chat-input')?.focus();
+    }
   } catch (_e) {
     console.error('Failed to load article', _e);
   }

--- a/tests/tests_backend/test_agent_chat.py
+++ b/tests/tests_backend/test_agent_chat.py
@@ -1,0 +1,76 @@
+from fastapi.testclient import TestClient
+
+import backend.services.agent_chat as agent_chat
+import backend.store as store
+
+_USER_ID = "user_seed"
+
+
+def _session(client: TestClient, provider: str = "anthropic") -> str:
+    store.save_connection(
+        _USER_ID, provider, token=f"web_session:{provider}", status="connected"
+    )
+    response = client.post("/api/agent-sessions", json={
+        "provider": provider, "articleId": "art_001", "title": "Editor chat",
+    })
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+def test_chat_turn_persists_message_native_tool_and_reply(client, monkeypatch):
+    session_id = _session(client)
+    monkeypatch.setattr(agent_chat.runner, "stream_chat", lambda **_kwargs: iter([
+        {"type": "assistant_delta", "text": "Reading"},
+        {"type": "tool_started", "toolId": "read-1", "name": "Read",
+         "arguments": {"path": "article.md"}},
+        {"type": "tool_completed", "toolId": "read-1", "status": "completed",
+         "result": "article content"},
+        {"type": "assistant_message", "text": "The introduction needs a concrete example."},
+        {"type": "done", "exitCode": 0},
+    ]))
+
+    response = client.post(
+        f"/api/agent-sessions/{session_id}/turns",
+        json={"content": "Review the introduction"},
+    )
+    assert response.status_code == 202
+    persisted = client.get(f"/api/agent-sessions/{session_id}").json()
+    assert [message["role"] for message in persisted["messages"]] == ["user", "assistant"]
+    assert persisted["tool_calls"][0]["name"] == "Read"
+    assert persisted["tool_calls"][0]["status"] == "completed"
+    assert persisted["status"] == "waiting_for_input"
+
+
+def test_chat_turn_requires_connected_selected_provider(client):
+    response = client.post("/api/agent-sessions", json={
+        "provider": "openai", "articleId": "art_001", "title": "Editor chat",
+    })
+    session_id = response.json()["id"]
+    turn = client.post(
+        f"/api/agent-sessions/{session_id}/turns", json={"content": "Hello"}
+    )
+    assert turn.status_code == 409
+    assert "not connected" in turn.json()["detail"]
+
+
+def test_provider_permission_request_becomes_resolvable_approval(client, monkeypatch):
+    session_id = _session(client)
+    monkeypatch.setattr(agent_chat.runner, "stream_chat", lambda **_kwargs: iter([
+        {"type": "approval_required", "request": {
+            "tool_name": "Edit", "path": "article.md",
+        }},
+        {"type": "done", "exitCode": 0},
+    ]))
+    client.post(
+        f"/api/agent-sessions/{session_id}/turns", json={"content": "Rewrite the title"}
+    )
+    pending = client.get(f"/api/agent-sessions/{session_id}").json()
+    assert pending["status"] == "waiting_for_approval"
+    approval = pending["approvals"][0]
+
+    resolved = client.post(
+        f"/api/agent-sessions/{session_id}/approvals/{approval['id']}/resolve",
+        json={"approved": True, "response": {"surface": "editor"}},
+    )
+    assert resolved.status_code == 200
+    assert resolved.json()["status"] == "approved"

--- a/tests/tests_backend/test_auth.py
+++ b/tests/tests_backend/test_auth.py
@@ -146,6 +146,16 @@ class TestMiddleware:
         r = client.get("/api/articles")
         assert r.status_code == 200
 
+    def test_disabled_auth_uses_seed_user(self, anon_client, monkeypatch):
+        monkeypatch.setenv("BLOGHUB_DISABLE_AUTH", "true")
+
+        articles = anon_client.get("/api/articles")
+        current_user = anon_client.get("/api/auth/me")
+
+        assert articles.status_code == 200
+        assert current_user.status_code == 200
+        assert current_user.json()["id"] == "user_seed"
+
     def test_health_is_public(self, client):
         r = client.get("/health")
         assert r.status_code == 200

--- a/tests/tests_backend/test_cli_runner_auth.py
+++ b/tests/tests_backend/test_cli_runner_auth.py
@@ -39,3 +39,50 @@ def test_task_request_accepts_an_ephemeral_api_key():
         provider="openai", task="generate", article_md="prompt", api_key="secret"
     )
     assert request.api_key == "secret"
+
+
+def test_runner_normalizes_claude_text_tools_and_permission_requests():
+    runner = _runner_module()
+    started = runner._normalize_chat_event("anthropic", {
+        "type": "stream_event", "event": {
+            "type": "content_block_start",
+            "content_block": {"type": "tool_use", "id": "read-1", "name": "Read"},
+        },
+    })
+    delta = runner._normalize_chat_event("anthropic", {
+        "type": "stream_event", "event": {
+            "type": "content_block_delta", "delta": {"type": "text_delta", "text": "Hello"},
+        },
+    })
+    result = runner._normalize_chat_event("anthropic", {
+        "type": "result", "result": "Hello", "session_id": "native-1",
+        "permission_denials": [{"tool_name": "Edit", "path": "article.md"}],
+    })
+
+    assert started[0]["name"] == "Read"
+    assert delta == [{"type": "assistant_delta", "text": "Hello"}]
+    assert {event["type"] for event in result} == {
+        "assistant_message", "approval_required", "checkpoint"
+    }
+
+
+def test_runner_normalizes_codex_tool_and_message_events():
+    runner = _runner_module()
+    tool = {"id": "cmd-1", "type": "command_execution", "command": "cat article.md"}
+    assert runner._normalize_chat_event(
+        "openai", {"type": "item.started", "item": tool}
+    )[0]["type"] == "tool_started"
+    assert runner._normalize_chat_event("openai", {
+        "type": "item.completed", "item": {"type": "agent_message", "text": "Done"},
+    }) == [{"type": "assistant_message", "text": "Done"}]
+
+
+def test_codex_receives_article_from_audited_runner_tool_without_shell_requirement():
+    runner = _runner_module()
+    prompt = runner._chat_prompt(
+        "openai", "/tmp/chat/article.md", "# Synthetic\n\nSafe content.",
+        [{"role": "user", "content": "Review it"}],
+    )
+    assert "audited read_article tool" in prompt
+    assert "# Synthetic" in prompt
+    assert "Do not invoke command execution" in prompt


### PR DESCRIPTION
Refs #9

## What changed

- replaces the editor's command-style chat path with durable model-backed agent turns
- lets users switch between connected Anthropic and OpenAI providers
- streams Claude partial text and normalizes native provider events into one runner contract
- persists messages, tool calls, checkpoints, errors, cancellation, and approval decisions
- renders live status, tool activity, approve/deny controls, cancel, resume, and new-thread actions
- restores the latest per-provider conversation after reload
- replaces the hard-coded editor preview with the active Markdown draft
- keeps legacy article chat messages readable without writing new turns to both stores
- supports deep-linking directly to the editor chat panel
- disables BlogHub account auth in local Compose while retaining provider authentication

## Isolation

- every turn runs against a temporary workspace containing only `article.md`
- Claude uses read-only provider permissions and exposes denied operations as approval requests
- Codex cannot nest Bubblewrap inside the Docker runner, so BlogHub performs an audited allowlisted `read_article` tool and supplies that text without granting sandbox-bypass privileges
- the current tool policy is read-only; future write tools must produce reviewable article patches

## Validation

- 17 focused runner, normalization, persistence, and Compose tests pass
- direct worker smoke test verifies durable messages and tool completion
- live Playwright completed real Claude and OpenAI turns using disposable synthetic article content
- live browser flow verified provider switching, persisted responses, focused layout, and approval denial
- anonymous live HTTP requests to articles, current user, and provider connections return `200`
- Anthropic and OpenAI connections survive the local auth bypass and Compose rebuild
- backend and CLI runner are healthy in the rebuilt Compose stack

## Stack note

This PR targets `feat/7` because it depends on the connected provider sessions introduced by PR #34. Retarget it to `develop` after #34 merges.
