### PR TITLE
feat: reconcile remote article changes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
-from backend.routers import agent, agent_sessions, articles, comments, connections, dev, jobs, patches, platforms
+from backend.routers import agent, agent_sessions, articles, comments, connections, dev, jobs, patches, platforms, reconciliation
 from backend.routers import auth as auth_router
 from backend.middleware.auth import AuthMiddleware
 from backend.security import install_secret_redaction
@@ -59,6 +59,7 @@ app.include_router(patches.router)
 app.include_router(connections.router)
 app.include_router(jobs.router)
 app.include_router(platforms.router)
+app.include_router(reconciliation.router)
 app.include_router(dev.router)
 
 

--- a/backend/routers/articles.py
+++ b/backend/routers/articles.py
@@ -23,6 +23,7 @@ from backend.schemas.overview import (
 import backend.store as store
 import backend.services.cli_runner as runner
 from backend.services.push import push_article_to_platforms
+from backend.services import reconciliation
 from backend.store.article_revisions import RevisionConflict
 
 router = APIRouter(prefix="/api/articles", tags=["articles"])
@@ -441,6 +442,25 @@ def push_article(request: Request, article_id: str, body: dict = {}):
         raise HTTPException(status_code=404, detail="Article not found")
 
     platforms = body.get("platforms", list(article["destinations"].keys()))
+    remote_conflicts = []
+    for platform in platforms:
+        snapshot = store.get_latest_remote_snapshot(user_id, article_id, platform)
+        if snapshot is None:
+            continue
+        state = reconciliation.current_view(
+            store, user_id, article_id, snapshot
+        )["sync_state"]
+        if state in {"conflict", "remote_ahead"}:
+            remote_conflicts.append(platform)
+    if remote_conflicts:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "remote_conflict",
+                "message": "Resolve remote changes before pushing local content.",
+                "platforms": remote_conflicts,
+            },
+        )
     store.set_destinations_pending(user_id, article_id, platforms)
     job = store.create_job(user_id, "push", article_id)
 

--- a/backend/routers/reconciliation.py
+++ b/backend/routers/reconciliation.py
@@ -1,0 +1,95 @@
+"""Remote article comparison and explicit conflict resolution endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+import backend.store as store
+from backend.schemas.reconciliation import (
+    ReconciliationListResponse,
+    RemoteSnapshot,
+    ResolveRemoteConflictRequest,
+)
+from backend.services import reconciliation
+from backend.store.article_revisions import RevisionConflict
+
+
+router = APIRouter(prefix="/api/articles", tags=["reconciliation"])
+
+
+def _require_article(user_id: str, article_id: str) -> None:
+    if store.get_article(user_id, article_id) is None:
+        raise HTTPException(status_code=404, detail="Article not found")
+
+
+@router.get("/{article_id}/reconciliation", response_model=ReconciliationListResponse)
+def list_comparisons(request: Request, article_id: str):
+    user_id = request.state.user_id
+    _require_article(user_id, article_id)
+    snapshots = store.list_latest_remote_snapshots(user_id, article_id)
+    return ReconciliationListResponse(
+        comparisons=[
+            RemoteSnapshot(**reconciliation.current_view(store, user_id, article_id, item))
+            for item in snapshots
+        ]
+    )
+
+
+@router.post(
+    "/{article_id}/reconciliation/{platform}/refresh",
+    response_model=RemoteSnapshot,
+)
+def refresh_comparison(request: Request, article_id: str, platform: str):
+    user_id = request.state.user_id
+    _require_article(user_id, article_id)
+    try:
+        snapshot = reconciliation.refresh(store, user_id, article_id, platform)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=f"Unsupported platform: {platform}") from exc
+    if snapshot["availability"] == "available":
+        store.apply_remote_destination_state(
+            user_id,
+            article_id,
+            platform,
+            status=snapshot["remote_status"],
+            url=snapshot["remote_url"],
+            remote_id=snapshot["remote_id"],
+        )
+    return RemoteSnapshot(**reconciliation.current_view(store, user_id, article_id, snapshot))
+
+
+@router.post(
+    "/{article_id}/reconciliation/{platform}/resolve",
+    response_model=RemoteSnapshot,
+)
+def resolve_comparison(
+    request: Request,
+    article_id: str,
+    platform: str,
+    body: ResolveRemoteConflictRequest,
+):
+    user_id = request.state.user_id
+    _require_article(user_id, article_id)
+    try:
+        if body.action == "use_remote":
+            reconciliation.import_remote(
+                store, user_id, article_id, platform, body.base_revision_id
+            )
+            latest = store.get_latest_remote_snapshot(user_id, article_id, platform)
+            assert latest is not None
+            snapshot = latest
+        else:
+            snapshot = reconciliation.acknowledge_local(
+                store, user_id, article_id, platform
+            )
+    except RevisionConflict as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "revision_conflict",
+                "message": str(exc),
+                "current": exc.current,
+            },
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return RemoteSnapshot(**reconciliation.current_view(store, user_id, article_id, snapshot))

--- a/backend/schemas/reconciliation.py
+++ b/backend/schemas/reconciliation.py
@@ -1,0 +1,37 @@
+"""API models for local-versus-remote article reconciliation."""
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class RemoteSnapshot(BaseModel):
+    id: str
+    article_id: str
+    platform: str
+    remote_id: str | None = None
+    availability: str
+    sync_state: str
+    local_revision_id: str | None = None
+    current_revision_id: str | None = None
+    local_fingerprint: str
+    remote_fingerprint: str | None = None
+    title: str | None = None
+    content: str | None = None
+    canonical_url: str | None = None
+    remote_url: str | None = None
+    remote_status: str | None = None
+    remote_updated_at: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    error: str | None = None
+    fetched_at: str
+
+
+class ReconciliationListResponse(BaseModel):
+    comparisons: list[RemoteSnapshot]
+
+
+class ResolveRemoteConflictRequest(BaseModel):
+    action: Literal["keep_local", "use_remote"]
+    base_revision_id: str

--- a/backend/services/push.py
+++ b/backend/services/push.py
@@ -74,7 +74,12 @@ def _push_devto(article: dict, source_markdown: str, get_connection_token: Token
         published=False,
     )
     client = DevToClient(token)
-    result = client.publish_article(prepared.article)
+    existing_id = article.get("destinations", {}).get("devto", {}).get("draft_id")
+    result = (
+        client.update_article(int(existing_id), prepared.article)
+        if existing_id
+        else client.publish_article(prepared.article)
+    )
     return PushPlatformResult(
         platform="devto",
         success=True,
@@ -103,7 +108,12 @@ def _push_hashnode(article: dict, source_markdown: str, get_connection_token: To
         cover_image_url=_cover_image_url(article, "hashnode"),
         tags=("integration", "bloghub"),
     )
-    result = client.create_draft(prepared.draft)
+    existing_id = article.get("destinations", {}).get("hashnode", {}).get("draft_id")
+    result = (
+        client.update_draft(existing_id, prepared.draft)
+        if existing_id
+        else client.create_draft(prepared.draft)
+    )
     publication_url = _read_hashnode_publication_url(client, result.draft_id)
     preview_url = None
     if publication_url:
@@ -131,13 +141,15 @@ def _push_medium_placeholder(article: dict) -> PushPlatformResult:
 
 
 def _simulated_result(platform: str, article: dict) -> PushPlatformResult:
-    existing_url = article.get("destinations", {}).get(platform, {}).get("url")
+    destination = article.get("destinations", {}).get(platform, {})
+    existing_url = destination.get("url")
     return PushPlatformResult(
         platform=platform,
         success=True,
         status="draft",
         label="Draft",
         url=existing_url,
+        draft_id=destination.get("draft_id"),
     )
 
 

--- a/backend/services/reconciliation.py
+++ b/backend/services/reconciliation.py
@@ -1,0 +1,276 @@
+"""Compare local article revisions with linked remote publishing records."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import hashlib
+import json
+import re
+from typing import Any, Callable
+
+from blogs.devto.client import DevToClient
+from blogs.hashnode.client import HashnodeClient
+
+
+SUPPORTED_PLATFORMS = ("hashnode", "devto")
+
+
+class ReconciliationError(RuntimeError):
+    """A remote article could not be fetched reliably."""
+
+
+@dataclass(frozen=True)
+class RemoteArticle:
+    platform: str
+    remote_id: str
+    title: str
+    content: str
+    canonical_url: str | None
+    remote_url: str | None
+    status: str
+    updated_at: str | None
+    metadata: dict[str, Any]
+
+
+RemoteFetcher = Callable[..., RemoteArticle | None]
+
+
+def content_fingerprint(title: str, content: str, canonical_url: str | None = None) -> str:
+    """Hash provider-neutral article content after harmless normalization."""
+    normalized_title = " ".join(title.strip().split())
+    normalized_body = content.replace("\r\n", "\n").strip()
+    lines = normalized_body.splitlines()
+    if lines and re.sub(r"\s+", " ", lines[0].removeprefix("# ").strip()) == normalized_title:
+        lines = lines[1:]
+        while lines and not lines[0].strip():
+            lines.pop(0)
+    normalized_body = "\n".join(line.rstrip() for line in lines).strip()
+    payload = {
+        "title": normalized_title,
+        "content": normalized_body,
+        "canonical_url": (canonical_url or "").strip(),
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def fetch_remote_article(
+    platform: str,
+    token: str,
+    remote_id: str,
+    expected_title: str | None = None,
+    expected_canonical_url: str | None = None,
+) -> RemoteArticle | None:
+    """Fetch one linked record, returning None only when a complete listing omits it."""
+    try:
+        if platform == "devto":
+            records = DevToClient(token).list_my_articles(per_page=100, page=1)
+            match = next((item for item in records if str(item.article_id) == remote_id), None)
+            if match is None:
+                return None
+            return RemoteArticle(
+                platform=platform,
+                remote_id=str(match.article_id),
+                title=match.title,
+                content=match.body_markdown,
+                canonical_url=match.canonical_url,
+                remote_url=match.url,
+                status="published" if match.published else "draft",
+                updated_at=_iso(match.updated_at),
+                metadata={
+                    "description": match.description,
+                    "cover_image": match.cover_image,
+                },
+            )
+        if platform == "hashnode":
+            client = HashnodeClient(token)
+            records = [*client.list_drafts(first=100), *client.list_published_articles(post_first=100)]
+            match = next((item for item in records if str(item.article_id) == remote_id), None)
+            if match is None and expected_canonical_url:
+                canonical_matches = [
+                    item for item in records
+                    if item.canonical_url == expected_canonical_url
+                ]
+                match = canonical_matches[0] if len(canonical_matches) == 1 else None
+            if match is None and expected_title:
+                normalized_title = " ".join(expected_title.casefold().split())
+                title_matches = [
+                    item for item in records
+                    if " ".join(item.title.casefold().split()) == normalized_title
+                ]
+                match = title_matches[0] if len(title_matches) == 1 else None
+            if match is None:
+                return None
+            return RemoteArticle(
+                platform=platform,
+                remote_id=str(match.article_id),
+                title=match.title,
+                content=match.body_markdown,
+                canonical_url=match.canonical_url,
+                remote_url=match.url,
+                status="published" if match.published else "draft",
+                updated_at=_iso(match.updated_at),
+                metadata={
+                    "subtitle": match.subtitle,
+                    "cover_image": match.cover_image_url,
+                },
+            )
+    except Exception as exc:
+        raise ReconciliationError(str(exc)) from exc
+    raise ReconciliationError(f"Reconciliation is not supported for {platform}")
+
+
+def refresh(store: Any, user_id: str, article_id: str, platform: str,
+            *, fetcher: RemoteFetcher | None = None) -> dict:
+    article = store.get_article(user_id, article_id)
+    if article is None:
+        raise KeyError(article_id)
+    if platform not in SUPPORTED_PLATFORMS:
+        raise ValueError(platform)
+
+    current_revision = store.get_current_article_revision(user_id, article_id)
+    assert current_revision is not None
+    local_fingerprint = content_fingerprint(
+        current_revision["title"], current_revision["content"], article.get("canonical_url")
+    )
+    destination = article["destinations"].get(platform) or {}
+    remote_id = destination.get("draft_id")
+    previous = store.get_latest_remote_snapshot(user_id, article_id, platform)
+
+    common = {
+        "platform": platform,
+        "remote_id": remote_id,
+        "local_revision_id": current_revision["id"],
+        "local_fingerprint": local_fingerprint,
+    }
+    if not remote_id:
+        return store.record_remote_snapshot(user_id, article_id, {
+            **common,
+            "availability": "unlinked",
+            "sync_state": "unlinked",
+            "error": "No remote article ID is linked to this destination.",
+        })
+
+    token = store.get_connection_token(user_id, platform)
+    if not token:
+        return store.record_remote_snapshot(user_id, article_id, {
+            **common,
+            "availability": "inaccessible",
+            "sync_state": "inaccessible",
+            "error": f"{platform} is not connected.",
+        })
+
+    try:
+        remote = (fetcher or fetch_remote_article)(
+            platform,
+            token,
+            remote_id,
+            article["title"],
+            article.get("canonical_url"),
+        )
+    except ReconciliationError as exc:
+        return store.record_remote_snapshot(user_id, article_id, {
+            **common,
+            "availability": "inaccessible",
+            "sync_state": "inaccessible",
+            "error": str(exc),
+        })
+    if remote is None:
+        return store.record_remote_snapshot(user_id, article_id, {
+            **common,
+            "availability": "deleted",
+            "sync_state": "remote_deleted",
+            "error": "The linked remote article no longer exists or is no longer visible.",
+        })
+
+    remote_fingerprint = content_fingerprint(
+        remote.title, remote.content, remote.canonical_url
+    )
+    sync_state = _classify(local_fingerprint, remote_fingerprint, previous)
+    return store.record_remote_snapshot(user_id, article_id, {
+        **common,
+        "remote_id": remote.remote_id,
+        "availability": "available",
+        "sync_state": sync_state,
+        "remote_fingerprint": remote_fingerprint,
+        "title": remote.title,
+        "content": remote.content,
+        "canonical_url": remote.canonical_url,
+        "remote_url": remote.remote_url,
+        "remote_status": remote.status,
+        "remote_updated_at": remote.updated_at,
+        "metadata": remote.metadata,
+    })
+
+
+def current_view(store: Any, user_id: str, article_id: str, snapshot: dict) -> dict:
+    article = store.get_article(user_id, article_id)
+    revision = store.get_current_article_revision(user_id, article_id)
+    if article is None or revision is None:
+        raise KeyError(article_id)
+    current_fingerprint = content_fingerprint(
+        revision["title"], revision["content"], article.get("canonical_url")
+    )
+    state = snapshot["sync_state"]
+    if snapshot["availability"] == "available":
+        if current_fingerprint == snapshot["remote_fingerprint"]:
+            state = "in_sync"
+        elif current_fingerprint != snapshot["local_fingerprint"]:
+            state = "conflict" if snapshot["sync_state"] in {"remote_ahead", "conflict"} else "local_ahead"
+    return {**snapshot, "sync_state": state, "current_revision_id": revision["id"]}
+
+
+def acknowledge_local(store: Any, user_id: str, article_id: str, platform: str) -> dict:
+    latest = store.get_latest_remote_snapshot(user_id, article_id, platform)
+    if latest is None or latest["availability"] != "available":
+        raise ValueError("No available remote snapshot can be resolved")
+    article = store.get_article(user_id, article_id)
+    revision = store.get_current_article_revision(user_id, article_id)
+    assert article is not None and revision is not None
+    return store.record_remote_snapshot(user_id, article_id, {
+        **latest,
+        "id": None,
+        "local_revision_id": revision["id"],
+        "local_fingerprint": content_fingerprint(
+            revision["title"], revision["content"], article.get("canonical_url")
+        ),
+        "sync_state": "local_ahead",
+    })
+
+
+def import_remote(store: Any, user_id: str, article_id: str, platform: str,
+                  expected_revision_id: str) -> dict:
+    latest = store.get_latest_remote_snapshot(user_id, article_id, platform)
+    if latest is None or latest["availability"] != "available":
+        raise ValueError("No available remote snapshot can be imported")
+    return store.save_article_revision(
+        user_id,
+        article_id,
+        title=latest["title"],
+        content=latest["content"],
+        expected_revision_id=expected_revision_id,
+        source="import",
+        description=f"Accepted remote {platform.title()} version",
+    )
+
+
+def _classify(local_fingerprint: str, remote_fingerprint: str,
+              previous: dict | None) -> str:
+    if local_fingerprint == remote_fingerprint:
+        return "in_sync"
+    if previous is None or previous["availability"] != "available":
+        return "conflict"
+    local_changed = local_fingerprint != previous["local_fingerprint"]
+    remote_changed = remote_fingerprint != previous["remote_fingerprint"]
+    if local_changed and remote_changed:
+        return "conflict"
+    if remote_changed:
+        return "conflict" if previous["sync_state"] == "local_ahead" else "remote_ahead"
+    if local_changed:
+        return "conflict" if previous["sync_state"] == "remote_ahead" else "local_ahead"
+    return previous["sync_state"] if previous["sync_state"] != "in_sync" else "conflict"
+
+
+def _iso(value: datetime | None) -> str | None:
+    return value.isoformat() if value else None

--- a/backend/store/__init__.py
+++ b/backend/store/__init__.py
@@ -97,6 +97,22 @@ def set_destinations_pending(user_id: str, *a, **kw):
     return _backend.set_destinations_pending(user_id, *a, **kw)
 
 
+def record_remote_snapshot(user_id: str, *a, **kw):
+    return _backend.record_remote_snapshot(user_id, *a, **kw)
+
+
+def get_latest_remote_snapshot(user_id: str, *a, **kw):
+    return _backend.get_latest_remote_snapshot(user_id, *a, **kw)
+
+
+def list_latest_remote_snapshots(user_id: str, *a, **kw):
+    return _backend.list_latest_remote_snapshots(user_id, *a, **kw)
+
+
+def apply_remote_destination_state(user_id: str, *a, **kw):
+    return _backend.apply_remote_destination_state(user_id, *a, **kw)
+
+
 # ── Connections ───────────────────────────────────────────────────────────────
 
 

--- a/backend/store/backends/sqlite.py
+++ b/backend/store/backends/sqlite.py
@@ -633,6 +633,122 @@ class SQLiteStore(ConnectionAuthStoreMixin, AgentSessionStoreMixin, ArticleRevis
         self._touch(article_id)
         self._con.commit()
 
+    # ── Remote reconciliation ────────────────────────────────────────────────
+
+    @staticmethod
+    def _remote_snapshot_row_to_dict(row: sqlite3.Row) -> dict:
+        return {
+            "id": row["id"],
+            "article_id": row["article_id"],
+            "platform": row["platform"],
+            "remote_id": row["remote_id"],
+            "availability": row["availability"],
+            "sync_state": row["sync_state"],
+            "local_revision_id": row["local_revision_id"],
+            "local_fingerprint": row["local_fingerprint"],
+            "remote_fingerprint": row["remote_fingerprint"],
+            "title": row["title"],
+            "content": row["content"],
+            "canonical_url": row["canonical_url"],
+            "remote_url": row["remote_url"],
+            "remote_status": row["remote_status"],
+            "remote_updated_at": row["remote_updated_at"],
+            "metadata": json.loads(row["metadata_json"] or "{}"),
+            "error": row["error"],
+            "fetched_at": row["fetched_at"],
+        }
+
+    def record_remote_snapshot(
+        self, user_id: str, article_id: str, snapshot: dict
+    ) -> dict:
+        owner = self._con.execute(
+            "SELECT id FROM articles WHERE id=? AND user_id=?", (article_id, user_id)
+        ).fetchone()
+        if owner is None:
+            raise KeyError(article_id)
+        snapshot_id = f"remote_{uuid.uuid4().hex}"
+        fetched_at = _ts(_now())
+        self._con.execute(
+            """INSERT INTO remote_article_snapshots
+               (id, article_id, platform, remote_id, availability, sync_state,
+                local_revision_id, local_fingerprint, remote_fingerprint, title,
+                content, canonical_url, remote_url, remote_status, remote_updated_at,
+                metadata_json, error, fetched_at)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (
+                snapshot_id,
+                article_id,
+                snapshot["platform"],
+                snapshot.get("remote_id"),
+                snapshot["availability"],
+                snapshot["sync_state"],
+                snapshot.get("local_revision_id"),
+                snapshot["local_fingerprint"],
+                snapshot.get("remote_fingerprint"),
+                snapshot.get("title"),
+                snapshot.get("content"),
+                snapshot.get("canonical_url"),
+                snapshot.get("remote_url"),
+                snapshot.get("remote_status"),
+                snapshot.get("remote_updated_at"),
+                json.dumps(snapshot.get("metadata") or {}, sort_keys=True),
+                snapshot.get("error"),
+                fetched_at,
+            ),
+        )
+        self._con.commit()
+        row = self._con.execute(
+            "SELECT * FROM remote_article_snapshots WHERE id=?", (snapshot_id,)
+        ).fetchone()
+        return self._remote_snapshot_row_to_dict(row)
+
+    def get_latest_remote_snapshot(
+        self, user_id: str, article_id: str, platform: str
+    ) -> dict | None:
+        row = self._con.execute(
+            """SELECT s.* FROM remote_article_snapshots s
+               JOIN articles a ON a.id=s.article_id
+               WHERE s.article_id=? AND s.platform=? AND a.user_id=?
+               ORDER BY s.fetched_at DESC, s.rowid DESC LIMIT 1""",
+            (article_id, platform, user_id),
+        ).fetchone()
+        return self._remote_snapshot_row_to_dict(row) if row else None
+
+    def list_latest_remote_snapshots(self, user_id: str, article_id: str) -> list[dict]:
+        rows = self._con.execute(
+            """SELECT s.* FROM remote_article_snapshots s
+               JOIN articles a ON a.id=s.article_id
+               WHERE s.article_id=? AND a.user_id=?
+                 AND s.rowid=(
+                   SELECT s2.rowid FROM remote_article_snapshots s2
+                   WHERE s2.article_id=s.article_id AND s2.platform=s.platform
+                   ORDER BY s2.fetched_at DESC, s2.rowid DESC LIMIT 1
+                 )
+               ORDER BY s.platform""",
+            (article_id, user_id),
+        ).fetchall()
+        return [self._remote_snapshot_row_to_dict(row) for row in rows]
+
+    def apply_remote_destination_state(
+        self,
+        user_id: str,
+        article_id: str,
+        platform: str,
+        *,
+        status: str,
+        url: str | None,
+        remote_id: str,
+    ) -> None:
+        label = "Published" if status == "published" else "Draft"
+        self._con.execute(
+            """UPDATE article_destinations
+               SET status=?, label=?, url=?, draft_id=?, error=NULL
+               WHERE article_id=? AND platform=?
+                 AND article_id IN (SELECT id FROM articles WHERE id=? AND user_id=?)""",
+            (status, label, url, remote_id, article_id, platform, article_id, user_id),
+        )
+        self._con.commit()
+
     # ── Connections ──────────────────────────────────────────────────────────
 
     def list_connections(self, user_id: str) -> list[dict]:
@@ -979,6 +1095,7 @@ class SQLiteStore(ConnectionAuthStoreMixin, AgentSessionStoreMixin, ArticleRevis
                 DELETE FROM article_patches;
                 DELETE FROM article_comments;
                 DELETE FROM article_timeline;
+                DELETE FROM remote_article_snapshots;
                 DELETE FROM article_revisions;
                 DELETE FROM article_destinations;
                 DELETE FROM article_assets;

--- a/backend/store/base.py
+++ b/backend/store/base.py
@@ -120,6 +120,26 @@ class ArticleStore(Protocol):
     def set_destinations_pending(self, article_id: str, platforms: list[str]) -> None:
         ...
 
+    def record_remote_snapshot(
+        self, user_id: str, article_id: str, snapshot: dict
+    ) -> dict:
+        ...
+
+    def get_latest_remote_snapshot(
+        self, user_id: str, article_id: str, platform: str
+    ) -> dict | None:
+        ...
+
+    def list_latest_remote_snapshots(
+        self, user_id: str, article_id: str
+    ) -> list[dict]:
+        ...
+
+    def apply_remote_destination_state(
+        self, user_id: str, article_id: str, platform: str, **kwargs
+    ) -> None:
+        ...
+
     # ── Connections ──────────────────────────────────────────────────────────
 
     def list_connections(self, user_id: str) -> list[dict]:

--- a/backend/store/schema.py
+++ b/backend/store/schema.py
@@ -16,7 +16,7 @@ SEED_USER_HASH = "$2b$12$BJsbJlf3SZUMUISLA8oASeFn.Q3U.Ar6TqoIFtu0F9OlYyev.DZLC"
 # Bump when sql/schema.sql changes in a way that isn't safe to layer onto an
 # existing database (e.g. a dropped/renamed column). Operators reset by
 # deleting the database file; there is no in-place upgrade path.
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 _SCHEMA_SQL_PATH = Path(__file__).resolve().parent / "sql" / "schema.sql"
 

--- a/backend/store/sql/schema.sql
+++ b/backend/store/sql/schema.sql
@@ -70,6 +70,30 @@ CREATE TABLE IF NOT EXISTS article_revisions (
     UNIQUE(article_id, revision_number)
 );
 
+-- Immutable observations of a linked article on a remote publishing platform.
+-- A new row is appended on every refresh or explicit resolution so drift can
+-- be classified against the last known common state without mutable history.
+CREATE TABLE IF NOT EXISTS remote_article_snapshots (
+    id                   TEXT PRIMARY KEY,
+    article_id           TEXT NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+    platform             TEXT NOT NULL,
+    remote_id            TEXT,
+    availability         TEXT NOT NULL,
+    sync_state           TEXT NOT NULL,
+    local_revision_id    TEXT REFERENCES article_revisions(id) ON DELETE SET NULL,
+    local_fingerprint    TEXT NOT NULL,
+    remote_fingerprint   TEXT,
+    title                TEXT,
+    content              TEXT,
+    canonical_url        TEXT,
+    remote_url           TEXT,
+    remote_status        TEXT,
+    remote_updated_at    TEXT,
+    metadata_json        TEXT NOT NULL DEFAULT '{}',
+    error                TEXT,
+    fetched_at           TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS connections (
     platform      TEXT NOT NULL,
     token         TEXT NOT NULL,
@@ -262,6 +286,9 @@ CREATE INDEX IF NOT EXISTS idx_article_timeline_article
 
 CREATE INDEX IF NOT EXISTS idx_article_revisions_article
     ON article_revisions(article_id, revision_number DESC);
+
+CREATE INDEX IF NOT EXISTS idx_remote_snapshots_article_platform
+    ON remote_article_snapshots(article_id, platform, fetched_at DESC);
 
 CREATE INDEX IF NOT EXISTS idx_article_comments_article
     ON article_comments(article_id);

--- a/blogs/hashnode/client.py
+++ b/blogs/hashnode/client.py
@@ -108,6 +108,45 @@ class HashnodeClient:
             raw=data,
         )
 
+    def update_draft(self, draft_id: str, draft: HashnodeDraftInput) -> HashnodeDraftResult:
+        """Update an existing draft so retries do not create duplicate submissions."""
+        mutation = """
+        mutation UpdateDraft($input: UpdateDraftInput!) {
+          updateDraft(input: $input) {
+            draft {
+              id
+              title
+              canonicalUrl
+              coverImage {
+                url
+              }
+            }
+          }
+        }
+        """
+        input_payload = self._draft_payload(draft)
+        input_payload["id"] = draft_id
+        response = self._session.post(
+            "https://gql.hashnode.com",
+            headers=self.headers,
+            json={"query": mutation, "variables": {"input": input_payload}},
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+        errors = data.get("errors")
+        if errors:
+            raise HashnodeError(str(errors))
+        draft_data = data["data"]["updateDraft"]["draft"]
+        cover_image = draft_data.get("coverImage") or {}
+        return HashnodeDraftResult(
+            draft_id=str(draft_data["id"]),
+            title=draft_data.get("title"),
+            canonical_url=draft_data.get("canonicalUrl"),
+            cover_image_url=cover_image.get("url"),
+            raw=data,
+        )
+
     def list_drafts(self, *, first: int = 20) -> list[HashnodeRemoteArticle]:
         query = """
         query MeDrafts($first: Int!) {

--- a/screens/editor/v2.html
+++ b/screens/editor/v2.html
@@ -312,6 +312,7 @@ if (!ARTICLE_ID) { location.replace('../overview/v3.html'); }
 
 let DESTINATIONS = [
 ];
+let RECONCILIATIONS = {};
 
 let COMMENTS = [];
 
@@ -775,24 +776,89 @@ async function restoreRevision(revisionId) {
 }
 
 function buildDestinations() {
-  const rows = DESTINATIONS.map((d, i) => `
+  const stateMeta = {
+    in_sync:['In sync','#4ade80'], local_ahead:['Local changes','#fbbf24'],
+    remote_ahead:['Remote changed','#7dd3fc'], conflict:['Conflict','#f87171'],
+    remote_deleted:['Remote deleted','#f87171'], inaccessible:['Unavailable','#f87171'],
+    unlinked:['Not linked','#5a6080']
+  };
+  const rows = DESTINATIONS.map((d, i) => {
+    const comparison = RECONCILIATIONS[d.id];
+    const remoteState = comparison ? (stateMeta[comparison.sync_state] || [comparison.sync_state, '#8b93ac']) : null;
+    const canCompare = d.id === 'hashnode' || d.id === 'devto';
+    const needsChoice = comparison && ['conflict','remote_ahead'].includes(comparison.sync_state);
+    const localAhead = comparison?.sync_state === 'local_ahead';
+    const localTitle = document.getElementById('article-title').textContent.trim();
+    return `
     <div style="${i ? 'border-top:1px solid #252a38;' : ''}padding:9px 0;">
       <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:${d.url || d.error ? 4 : 0}px;">
         <span style="font-size:13px;color:#e8eaf2;">${d.platform}</span>
-        <span class="pill ${d.status === 'draft' ? 's-draft' : d.status === 'error' ? 's-error' : 's-none'}">${d.label}</span>
+        <div style="display:flex;align-items:center;gap:6px;">
+          ${remoteState ? `<span style="font-size:9px;color:${remoteState[1]};font-family:'JetBrains Mono',monospace;">${remoteState[0]}</span>` : ''}
+          <span class="pill ${d.status === 'draft' ? 's-draft' : d.status === 'error' ? 's-error' : 's-none'}">${d.label}</span>
+        </div>
       </div>
       ${d.url ? `<a href="${esc(d.url.startsWith('http') ? d.url : 'https://' + d.url)}" target="_blank" rel="noopener" style="font-size:11px;color:#6366f1;text-decoration:none;">${esc(d.url)} ↗</a>` : ''}
+      ${comparison?.error ? `<div style="font-size:10px;color:#f87171;margin-top:5px;line-height:1.4;">${esc(comparison.error)}</div>` : ''}
+      <div style="display:flex;gap:5px;margin-top:7px;flex-wrap:wrap;">
+        ${canCompare ? `<button onclick="refreshReconciliation('${d.id}')" class="ai-btn" title="Fetch and compare the linked remote article">Refresh remote</button>` : '<span style="font-size:10px;color:#4d5368;">Remote comparison unavailable</span>'}
+        ${needsChoice ? `<button onclick="resolveRemote('${d.id}','use_remote')" class="ai-btn" style="color:#7dd3fc;">Use remote</button><button onclick="resolveRemote('${d.id}','keep_local')" class="ai-btn warn">Keep local</button>` : ''}
+        ${localAhead ? `<button onclick="pushLocal('${d.id}')" class="ai-btn warn">Push local</button>` : ''}
+      </div>
+      ${needsChoice ? `<details style="margin-top:7px;font-size:10px;color:#8b93ac;"><summary style="cursor:pointer;color:#aab2cc;">Compare versions</summary><div style="margin-top:6px;padding-left:7px;border-left:2px solid #fbbf24;"><div style="color:#fbbf24;margin-bottom:2px;">LOCAL</div><div style="color:#c9cfe0;overflow-wrap:anywhere;">${esc(localTitle)}</div></div><div style="margin-top:6px;padding-left:7px;border-left:2px solid #7dd3fc;"><div style="color:#7dd3fc;margin-bottom:2px;">REMOTE</div><div style="color:#c9cfe0;overflow-wrap:anywhere;">${esc(comparison.title || 'Untitled')}</div><div style="color:#5a6080;margin-top:2px;">${comparison.remote_updated_at ? new Date(comparison.remote_updated_at).toLocaleString() : 'Update time unavailable'}</div></div></details>` : ''}
       ${d.error ? `<div style="margin-top:5px;background:#2d1a1a;border:1px solid #4d2a2a;border-radius:4px;padding:5px 9px;display:flex;align-items:center;justify-content:space-between;gap:6px;">
         <span style="font-size:11px;color:#f87171;">${esc(d.error)}</span>
         <button style="font-size:10px;padding:2px 7px;border-radius:3px;background:#0f1117;border:1px solid #4d2a2a;color:#f87171;cursor:pointer;flex-shrink:0;">Retry</button>
       </div>` : ''}
-    </div>`).join('');
+    </div>`}).join('');
   return `<div>${rows}</div>
     <div style="padding-top:10px;">
       <button onclick="triggerInspect()" style="width:100%;font-size:12px;padding:7px 10px;border-radius:5px;border:1px solid #252a38;background:transparent;color:#c9cfe0;cursor:pointer;text-align:left;display:flex;align-items:center;gap:7px;">
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>Run inspection
       </button>
     </div>`;
+}
+
+async function loadReconciliation() {
+  try {
+    const r = await fetch(`/api/articles/${ARTICLE_ID}/reconciliation`);
+    if (!r.ok) return;
+    const data = await r.json();
+    RECONCILIATIONS = Object.fromEntries(data.comparisons.map(item => [item.platform, item]));
+    if (accOpen.destinations) renderSection('destinations');
+  } catch (_e) {}
+}
+
+async function refreshReconciliation(platform) {
+  const r = await fetch(`/api/articles/${ARTICLE_ID}/reconciliation/${platform}/refresh`, {method:'POST'});
+  const data = await r.json();
+  if (!r.ok) { alert(data.detail || 'Remote refresh failed'); return; }
+  RECONCILIATIONS[platform] = data;
+  renderSection('destinations');
+}
+
+async function resolveRemote(platform, action) {
+  const r = await fetch(`/api/articles/${ARTICLE_ID}/reconciliation/${platform}/resolve`, {
+    method:'POST', headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({action, base_revision_id:CURRENT_REVISION_ID}),
+  });
+  const data = await r.json();
+  if (r.status === 409 && data.detail?.code === 'revision_conflict') { showConflict(data.detail.current); return; }
+  if (!r.ok) { alert(data.detail || 'Resolution failed'); return; }
+  RECONCILIATIONS[platform] = data;
+  if (action === 'use_remote') await reloadArticleHead();
+  renderSection('destinations');
+}
+
+async function pushLocal(platform) {
+  const r = await fetch(`/api/articles/${ARTICLE_ID}/push`, {
+    method:'POST', headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({platforms:[platform]}),
+  });
+  const data = await r.json();
+  if (!r.ok) { alert(data.detail?.message || data.detail || 'Push failed'); return; }
+  await refreshReconciliation(platform);
+  await loadArticle();
 }
 
 function buildChat() {
@@ -1197,6 +1263,7 @@ async function loadArticle() {
     await loadComments();
     await loadPatches();
     await loadRevisions();
+    await loadReconciliation();
     await loadChat();
     await loadConnectedProviders();
     await loadAgentSession();

--- a/tests/tests_backend/test_articles/test_push.py
+++ b/tests/tests_backend/test_articles/test_push.py
@@ -81,3 +81,37 @@ class TestPushArticle:
         item = next(i for i in client.get("/api/articles").json()["items"] if i["id"] == "art_001")
         assert item["destinations"]["hashnode"]["url"] == "https://hashnode.example/preview/123"
         assert item["destinations"]["devto"]["url"] == "https://dev.to/example/draft"
+
+
+def test_devto_retry_updates_linked_article_instead_of_creating(monkeypatch):
+    from backend.services import push
+
+    article = {
+        "id": "art_test",
+        "title": "Retryable",
+        "body": "# Retryable\n\nBody",
+        "destinations": {"devto": {"draft_id": "42", "url": "https://dev.to/test"}},
+    }
+    calls = []
+
+    class FakeClient:
+        def __init__(self, token):
+            pass
+
+        def update_article(self, article_id, payload):
+            calls.append((article_id, payload.title))
+            return type("Result", (), {
+                "article_id": article_id,
+                "url": "https://dev.to/test",
+            })()
+
+        def publish_article(self, payload):
+            raise AssertionError("retry created a duplicate article")
+
+    monkeypatch.setattr(push, "DevToClient", FakeClient)
+    result = push.push_article_to_platforms(
+        article, ["devto"], get_connection_token=lambda _: "secret"
+    )["devto"]
+
+    assert calls == [(42, "Retryable")]
+    assert result.draft_id == "42"

--- a/tests/tests_backend/test_articles/test_reconciliation.py
+++ b/tests/tests_backend/test_articles/test_reconciliation.py
@@ -1,0 +1,168 @@
+"""Remote reconciliation API and state transition tests."""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+import backend.store as store
+from backend.services import reconciliation
+from backend.services.reconciliation import RemoteArticle
+from backend.store.schema import SEED_USER_ID
+
+
+def _link(platform: str = "devto", remote_id: str = "42") -> None:
+    store.merge_platform_into_article(
+        SEED_USER_ID,
+        "art_001",
+        platform,
+        "draft",
+        f"https://example.test/{remote_id}",
+        remote_id,
+        "Linked test destination",
+    )
+    store.save_connection(SEED_USER_ID, platform, token="secret")
+
+
+def _remote(platform: str, remote_id: str, title: str, content: str) -> RemoteArticle:
+    return RemoteArticle(
+        platform=platform,
+        remote_id=remote_id,
+        title=title,
+        content=content,
+        canonical_url=None,
+        remote_url=f"https://example.test/{remote_id}",
+        status="draft",
+        updated_at="2026-08-18T12:00:00+00:00",
+        metadata={},
+    )
+
+
+def test_refresh_detects_remote_change_and_persists_immutable_snapshots():
+    _link()
+    article = store.get_article(SEED_USER_ID, "art_001")
+    assert article is not None
+    first = reconciliation.refresh(
+        store,
+        SEED_USER_ID,
+        "art_001",
+        "devto",
+        fetcher=lambda *_: _remote("devto", "42", article["title"], article["body"]),
+    )
+    second = reconciliation.refresh(
+        store,
+        SEED_USER_ID,
+        "art_001",
+        "devto",
+        fetcher=lambda *_: _remote("devto", "42", article["title"], article["body"] + "\nRemote edit."),
+    )
+
+    assert first["sync_state"] == "in_sync"
+    assert second["sync_state"] == "remote_ahead"
+    assert first["id"] != second["id"]
+    assert store.get_latest_remote_snapshot(
+        SEED_USER_ID, "art_001", "devto"
+    )["id"] == second["id"]
+
+
+def test_refresh_detects_true_two_sided_conflict():
+    _link()
+    article = store.get_article(SEED_USER_ID, "art_001")
+    assert article is not None
+    reconciliation.refresh(
+        store,
+        SEED_USER_ID,
+        "art_001",
+        "devto",
+        fetcher=lambda *_: _remote("devto", "42", article["title"], article["body"]),
+    )
+    store.update_article_body(SEED_USER_ID, "art_001", article["body"] + "\nLocal edit.")
+    result = reconciliation.refresh(
+        store,
+        SEED_USER_ID,
+        "art_001",
+        "devto",
+        fetcher=lambda *_: _remote("devto", "42", article["title"], article["body"] + "\nRemote edit."),
+    )
+    assert result["sync_state"] == "conflict"
+
+
+def test_successful_missing_lookup_is_remote_deletion():
+    _link()
+    result = reconciliation.refresh(
+        store,
+        SEED_USER_ID,
+        "art_001",
+        "devto",
+        fetcher=lambda *_: None,
+    )
+    assert result["availability"] == "deleted"
+    assert result["sync_state"] == "remote_deleted"
+
+
+def test_provider_failure_is_inaccessible_not_deleted():
+    _link()
+
+    def fail(*_):
+        raise reconciliation.ReconciliationError("provider timed out")
+
+    result = reconciliation.refresh(
+        store, SEED_USER_ID, "art_001", "devto", fetcher=fail
+    )
+    assert result["availability"] == "inaccessible"
+    assert result["sync_state"] == "inaccessible"
+
+
+def test_api_refresh_and_use_remote_resolution(client: TestClient, monkeypatch):
+    _link()
+    article = store.get_article(SEED_USER_ID, "art_001")
+    assert article is not None
+    monkeypatch.setattr(
+        reconciliation,
+        "fetch_remote_article",
+        lambda *_: _remote("devto", "42", "Remote title", "Remote body"),
+    )
+
+    refreshed = client.post("/api/articles/art_001/reconciliation/devto/refresh")
+    assert refreshed.status_code == 200
+    assert refreshed.json()["sync_state"] == "conflict"
+
+    current = client.get("/api/articles/art_001").json()
+    resolved = client.post(
+        "/api/articles/art_001/reconciliation/devto/resolve",
+        json={"action": "use_remote", "base_revision_id": current["revision_id"]},
+    )
+    assert resolved.status_code == 200
+    assert resolved.json()["sync_state"] == "in_sync"
+    updated = client.get("/api/articles/art_001").json()
+    assert updated["title"] == "Remote title"
+    assert updated["content"] == "Remote body"
+
+
+def test_push_is_blocked_until_remote_conflict_is_resolved(client: TestClient, monkeypatch):
+    _link()
+    monkeypatch.setattr(
+        reconciliation,
+        "fetch_remote_article",
+        lambda *_: _remote("devto", "42", "Remote title", "Remote body"),
+    )
+    assert client.post(
+        "/api/articles/art_001/reconciliation/devto/refresh"
+    ).json()["sync_state"] == "conflict"
+
+    blocked = client.post(
+        "/api/articles/art_001/push", json={"platforms": ["devto"]}
+    )
+    assert blocked.status_code == 409
+    assert blocked.json()["detail"]["code"] == "remote_conflict"
+
+    current = client.get("/api/articles/art_001").json()
+    resolved = client.post(
+        "/api/articles/art_001/reconciliation/devto/resolve",
+        json={"action": "keep_local", "base_revision_id": current["revision_id"]},
+    )
+    assert resolved.status_code == 200
+    assert resolved.json()["sync_state"] == "local_ahead"
+
+
+def test_reconciliation_is_scoped_to_article_owner(anon_client: TestClient):
+    response = anon_client.post("/api/articles/art_001/reconciliation/devto/refresh")
+    assert response.status_code == 401

--- a/tests/tests_hashnode/test_client.py
+++ b/tests/tests_hashnode/test_client.py
@@ -69,3 +69,34 @@ def test_create_draft_sends_cover_image_and_slugged_tags():
         "originalArticleURL": "https://example.com/source",
         "coverImageOptions": {"coverImageURL": "https://example.com/cover.png"},
     }
+
+
+def test_update_draft_includes_existing_id():
+    session = _FakeSession(
+        {
+            "data": {
+                "updateDraft": {
+                    "draft": {
+                        "id": "draft-1",
+                        "title": "Updated",
+                        "canonicalUrl": None,
+                        "coverImage": None,
+                    }
+                }
+            }
+        }
+    )
+    client = HashnodeClient("token", session=session)
+
+    result = client.update_draft(
+        "draft-1",
+        HashnodeDraftInput(
+            title="Updated",
+            publication_id="pub-1",
+            content_markdown="New body",
+        ),
+    )
+
+    assert result.draft_id == "draft-1"
+    assert session.calls[0]["json"]["variables"]["input"]["id"] == "draft-1"
+    assert "updateDraft" in session.calls[0]["json"]["query"]


### PR DESCRIPTION
## Summary

- add immutable remote article snapshots and deterministic local/remote fingerprints
- reconcile linked Hashnode and Dev.to drafts or publications, including remote edits, publication state, URL changes, deletion, and inaccessible providers
- expose manual refresh and explicit `use_remote` / `keep_local` conflict resolution in the editor
- block pushes while remote changes are unresolved
- make Dev.to and Hashnode retries update linked remote IDs instead of creating duplicate drafts
- recognize Hashnode draft-to-publication transitions conservatively by ID, canonical URL, or a unique normalized title

## Verification

- `16 passed` in the focused reconciliation, push, schema, Hashnode, and Dev.to suite
- Playwright visual inspection at 1440x900 and 390x844, including expanded conflict comparison
- broader regression run: `268 passed`; remaining legacy failures are existing environment/fixture issues (live Hashnode API 502, Windows-mounted POSIX mode assertion, and provider service fixtures omitting the required user ID)

Closes #24