### PR TITLE
feat: add non-Pro Hashnode browser login

### DIFF
--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -582,13 +582,13 @@ def disconnect_hashnode_browser_connection(request: Request):
     if connection and connection.get("skyvern_session_id") and connection["status"] == "waiting_for_login":
         try:
             runner.cancel_hashnode_browser_login(connection["skyvern_session_id"])
-        except runner.RunnerUnavailable:
-            pass
+        except runner.RunnerUnavailable as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
     if connection and connection.get("skyvern_profile_id"):
         try:
             runner.delete_hashnode_browser_profile(connection["skyvern_profile_id"])
-        except runner.RunnerUnavailable:
-            pass
+        except runner.RunnerUnavailable as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
     store.delete_browser_connection(request.state.user_id, "hashnode")
     return {"platform": "hashnode", "status": "disconnected"}
 

--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -21,6 +21,7 @@ The backend never spawns CLI subprocesses directly.
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 
 import httpx
@@ -484,6 +485,112 @@ def _cli_oauth_start(conn_id: str) -> OAuthStartResponse:
 
 class SubmitCodeRequest(BaseModel):
     code: str
+
+
+def _browser_connection_response(connection: dict | None) -> dict:
+    if connection is None:
+        return {"platform": "hashnode", "status": "disconnected"}
+    return {
+        "platform": connection["platform"],
+        "status": connection["status"],
+        "authorizationUrl": (
+            connection.get("app_url")
+            if connection["status"] == "waiting_for_login"
+            else None
+        ),
+        "verifiedAt": connection.get("verified_at"),
+        "error": connection.get("error"),
+    }
+
+
+@router.get("/hashnode/browser-connection")
+def get_hashnode_browser_connection(request: Request):
+    return _browser_connection_response(
+        store.get_browser_connection(request.state.user_id, "hashnode")
+    )
+
+
+@router.post("/hashnode/browser-connection", status_code=201)
+def start_hashnode_browser_connection(request: Request):
+    previous = store.get_browser_connection(request.state.user_id, "hashnode")
+    if previous and previous.get("skyvern_session_id") and previous["status"] == "waiting_for_login":
+        try:
+            runner.cancel_hashnode_browser_login(previous["skyvern_session_id"])
+        except runner.RunnerUnavailable:
+            pass
+    reusable_profile_id = previous.get("skyvern_profile_id") if previous else None
+    try:
+        session = runner.start_hashnode_browser_login(reusable_profile_id)
+    except runner.RunnerUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    connection = store.start_browser_connection(
+        request.state.user_id,
+        "hashnode",
+        session_id=session["session_id"],
+        organization_id=session["organization_id"],
+        app_url=session["app_url"],
+        profile_id=reusable_profile_id,
+    )
+    return _browser_connection_response(connection)
+
+
+@router.post("/hashnode/browser-connection/complete")
+def complete_hashnode_browser_connection(request: Request):
+    user_id = request.state.user_id
+    connection = store.get_browser_connection(user_id, "hashnode")
+    if not connection or connection["status"] != "waiting_for_login":
+        raise HTTPException(status_code=409, detail="No Hashnode browser login is active")
+    store.update_browser_connection(user_id, "hashnode", "verifying")
+    profile_name = "bloghub-" + hashlib.sha256(user_id.encode()).hexdigest()[:16]
+    try:
+        result = runner.complete_hashnode_browser_login(
+            connection["skyvern_session_id"],
+            profile_name,
+            profile_id=connection.get("skyvern_profile_id"),
+            organization_id=connection.get("skyvern_organization_id"),
+        )
+    except runner.RunnerUnavailable as exc:
+        store.update_browser_connection(user_id, "hashnode", "failed", error=str(exc))
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    if not result.get("authenticated"):
+        failed = store.update_browser_connection(
+            user_id, "hashnode", "failed",
+            profile_id=result.get("profile_id"),
+            error="Hashnode sign-in was not completed in the browser",
+        )
+        return _browser_connection_response(failed)
+    if result.get("organization_id") != connection["skyvern_organization_id"]:
+        if result.get("profile_id"):
+            try:
+                runner.delete_hashnode_browser_profile(result["profile_id"])
+            except runner.RunnerUnavailable:
+                pass
+        failed = store.update_browser_connection(
+            user_id, "hashnode", "failed",
+            error="Browser profile ownership could not be verified",
+        )
+        return _browser_connection_response(failed)
+    connected = store.update_browser_connection(
+        user_id, "hashnode", "connected", profile_id=result["profile_id"]
+    )
+    return _browser_connection_response(connected)
+
+
+@router.delete("/hashnode/browser-connection")
+def disconnect_hashnode_browser_connection(request: Request):
+    connection = store.get_browser_connection(request.state.user_id, "hashnode")
+    if connection and connection.get("skyvern_session_id") and connection["status"] == "waiting_for_login":
+        try:
+            runner.cancel_hashnode_browser_login(connection["skyvern_session_id"])
+        except runner.RunnerUnavailable:
+            pass
+    if connection and connection.get("skyvern_profile_id"):
+        try:
+            runner.delete_hashnode_browser_profile(connection["skyvern_profile_id"])
+        except runner.RunnerUnavailable:
+            pass
+    store.delete_browser_connection(request.state.user_id, "hashnode")
+    return {"platform": "hashnode", "status": "disconnected"}
 
 
 @router.post("/{conn_id}/submit-code")

--- a/backend/services/cli_runner.py
+++ b/backend/services/cli_runner.py
@@ -141,6 +141,58 @@ def cancel_chat(session_id: str) -> None:
     _post(f"/chat/{session_id}/cancel")
 
 
+def start_hashnode_browser_login(profile_id: str | None = None) -> dict:
+    if profile_id:
+        return _post("/browser/hashnode/login", profile_id=profile_id)
+    return _post("/browser/hashnode/login")
+
+
+def get_hashnode_browser_login(session_id: str) -> dict:
+    return _get(f"/browser/hashnode/login/{session_id}")
+
+
+def cancel_hashnode_browser_login(session_id: str) -> None:
+    try:
+        with _client() as client:
+            response = client.delete(f"/browser/hashnode/login/{session_id}")
+            response.raise_for_status()
+    except (httpx.ConnectError, httpx.HTTPStatusError, httpx.ReadTimeout) as exc:
+        raise RunnerUnavailable(f"Browser login runner unavailable: {exc}") from exc
+
+
+def complete_hashnode_browser_login(
+    session_id: str,
+    profile_name: str,
+    *,
+    profile_id: str | None = None,
+    organization_id: str | None = None,
+) -> dict:
+    try:
+        with _client() as client:
+            response = client.post(
+                f"/browser/hashnode/login/{session_id}/complete",
+                json={
+                    "profile_name": profile_name,
+                    "profile_id": profile_id,
+                    "organization_id": organization_id,
+                },
+                timeout=httpx.Timeout(connect=3, read=180, write=10, pool=5),
+            )
+            response.raise_for_status()
+            return response.json()
+    except (httpx.ConnectError, httpx.HTTPStatusError, httpx.ReadTimeout) as exc:
+        raise RunnerUnavailable(f"Browser login runner unavailable: {exc}") from exc
+
+
+def delete_hashnode_browser_profile(profile_id: str) -> None:
+    try:
+        with _client() as client:
+            response = client.delete(f"/browser/hashnode/profiles/{profile_id}")
+            response.raise_for_status()
+    except (httpx.ConnectError, httpx.HTTPStatusError, httpx.ReadTimeout) as exc:
+        raise RunnerUnavailable(f"Browser login runner unavailable: {exc}") from exc
+
+
 def run_task(
     provider: str,
     task: str,

--- a/backend/store/__init__.py
+++ b/backend/store/__init__.py
@@ -178,6 +178,25 @@ def complete_job(user_id: str, *a, **kw):
     return _backend.complete_job(user_id, *a, **kw)
 
 
+# ── Browser connections ────────────────────────────────────────────────────
+
+
+def get_browser_connection(user_id: str, *a, **kw):
+    return _backend.get_browser_connection(user_id, *a, **kw)
+
+
+def start_browser_connection(user_id: str, *a, **kw):
+    return _backend.start_browser_connection(user_id, *a, **kw)
+
+
+def update_browser_connection(user_id: str, *a, **kw):
+    return _backend.update_browser_connection(user_id, *a, **kw)
+
+
+def delete_browser_connection(user_id: str, *a, **kw):
+    return _backend.delete_browser_connection(user_id, *a, **kw)
+
+
 # ── Agent sessions ───────────────────────────────────────────────────────────
 
 

--- a/backend/store/backends/sqlite.py
+++ b/backend/store/backends/sqlite.py
@@ -243,6 +243,7 @@ class SQLiteStore(
         with self._workspace_lock.acquire():
             apply_schema(self._con)
             self.reencrypt_connection_credentials()
+            self.reencrypt_browser_connection_credentials()
             self._seed_if_empty()
             self._ensure_initial_article_revisions()
             self._ensure_patch_revision_links()

--- a/backend/store/backends/sqlite.py
+++ b/backend/store/backends/sqlite.py
@@ -32,6 +32,7 @@ from backend.store.locking import WorkspaceLock
 from backend.store.agent_sessions import AgentSessionStoreMixin
 from backend.store.article_revisions import ArticleRevisionStoreMixin
 from backend.store.connection_auth import ConnectionAuthStoreMixin
+from backend.store.browser_connections import BrowserConnectionStoreMixin
 from backend.store.schema import (
     SEED_USER_EMAIL as DEFAULT_SEED_USER_EMAIL,
     SEED_USER_HASH as DEFAULT_SEED_USER_HASH,
@@ -218,7 +219,12 @@ def _seed_articles() -> list[dict]:
 # ─── SQLiteStore ──────────────────────────────────────────────────────────────
 
 
-class SQLiteStore(ConnectionAuthStoreMixin, AgentSessionStoreMixin, ArticleRevisionStoreMixin):
+class SQLiteStore(
+    BrowserConnectionStoreMixin,
+    ConnectionAuthStoreMixin,
+    AgentSessionStoreMixin,
+    ArticleRevisionStoreMixin,
+):
 
     def __init__(self, db_path: str, blobs_dir: str = "data/blobs") -> None:
         self._db_path = db_path
@@ -975,6 +981,7 @@ class SQLiteStore(ConnectionAuthStoreMixin, AgentSessionStoreMixin, ArticleRevis
             self._con.executescript("""
                 DELETE FROM article_chat_log;
                 DELETE FROM agent_sessions;
+                DELETE FROM browser_connections;
                 DELETE FROM article_patch_revisions;
                 DELETE FROM article_patches;
                 DELETE FROM article_comments;

--- a/backend/store/base.py
+++ b/backend/store/base.py
@@ -188,6 +188,22 @@ class ArticleStore(Protocol):
     def get_job(self, user_id: str, job_id: str) -> dict | None:
         ...
 
+    # ── Browser connections ────────────────────────────────────────────────
+
+    def get_browser_connection(self, user_id: str, platform: str) -> dict | None:
+        ...
+
+    def start_browser_connection(self, user_id: str, platform: str, **kwargs: Any) -> dict:
+        ...
+
+    def update_browser_connection(
+        self, user_id: str, platform: str, status: str, **kwargs: Any
+    ) -> dict:
+        ...
+
+    def delete_browser_connection(self, user_id: str, platform: str) -> bool:
+        ...
+
     def complete_job(self, user_id: str, job_id: str, result: dict | None = None, error: str | None = None) -> None:
         ...
 

--- a/backend/store/browser_connections.py
+++ b/backend/store/browser_connections.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from backend.store.crypto import decrypt_token, encrypt_token, needs_reencryption
+
 
 BROWSER_CONNECTION_STATUSES = {
     "disconnected",
@@ -18,13 +20,20 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _browser_connection_row(row) -> dict:
+    result = dict(row)
+    if result.get("app_url"):
+        result["app_url"] = decrypt_token(result["app_url"])
+    return result
+
+
 class BrowserConnectionStoreMixin:
     def get_browser_connection(self, user_id: str, platform: str) -> dict | None:
         row = self._con.execute(
             "SELECT * FROM browser_connections WHERE user_id=? AND platform=?",
             (user_id, platform),
         ).fetchone()
-        return dict(row) if row else None
+        return _browser_connection_row(row) if row else None
 
     def start_browser_connection(
         self,
@@ -60,12 +69,35 @@ class BrowserConnectionStoreMixin:
                         session_id,
                         organization_id,
                         profile_id,
-                        app_url,
+                        encrypt_token(app_url),
                         now,
                         now,
                     ),
                 )
         return self.get_browser_connection(user_id, platform)  # type: ignore[return-value]
+
+    def reencrypt_browser_connection_credentials(self) -> int:
+        """Move plaintext and retired-key browser stream URLs to the active key."""
+        rows = self._con.execute(
+            """SELECT user_id, platform, app_url FROM browser_connections
+               WHERE app_url IS NOT NULL AND app_url <> ''"""
+        ).fetchall()
+        replacements = []
+        for row in rows:
+            if needs_reencryption(row["app_url"]):
+                replacements.append((
+                    encrypt_token(decrypt_token(row["app_url"])),
+                    row["user_id"],
+                    row["platform"],
+                ))
+        if replacements:
+            with self._con:
+                self._con.executemany(
+                    """UPDATE browser_connections SET app_url=?
+                       WHERE user_id=? AND platform=?""",
+                    replacements,
+                )
+        return len(replacements)
 
     def update_browser_connection(
         self,

--- a/backend/store/browser_connections.py
+++ b/backend/store/browser_connections.py
@@ -1,0 +1,118 @@
+"""Durable references to provider browser profiles owned by Skyvern."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+BROWSER_CONNECTION_STATUSES = {
+    "disconnected",
+    "waiting_for_login",
+    "verifying",
+    "connected",
+    "expired",
+    "failed",
+}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class BrowserConnectionStoreMixin:
+    def get_browser_connection(self, user_id: str, platform: str) -> dict | None:
+        row = self._con.execute(
+            "SELECT * FROM browser_connections WHERE user_id=? AND platform=?",
+            (user_id, platform),
+        ).fetchone()
+        return dict(row) if row else None
+
+    def start_browser_connection(
+        self,
+        user_id: str,
+        platform: str,
+        *,
+        session_id: str,
+        organization_id: str,
+        app_url: str,
+        profile_id: str | None = None,
+    ) -> dict:
+        now = _now()
+        with self._workspace_lock.acquire():
+            with self._con:
+                self._con.execute(
+                    """INSERT INTO browser_connections
+                       (user_id, platform, status, skyvern_session_id,
+                        skyvern_organization_id, skyvern_profile_id, app_url,
+                        created_at, updated_at)
+                       VALUES (?, ?, 'waiting_for_login', ?, ?, ?, ?, ?, ?)
+                       ON CONFLICT(user_id, platform) DO UPDATE SET
+                         status='waiting_for_login',
+                         skyvern_session_id=excluded.skyvern_session_id,
+                         skyvern_organization_id=excluded.skyvern_organization_id,
+                         skyvern_profile_id=excluded.skyvern_profile_id,
+                         app_url=excluded.app_url,
+                         error=NULL,
+                         verified_at=NULL,
+                         updated_at=excluded.updated_at""",
+                    (
+                        user_id,
+                        platform,
+                        session_id,
+                        organization_id,
+                        profile_id,
+                        app_url,
+                        now,
+                        now,
+                    ),
+                )
+        return self.get_browser_connection(user_id, platform)  # type: ignore[return-value]
+
+    def update_browser_connection(
+        self,
+        user_id: str,
+        platform: str,
+        status: str,
+        *,
+        profile_id: str | None = None,
+        error: str | None = None,
+    ) -> dict:
+        if status not in BROWSER_CONNECTION_STATUSES:
+            raise ValueError(f"Unsupported browser connection status: {status}")
+        now = _now()
+        verified_at = now if status == "connected" else None
+        with self._workspace_lock.acquire():
+            with self._con:
+                row = self._con.execute(
+                    "SELECT 1 FROM browser_connections WHERE user_id=? AND platform=?",
+                    (user_id, platform),
+                ).fetchone()
+                if row is None:
+                    raise KeyError("Browser connection not found")
+                self._con.execute(
+                    """UPDATE browser_connections
+                       SET status=?,
+                           skyvern_profile_id=COALESCE(?, skyvern_profile_id),
+                           error=?,
+                           verified_at=COALESCE(?, verified_at),
+                           updated_at=?
+                       WHERE user_id=? AND platform=?""",
+                    (
+                        status,
+                        profile_id,
+                        error,
+                        verified_at,
+                        now,
+                        user_id,
+                        platform,
+                    ),
+                )
+        return self.get_browser_connection(user_id, platform)  # type: ignore[return-value]
+
+    def delete_browser_connection(self, user_id: str, platform: str) -> bool:
+        with self._workspace_lock.acquire():
+            with self._con:
+                cursor = self._con.execute(
+                    "DELETE FROM browser_connections WHERE user_id=? AND platform=?",
+                    (user_id, platform),
+                )
+        return cursor.rowcount > 0

--- a/backend/store/schema.py
+++ b/backend/store/schema.py
@@ -16,7 +16,7 @@ SEED_USER_HASH = "$2b$12$BJsbJlf3SZUMUISLA8oASeFn.Q3U.Ar6TqoIFtu0F9OlYyev.DZLC"
 # Bump when sql/schema.sql changes in a way that isn't safe to layer onto an
 # existing database (e.g. a dropped/renamed column). Operators reset by
 # deleting the database file; there is no in-place upgrade path.
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 _SCHEMA_SQL_PATH = Path(__file__).resolve().parent / "sql" / "schema.sql"
 

--- a/backend/store/sql/schema.sql
+++ b/backend/store/sql/schema.sql
@@ -239,6 +239,21 @@ CREATE TABLE IF NOT EXISTS agent_session_outputs (
     created_at    TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS browser_connections (
+    user_id                 TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    platform                TEXT NOT NULL,
+    status                  TEXT NOT NULL,
+    skyvern_session_id      TEXT,
+    skyvern_organization_id TEXT NOT NULL,
+    skyvern_profile_id      TEXT,
+    app_url                 TEXT,
+    error                   TEXT,
+    verified_at             TEXT,
+    created_at              TEXT NOT NULL,
+    updated_at              TEXT NOT NULL,
+    PRIMARY KEY (user_id, platform)
+);
+
 CREATE INDEX IF NOT EXISTS idx_articles_user_updated
     ON articles(user_id, updated_at DESC);
 
@@ -301,3 +316,6 @@ CREATE INDEX IF NOT EXISTS idx_agent_checkpoints_session
 
 CREATE INDEX IF NOT EXISTS idx_agent_outputs_session
     ON agent_session_outputs(session_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_browser_connections_status
+    ON browser_connections(status, updated_at DESC);

--- a/cli-runner/Dockerfile
+++ b/cli-runner/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-# System deps: Node (for claude CLI) + curl
+# System deps: Node (for provider CLIs) + curl
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         ca-certificates \
@@ -18,10 +18,10 @@ RUN npm install -g @openai/codex
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY main.py .
+COPY main.py hashnode_browser.py skyvern_browser.py ./
 
 # Credential directories (will be overridden by named volumes in docker-compose)
-RUN mkdir -p /root/.claude /root/.config/openai
+RUN mkdir -p /root/.claude /root/.config/openai /root/.config/gh /data/skyvern-browser-sessions
 
 EXPOSE 8001
 

--- a/cli-runner/hashnode_browser.py
+++ b/cli-runner/hashnode_browser.py
@@ -1,0 +1,78 @@
+"""Verify persisted Hashnode browser profiles without exposing credentials."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sqlite3
+import time
+
+
+def check_hashnode_profile(*, profile_dir: str) -> dict:
+    """Verify a closed Chromium profile without launching another browser."""
+    profile = Path(profile_dir)
+    authenticated = _chromium_cookie_db_has_hashnode_session(profile)
+    if not authenticated:
+        authenticated = _cookie_snapshot_has_hashnode_session(profile)
+    return {
+        "authenticated": authenticated,
+        "status": "connected" if authenticated else "login_required",
+    }
+
+
+def _is_hashnode_session_cookie(domain: object, name: object) -> bool:
+    return (
+        str(domain or "").lstrip(".") == "hashnode.com"
+        and (
+            name in {"authjs.session-token", "hashnode-session"}
+            or str(name or "").startswith("__Secure-authjs.session-token")
+        )
+    )
+
+
+def _chromium_cookie_db_has_hashnode_session(profile: Path) -> bool:
+    # Chromium stores expiry as microseconds since 1601-01-01 UTC.
+    chrome_now = int((time.time() + 11_644_473_600) * 1_000_000)
+    for cookie_db in (profile / "Default" / "Cookies", profile / "Cookies"):
+        if not cookie_db.is_file():
+            continue
+        try:
+            connection = sqlite3.connect(f"file:{cookie_db}?mode=ro", uri=True)
+            try:
+                rows = connection.execute(
+                    "SELECT host_key, name, expires_utc, length(value), "
+                    "length(encrypted_value) FROM cookies"
+                )
+                if any(
+                    _is_hashnode_session_cookie(domain, name)
+                    and (int(value_length or 0) + int(encrypted_length or 0) > 0)
+                    and (not expires or int(expires) > chrome_now)
+                    for domain, name, expires, value_length, encrypted_length in rows
+                ):
+                    return True
+            finally:
+                connection.close()
+        except (OSError, sqlite3.Error, TypeError, ValueError):
+            continue
+    return False
+
+
+def _cookie_snapshot_has_hashnode_session(profile: Path) -> bool:
+    snapshot = profile / ".skyvern_session_cookies.json"
+    try:
+        cookies = json.loads(snapshot.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError):
+        cookies = []
+    if not isinstance(cookies, list):
+        cookies = []
+    now = time.time()
+    return any(
+        isinstance(cookie, dict)
+        and _is_hashnode_session_cookie(cookie.get("domain"), cookie.get("name"))
+        and bool(cookie.get("value"))
+        and (
+            not isinstance(cookie.get("expires"), (int, float))
+            or cookie["expires"] <= 0
+            or cookie["expires"] > now
+        )
+        for cookie in cookies
+    )

--- a/cli-runner/main.py
+++ b/cli-runner/main.py
@@ -32,6 +32,16 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
+from hashnode_browser import check_hashnode_profile
+from skyvern_browser import (
+    SkyvernUnavailable,
+    close_hashnode_login,
+    delete_hashnode_profile,
+    finish_hashnode_login,
+    get_hashnode_login,
+    start_hashnode_login,
+)
+
 app = FastAPI(title="BlogHub CLI Runner", version="0.1.0")
 
 _RUNNER_HOME = os.environ.get("RUNNER_HOME", "/root")
@@ -210,7 +220,84 @@ class ChatRequest(BaseModel):
     api_key: Optional[str] = None
 
 
+class HashnodeBrowserLoginCompleteRequest(BaseModel):
+    profile_name: str
+    profile_id: Optional[str] = None
+    organization_id: Optional[str] = None
+
+
+class HashnodeBrowserLoginRequest(BaseModel):
+    profile_id: Optional[str] = None
+
+
+class HashnodeBrowserProfileRequest(BaseModel):
+    profile_id: str
+
+
 _chat_processes: dict[str, subprocess.Popen] = {}
+
+
+@app.post("/browser/hashnode/login", status_code=201)
+def hashnode_browser_login(req: Optional[HashnodeBrowserLoginRequest] = None):
+    try:
+        return start_hashnode_login(req.profile_id if req else None)
+    except ValueError as exc:
+        raise HTTPException(422, str(exc)) from exc
+    except SkyvernUnavailable as exc:
+        raise HTTPException(503, _safe_reason(str(exc))) from exc
+
+
+@app.get("/browser/hashnode/login/{session_id}")
+def hashnode_browser_login_status(session_id: str):
+    try:
+        return get_hashnode_login(session_id)
+    except ValueError as exc:
+        raise HTTPException(422, str(exc)) from exc
+    except SkyvernUnavailable as exc:
+        raise HTTPException(503, _safe_reason(str(exc))) from exc
+
+
+@app.delete("/browser/hashnode/login/{session_id}")
+def hashnode_browser_login_cancel(session_id: str):
+    try:
+        close_hashnode_login(session_id)
+        return {"status": "canceled"}
+    except ValueError as exc:
+        raise HTTPException(422, str(exc)) from exc
+    except SkyvernUnavailable as exc:
+        raise HTTPException(503, _safe_reason(str(exc))) from exc
+
+
+@app.post("/browser/hashnode/login/{session_id}/complete")
+def hashnode_browser_login_complete(
+    session_id: str, req: HashnodeBrowserLoginCompleteRequest,
+):
+    try:
+        profile = finish_hashnode_login(
+            session_id,
+            req.profile_name,
+            profile_id=req.profile_id,
+            organization_id=req.organization_id,
+        )
+        verification = check_hashnode_profile(profile_dir=profile["profile_dir"])
+        return {**verification, **profile}
+    except ValueError as exc:
+        raise HTTPException(422, str(exc)) from exc
+    except SkyvernUnavailable as exc:
+        raise HTTPException(503, _safe_reason(str(exc))) from exc
+    except Exception as exc:
+        raise HTTPException(502, _safe_reason(str(exc))) from exc
+
+
+@app.delete("/browser/hashnode/profiles/{profile_id}")
+def hashnode_browser_profile_delete(profile_id: str):
+    try:
+        delete_hashnode_profile(profile_id)
+        return {"status": "disconnected"}
+    except ValueError as exc:
+        raise HTTPException(422, str(exc)) from exc
+    except SkyvernUnavailable as exc:
+        raise HTTPException(503, _safe_reason(str(exc))) from exc
 
 
 # ── Health ─────────────────────────────────────────────────────────────────────

--- a/cli-runner/skyvern_browser.py
+++ b/cli-runner/skyvern_browser.py
@@ -1,0 +1,174 @@
+"""Small privileged adapter around Skyvern's browser-session API."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+import tomllib
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+
+
+SKYVERN_URL = os.environ.get("SKYVERN_URL", "http://skyvern:8000").rstrip("/")
+SKYVERN_PUBLIC_APP_URL = os.environ.get(
+    "SKYVERN_PUBLIC_APP_URL", "http://localhost:8083"
+).rstrip("/")
+SKYVERN_CREDENTIALS_FILE = Path(
+    os.environ.get("SKYVERN_CREDENTIALS_FILE", "/run/skyvern/credentials.toml")
+)
+SKYVERN_BROWSER_SESSION_ROOT = Path(
+    os.environ.get("SKYVERN_BROWSER_SESSION_ROOT", "/data/skyvern-browser-sessions")
+)
+
+_SESSION_ID = re.compile(r"^pbs_[A-Za-z0-9]+$")
+_PROFILE_ID = re.compile(r"^bp_[A-Za-z0-9]+$")
+_ORG_ID = re.compile(r"^o_[A-Za-z0-9]+$")
+
+
+class SkyvernUnavailable(RuntimeError):
+    pass
+
+
+def _api_key() -> str:
+    configured = os.environ.get("SKYVERN_API_KEY")
+    if configured:
+        return configured
+    try:
+        document = tomllib.loads(SKYVERN_CREDENTIALS_FILE.read_text(encoding="utf-8"))
+        for config in document.get("skyvern", {}).get("configs", []):
+            for organization in config.get("orgs", []):
+                credential = organization.get("cred")
+                if credential:
+                    return credential
+    except (OSError, tomllib.TOMLDecodeError, TypeError):
+        pass
+    raise SkyvernUnavailable("Skyvern local API credential is unavailable")
+
+
+def _request(method: str, path: str, payload: dict | None = None) -> dict:
+    try:
+        response = httpx.request(
+            method,
+            SKYVERN_URL + path,
+            headers={"x-api-key": _api_key()},
+            json=payload,
+            timeout=httpx.Timeout(120, connect=5),
+        )
+        response.raise_for_status()
+        return response.json() if response.content else {}
+    except (httpx.HTTPError, ValueError) as exc:
+        raise SkyvernUnavailable(f"Skyvern request failed: {type(exc).__name__}") from exc
+
+
+def _public_app_url(app_url: str | None, session_id: str) -> str:
+    path = f"/browser-session/{session_id}/stream"
+    if app_url:
+        upstream_path = urlsplit(app_url).path.rstrip("/")
+        if upstream_path:
+            path = upstream_path
+            if not path.endswith("/stream"):
+                path += "/stream"
+    public = urlsplit(SKYVERN_PUBLIC_APP_URL)
+    return urlunsplit(
+        (
+            public.scheme,
+            public.netloc,
+            path,
+            "embed=true&purpose=hashnode-login",
+            "",
+        )
+    )
+
+
+def start_hashnode_login(profile_id: str | None = None) -> dict:
+    if profile_id is not None and not _PROFILE_ID.fullmatch(profile_id):
+        raise ValueError("Invalid Skyvern profile id")
+    payload = {
+        "url": "https://hashnode.com/login",
+        "timeout": None,
+        # New sessions need an export that can become a profile. Sessions
+        # loaded from a profile persist back to that profile automatically.
+        "generate_browser_profile": profile_id is None,
+        "needs_live_view": True,
+    }
+    if profile_id:
+        payload["browser_profile_id"] = profile_id
+    session = _request("POST", "/v1/browser_sessions", payload)
+    session_id = session.get("browser_session_id", "")
+    organization_id = session.get("organization_id", "")
+    if not _SESSION_ID.fullmatch(session_id) or not _ORG_ID.fullmatch(organization_id):
+        raise SkyvernUnavailable("Skyvern returned invalid browser identifiers")
+    return {
+        "session_id": session_id,
+        "organization_id": organization_id,
+        "app_url": _public_app_url(session.get("app_url"), session_id),
+        "status": session.get("status") or "created",
+    }
+
+
+def get_hashnode_login(session_id: str) -> dict:
+    if not _SESSION_ID.fullmatch(session_id):
+        raise ValueError("Invalid Skyvern session id")
+    session = _request("GET", f"/v1/browser_sessions/{session_id}")
+    return {
+        "session_id": session_id,
+        "status": session.get("status"),
+        "app_url": _public_app_url(session.get("app_url"), session_id),
+        "completed_at": session.get("completed_at"),
+    }
+
+
+def close_hashnode_login(session_id: str) -> None:
+    if not _SESSION_ID.fullmatch(session_id):
+        raise ValueError("Invalid Skyvern session id")
+    _request("POST", f"/v1/browser_sessions/{session_id}/close")
+
+
+def finish_hashnode_login(
+    session_id: str,
+    profile_name: str,
+    profile_id: str | None = None,
+    organization_id: str | None = None,
+) -> dict:
+    if not _SESSION_ID.fullmatch(session_id):
+        raise ValueError("Invalid Skyvern session id")
+    close_hashnode_login(session_id)
+    if profile_id is not None:
+        if organization_id is None:
+            raise ValueError("Skyvern organization id is required for a reused profile")
+        return {
+            "profile_id": profile_id,
+            "organization_id": organization_id,
+            "profile_dir": str(profile_directory(organization_id, profile_id)),
+        }
+    profile = _request(
+        "POST",
+        "/v1/browser_profiles",
+        {
+            "name": profile_name[:120],
+            "description": "BlogHub Hashnode browser login profile",
+            "browser_session_id": session_id,
+        },
+    )
+    profile_id = profile.get("browser_profile_id", "")
+    organization_id = profile.get("organization_id", "")
+    if not _PROFILE_ID.fullmatch(profile_id) or not _ORG_ID.fullmatch(organization_id):
+        raise SkyvernUnavailable("Skyvern returned invalid profile identifiers")
+    return {
+        "profile_id": profile_id,
+        "organization_id": organization_id,
+        "profile_dir": str(profile_directory(organization_id, profile_id)),
+    }
+
+
+def delete_hashnode_profile(profile_id: str) -> None:
+    if not _PROFILE_ID.fullmatch(profile_id):
+        raise ValueError("Invalid Skyvern profile id")
+    _request("DELETE", f"/v1/browser_profiles/{profile_id}")
+
+
+def profile_directory(organization_id: str, profile_id: str) -> Path:
+    if not _ORG_ID.fullmatch(organization_id) or not _PROFILE_ID.fullmatch(profile_id):
+        raise ValueError("Invalid Skyvern profile identifiers")
+    return SKYVERN_BROWSER_SESSION_ROOT / organization_id / "profiles" / profile_id

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,9 +52,6 @@ services:
       SKYVERN_PUBLIC_APP_URL: http://localhost:8083
       SKYVERN_CREDENTIALS_FILE: /run/skyvern/credentials.toml
       SKYVERN_BROWSER_SESSION_ROOT: /data/skyvern-browser-sessions
-    depends_on:
-      skyvern:
-        condition: service_healthy
     init: true
     restart: unless-stopped
     healthcheck:
@@ -64,6 +61,7 @@ services:
       retries: 10
 
   skyvern-postgres:
+    profiles: ["hashnode-browser"]
     image: postgres@sha256:727876d274666da0b92a445390ba093c84b8e9f8343e1c53cd4e9a7ab2d85310
     restart: unless-stopped
     environment:
@@ -80,6 +78,7 @@ services:
       retries: 10
 
   skyvern:
+    profiles: ["hashnode-browser"]
     image: bloghub-skyvern-patchright:1.62.1
     build:
       context: ./experiments/skyvern
@@ -125,6 +124,7 @@ services:
       start_period: 180s
 
   skyvern-ui:
+    profiles: ["hashnode-browser"]
     image: bloghub-skyvern-ui:1.0.50
     build:
       context: ./experiments/skyvern

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,10 +34,12 @@ services:
   cli-runner:
     build: ./cli-runner
     ports:
-      - "8001:8001"
+      - "127.0.0.1:${BLOGHUB_RUNNER_PORT:-8001}:8001"
     volumes:
       - claude-config:/root/.claude
       - codex-config:/root/.codex
+      - skyvern-config:/run/skyvern:ro
+      - skyvern-browser-sessions:/data/skyvern-browser-sessions
     environment:
       RUNNER_HOME: /root
       RUNNER_TASK_TIMEOUT: "180"
@@ -46,6 +48,13 @@ services:
       CLAUDE_CALLBACK_PORT: "54322"
       CLAUDE_CONFIG_DIR: /root/.claude
       CODEX_CONFIG_DIR: /root/.codex
+      SKYVERN_URL: http://skyvern:8000
+      SKYVERN_PUBLIC_APP_URL: http://localhost:8083
+      SKYVERN_CREDENTIALS_FILE: /run/skyvern/credentials.toml
+      SKYVERN_BROWSER_SESSION_ROOT: /data/skyvern-browser-sessions
+    depends_on:
+      skyvern:
+        condition: service_healthy
     init: true
     restart: unless-stopped
     healthcheck:
@@ -54,9 +63,97 @@ services:
       timeout: 3s
       retries: 10
 
+  skyvern-postgres:
+    image: postgres@sha256:727876d274666da0b92a445390ba093c84b8e9f8343e1c53cd4e9a7ab2d85310
+    restart: unless-stopped
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_USER: skyvern
+      POSTGRES_PASSWORD: skyvern
+      POSTGRES_DB: skyvern
+    volumes:
+      - skyvern-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U skyvern"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  skyvern:
+    image: bloghub-skyvern-patchright:1.62.1
+    build:
+      context: ./experiments/skyvern
+      dockerfile: Dockerfile.patchright
+    restart: on-failure
+    entrypoint: ["sh", "/experiment/entrypoint.sh"]
+    ports:
+      - "127.0.0.1:8003:8000"
+      - "127.0.0.1:6083:6080"
+    environment:
+      DATABASE_STRING: postgresql+psycopg://skyvern:skyvern@skyvern-postgres:5432/skyvern
+      SKYVERN_SCHEMA_WORKAROUND_DATABASE_URL: postgresql://skyvern:skyvern@skyvern-postgres:5432/skyvern
+      BROWSER_STREAMING_MODE: cdp
+      BROWSER_TYPE: chromium-headful
+      CHROME_EXECUTABLE_PATH: /root/.cache/ms-playwright/chromium-1134/chrome-linux/chrome
+      DOWNLOAD_PATH: /data/downloads
+      BROWSER_SESSION_BASE_PATH: /data/browser_sessions
+      CREDENTIAL_VAULT_TYPE: skyvern
+      ENABLE_LOCAL_CREDENTIAL_VAULT: "true"
+      LOCAL_CREDENTIAL_VAULT_PATH: /data/credential_vault
+      ENABLE_OPENAI: "false"
+      ENABLE_ANTHROPIC: "false"
+      ENABLE_GEMINI: "false"
+      SKYVERN_TELEMETRY: "false"
+      ENABLE_LOG_ARTIFACTS: "false"
+      ALLOWED_ORIGINS: '["http://localhost:8083","http://127.0.0.1:8083"]'
+    volumes:
+      - skyvern-artifacts:/data/artifacts
+      - skyvern-downloads:/data/downloads
+      - skyvern-browser-sessions:/data/browser_sessions
+      - skyvern-credential-vault:/data/credential_vault
+      - skyvern-config:/app/.skyvern
+      - ./experiments/skyvern/entrypoint.sh:/experiment/entrypoint.sh:ro
+      - ./experiments/skyvern/skyvern_1_0_50_schema_workaround.py:/experiment/skyvern_1_0_50_schema_workaround.py:ro
+    depends_on:
+      skyvern-postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/api/v1/heartbeat', timeout=5)"]
+      interval: 5s
+      timeout: 5s
+      retries: 36
+      start_period: 180s
+
+  skyvern-ui:
+    image: bloghub-skyvern-ui:1.0.50
+    build:
+      context: ./experiments/skyvern
+      dockerfile: Dockerfile.ui
+    restart: on-failure
+    environment:
+      VITE_BROWSER_STREAMING_MODE: cdp
+      VITE_WSS_BASE_URL: ws://localhost:8003/api/v1
+      VITE_ARTIFACT_API_BASE_URL: http://localhost:9093
+      VITE_API_BASE_URL: http://localhost:8003/api/v1
+    ports:
+      - "127.0.0.1:8083:8080"
+      - "127.0.0.1:9093:9090"
+    volumes:
+      - skyvern-artifacts:/data/artifacts
+      - skyvern-config:/app/.skyvern
+    depends_on:
+      skyvern:
+        condition: service_healthy
+
 volumes:
   bloghub-data:
   bloghub-previews:
   bloghub-credential-keys:
   claude-config:
   codex-config:
+  skyvern-artifacts:
+  skyvern-browser-sessions:
+  skyvern-config:
+  skyvern-credential-vault:
+  skyvern-downloads:
+  skyvern-postgres-data:

--- a/experiments/skyvern/.dockerignore
+++ b/experiments/skyvern/.dockerignore
@@ -1,0 +1,11 @@
+.env
+.skyvern/
+artifacts/
+browser_sessions/
+credential_vault/
+downloads/
+har/
+log/
+patchright-probe/artifacts/
+postgres-data/
+videos/

--- a/experiments/skyvern/.env.example
+++ b/experiments/skyvern/.env.example
@@ -1,0 +1,22 @@
+BROWSER_STREAMING_MODE=cdp
+BROWSER_TYPE=chromium-headful
+VITE_BROWSER_STREAMING_MODE=cdp
+
+# Browser/session validation does not require an LLM. BlogHub remains the agent
+# orchestrator during this experiment.
+ENABLE_OPENAI=false
+ENABLE_ANTHROPIC=false
+ENABLE_GEMINI=false
+LLM_KEY=
+
+CREDENTIAL_VAULT_TYPE=skyvern
+ENABLE_LOCAL_CREDENTIAL_VAULT=true
+
+# Set this from a secret manager before storing real credentials. If omitted,
+# Skyvern generates a key in its local data volume, which is only suitable for
+# this disposable experiment.
+# LOCAL_CREDENTIAL_VAULT_KEY=
+
+SKYVERN_TELEMETRY=false
+ENABLE_LOG_ARTIFACTS=false
+ALLOWED_ORIGINS=["http://localhost:8080","http://127.0.0.1:8080"]

--- a/experiments/skyvern/.gitignore
+++ b/experiments/skyvern/.gitignore
@@ -1,0 +1,10 @@
+.env
+.skyvern/
+artifacts/
+browser_sessions/
+credential_vault/
+downloads/
+har/
+log/
+postgres-data/
+videos/

--- a/experiments/skyvern/Dockerfile.patchright
+++ b/experiments/skyvern/Dockerfile.patchright
@@ -1,0 +1,11 @@
+FROM public.ecr.aws/skyvern/skyvern@sha256:18defe240c49c79c749c57f7e9008b1a169aa34193b267002c7e5ee437e28887
+
+COPY patchright-requirements.txt /tmp/patchright-requirements.txt
+RUN pip install --no-cache-dir --no-deps --require-hashes \
+      -r /tmp/patchright-requirements.txt \
+    && rm /tmp/patchright-requirements.txt
+
+COPY patch_skyvern_for_patchright.py /tmp/patch_skyvern_for_patchright.py
+RUN python /tmp/patch_skyvern_for_patchright.py \
+    && rm /tmp/patch_skyvern_for_patchright.py \
+    && python -m compileall -q /app/skyvern

--- a/experiments/skyvern/Dockerfile.ui
+++ b/experiments/skyvern/Dockerfile.ui
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/skyvern/skyvern-ui@sha256:69ffc56b25e96f5909d53f4c06574fed2bf331747d18cf715fb36debb070e1d5
+
+COPY skyvern_ui_browser_embed.css /tmp/bloghub-browser-embed.css
+COPY patch_skyvern_ui.cjs /tmp/patch-skyvern-ui.cjs
+RUN cat /tmp/bloghub-browser-embed.css >> /app/dist.template/assets/index--bCtSXVO.css \
+    && node /tmp/patch-skyvern-ui.cjs \
+    && rm /tmp/bloghub-browser-embed.css /tmp/patch-skyvern-ui.cjs

--- a/experiments/skyvern/README.md
+++ b/experiments/skyvern/README.md
@@ -1,8 +1,16 @@
 # Skyvern local capability experiment
 
 This is a free, self-hosted Skyvern fixture for evaluating BlogHub's managed
-browser login and persistent-profile path. It is deliberately isolated from
-the main BlogHub compose stack and binds every host port to loopback.
+browser login and persistent-profile path. Its services are opt-in and every
+host port is bound to loopback.
+
+BlogHub's main compose file also exposes this fixture behind the opt-in
+`hashnode-browser` profile. Core backend and agent-runner startup does not wait
+for Skyvern. Start the integrated login capability with:
+
+```bash
+docker compose --profile hashnode-browser up -d --wait
+```
 
 ## Pinned source
 

--- a/experiments/skyvern/README.md
+++ b/experiments/skyvern/README.md
@@ -1,0 +1,115 @@
+# Skyvern local capability experiment
+
+This is a free, self-hosted Skyvern fixture for evaluating BlogHub's managed
+browser login and persistent-profile path. It is deliberately isolated from
+the main BlogHub compose stack and binds every host port to loopback.
+
+## Pinned source
+
+- Skyvern source commit: `3c305c911f91beee3f04308453f3d9913f610efc`
+- Skyvern runtime: `1.0.50`, pinned by image digest in the compose file
+- Skyvern UI and PostgreSQL are also pinned by digest
+- Upstream compose source: <https://github.com/Skyvern-AI/skyvern/blob/3c305c911f91beee3f04308453f3d9913f610efc/docker-compose.yml>
+
+## Start it
+
+```bash
+cd experiments/skyvern
+cp .env.example .env
+docker compose up -d --wait --wait-timeout 300
+curl --fail http://127.0.0.1:8000/api/v1/heartbeat
+```
+
+Open <http://localhost:8080>. The first boot can take several minutes while
+Skyvern initializes PostgreSQL and downloads its browser.
+
+The pinned Skyvern release has a migration-check mismatch involving
+`ck_google_oauth_credentials_state`. The narrowly scoped startup wrapper waits
+for that constraint and removes it before Skyvern checks for schema drift.
+Remove the workaround when upgrading Skyvern; do not carry it to an unpinned
+release without reproducing the issue.
+
+The 1.0.50 home and browser-list pages may also show **Unable to verify Skyvern
+API key**. In this release, the generated key succeeds against browser and
+workflow endpoints while two UI diagnostics endpoints still return `403`.
+Treat the banner as an upstream UI issue only after the heartbeat and a real
+browser session both succeed.
+
+## Capability checklist
+
+1. Create a browser session for `https://example.com` and verify the live
+   stream renders.
+2. Select **Take control** and confirm mouse and keyboard input reaches the
+   remote browser.
+3. Sign into a disposable test account, save the session as a browser profile,
+   close it, and start a new session from the profile. Confirm the login state
+   survives the new browser process.
+4. Create a credential with an invented password. Confirm credential list
+   responses omit the password and neither username nor password appears as
+   plaintext in `/data/credential_vault` inside the Skyvern container. Delete
+   the test credential.
+5. Open the target publisher login and verify both the public site and the
+   authentication handoff. Do not publish during this experiment.
+
+Skyvern blocks loopback destinations submitted through its browser-session API.
+Keep that SSRF protection enabled; use a harmless public fixture when testing
+browser sessions.
+
+## Results on 2026-08-18
+
+| Capability | Result |
+| --- | --- |
+| API, UI, PostgreSQL health | Pass |
+| Headed Chromium live stream | Pass |
+| Human/Playwright live takeover | Pass |
+| Login through streamed browser | Pass, using a public disposable login fixture |
+| Browser-profile cookie persistence | Pass across a new Chromium process |
+| Local encrypted credential vault | Pass; password redacted and test values absent from vault files |
+| Hashnode public application | Pass |
+| Hashnode `/login` verification | **Blocked**: Vercel Security Checkpoint reports `Failed to verify your browser`, code 19 |
+| Hashnode `/login` with Patchright override | Pass; real Google, LinkedIn, GitHub, and email login options render |
+| Patchright live takeover and profile restore | Pass |
+
+The stock result means the upstream image is a useful integration substrate but
+does not validate unattended Hashnode login. Skyvern's free image registers
+local Playwright Chromium, while its `stealth-chromium` session type is not a
+bundled free local browser engine.
+
+The experimental override replaces Skyvern's Playwright imports with
+[Patchright](https://github.com/Kaliiiiiiiiii-Vinyzu/patchright-python) `1.62.1`
+and keeps the Chromium already pinned in Skyvern's image. This passed the same
+Hashnode checkpoint on this machine:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.patchright.yml \
+  up -d --build --wait --wait-timeout 300
+```
+
+The override is intentionally experimental. Its headed launcher omits
+Skyvern's HAR, video, fixed viewport, custom browser arguments, and custom
+headers because that bundle closed Patchright's browser during `Page.enable`.
+Live streaming, takeover, browser profiles, and profile restoration were
+verified. Downloads, recording, and HAR must be tested or reintroduced one
+option at a time before this image is considered a drop-in production
+replacement.
+
+No Skyvern LLM is enabled here. BlogHub owns the connection lifecycle while
+Skyvern supplies isolated browser sessions, streaming, profiles, and credentials.
+
+## Security boundaries
+
+- Keep ports loopback-only unless authentication and TLS are added.
+- Never commit `.env`, `.skyvern/`, browser profiles, vault data, or artifacts.
+- Set `LOCAL_CREDENTIAL_VAULT_KEY` from an external secret manager before
+  storing real credentials. The generated local key is for disposable testing.
+- Prefer OAuth/session profiles over storing a GitHub account password.
+
+Stop the experiment with:
+
+```bash
+docker compose down
+```
+
+Add `--volumes` only when intentionally deleting all experimental state.

--- a/experiments/skyvern/docker-compose.patchright.yml
+++ b/experiments/skyvern/docker-compose.patchright.yml
@@ -1,0 +1,8 @@
+services:
+  skyvern:
+    image: bloghub-skyvern-patchright:1.62.1
+    build:
+      context: .
+      dockerfile: Dockerfile.patchright
+    environment:
+      CHROME_EXECUTABLE_PATH: /root/.cache/ms-playwright/chromium-1134/chrome-linux/chrome

--- a/experiments/skyvern/docker-compose.yml
+++ b/experiments/skyvern/docker-compose.yml
@@ -1,0 +1,96 @@
+services:
+  postgres:
+    image: postgres@sha256:727876d274666da0b92a445390ba093c84b8e9f8343e1c53cd4e9a7ab2d85310
+    restart: unless-stopped
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_USER: skyvern
+      POSTGRES_PASSWORD: skyvern
+      POSTGRES_DB: skyvern
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U skyvern"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  skyvern:
+    image: public.ecr.aws/skyvern/skyvern@sha256:18defe240c49c79c749c57f7e9008b1a169aa34193b267002c7e5ee437e28887
+    restart: on-failure
+    entrypoint: ["sh", "/experiment/entrypoint.sh"]
+    env_file:
+      - path: .env
+        required: false
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    environment:
+      DATABASE_STRING: postgresql+psycopg://skyvern:skyvern@postgres:5432/skyvern
+      BROWSER_STREAMING_MODE: ${BROWSER_STREAMING_MODE:-cdp}
+      BROWSER_TYPE: ${BROWSER_TYPE:-chromium-headful}
+      DOWNLOAD_PATH: /data/downloads
+      BROWSER_SESSION_BASE_PATH: /data/browser_sessions
+      CREDENTIAL_VAULT_TYPE: ${CREDENTIAL_VAULT_TYPE:-skyvern}
+      ENABLE_LOCAL_CREDENTIAL_VAULT: ${ENABLE_LOCAL_CREDENTIAL_VAULT:-true}
+      LOCAL_CREDENTIAL_VAULT_PATH: /data/credential_vault
+      ENABLE_OPENAI: ${ENABLE_OPENAI:-false}
+      ENABLE_ANTHROPIC: ${ENABLE_ANTHROPIC:-false}
+      ENABLE_GEMINI: ${ENABLE_GEMINI:-false}
+      LLM_KEY: ${LLM_KEY:-}
+      SKYVERN_TELEMETRY: ${SKYVERN_TELEMETRY:-false}
+      ENABLE_LOG_ARTIFACTS: ${ENABLE_LOG_ARTIFACTS:-false}
+      ALLOWED_ORIGINS: '${ALLOWED_ORIGINS:-["http://localhost:8080","http://127.0.0.1:8080"]}'
+    ports:
+      - 127.0.0.1:8000:8000
+      - 127.0.0.1:6080:6080
+    volumes:
+      - artifacts:/data/artifacts
+      - videos:/data/videos
+      - har:/data/har
+      - logs:/data/log
+      - downloads:/data/downloads
+      - browser-sessions:/data/browser_sessions
+      - credential-vault:/data/credential_vault
+      - skyvern-config:/app/.skyvern
+      - ./entrypoint.sh:/experiment/entrypoint.sh:ro
+      - ./skyvern_1_0_50_schema_workaround.py:/experiment/skyvern_1_0_50_schema_workaround.py:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/api/v1/heartbeat', timeout=5)"]
+      interval: 5s
+      timeout: 5s
+      retries: 36
+      start_period: 180s
+
+  skyvern-ui:
+    image: public.ecr.aws/skyvern/skyvern-ui@sha256:69ffc56b25e96f5909d53f4c06574fed2bf331747d18cf715fb36debb070e1d5
+    restart: on-failure
+    environment:
+      VITE_BROWSER_STREAMING_MODE: ${VITE_BROWSER_STREAMING_MODE:-cdp}
+      VITE_WSS_BASE_URL: ws://localhost:8000/api/v1
+      VITE_ARTIFACT_API_BASE_URL: http://localhost:9090
+      VITE_API_BASE_URL: http://localhost:8000/api/v1
+    ports:
+      - 127.0.0.1:8080:8080
+      - 127.0.0.1:9090:9090
+    volumes:
+      - artifacts:/data/artifacts
+      - videos:/data/videos
+      - har:/data/har
+      - skyvern-config:/app/.skyvern
+    depends_on:
+      skyvern:
+        condition: service_healthy
+
+volumes:
+  artifacts:
+  browser-sessions:
+  credential-vault:
+  downloads:
+  har:
+  logs:
+  postgres-data:
+  skyvern-config:
+  videos:

--- a/experiments/skyvern/entrypoint.sh
+++ b/experiments/skyvern/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+python /experiment/skyvern_1_0_50_schema_workaround.py &
+exec /app/entrypoint-skyvern.sh

--- a/experiments/skyvern/patch_skyvern_for_patchright.py
+++ b/experiments/skyvern/patch_skyvern_for_patchright.py
@@ -1,0 +1,566 @@
+"""Apply the minimal Patchright experiment to the pinned Skyvern source tree."""
+
+from pathlib import Path
+
+
+SKYVERN_ROOT = Path("/app/skyvern")
+BROWSER_FACTORY = SKYVERN_ROOT / "webeye/browser_factory.py"
+SCREENCAST = SKYVERN_ROOT / "forge/sdk/routes/streaming/screencast.py"
+CDP_INPUT = SKYVERN_ROOT / "forge/sdk/routes/streaming/cdp_input.py"
+REAL_BROWSER_STATE = SKYVERN_ROOT / "webeye/real_browser_state.py"
+PERSISTENT_SESSIONS_MANAGER = SKYVERN_ROOT / "webeye/default_persistent_sessions_manager.py"
+
+
+def rewrite_imports() -> int:
+    changed = 0
+    for path in SKYVERN_ROOT.rglob("*.py"):
+        source = path.read_text(encoding="utf-8")
+        patched = source.replace("from playwright", "from patchright")
+        if patched != source:
+            path.write_text(patched, encoding="utf-8")
+            changed += 1
+    return changed
+
+
+def add_browser_executable() -> None:
+    source = BROWSER_FACTORY.read_text(encoding="utf-8")
+    headful_launch_anchor = '''    browser_args = BrowserContextFactory.build_browser_args(
+        proxy_location=proxy_location, cdp_port=cdp_port, extra_http_headers=extra_http_headers
+    )
+    browser_args.update(
+        {
+            "user_data_dir": user_data_dir,
+            "downloads_path": download_dir,
+            "headless": False,
+        }
+    )
+'''
+    headful_launch_replacement = '''    # Match Patchright's minimal persistent-context configuration. Skyvern's
+    # HAR/video/viewport bundle closes this pinned browser during Page.enable.
+    browser_args = {
+        "user_data_dir": user_data_dir,
+        "downloads_path": download_dir,
+        "headless": False,
+        "no_viewport": True,
+        # Chromium stalls for roughly 40 seconds while probing unavailable GPU
+        # support under Docker/Xvfb. Skip that probe and render in software.
+        "args": ["--window-size=1180,820", "--disable-gpu"],
+    }
+    if settings.CHROME_EXECUTABLE_PATH:
+        browser_args["executable_path"] = settings.CHROME_EXECUTABLE_PATH
+'''
+    headless_anchor = '''        }
+    )
+
+    browser_artifacts = BrowserContextFactory.build_browser_artifacts(
+'''
+    executable_assignment = '''        }
+    )
+    if settings.CHROME_EXECUTABLE_PATH:
+        browser_args["executable_path"] = settings.CHROME_EXECUTABLE_PATH
+
+    browser_artifacts = BrowserContextFactory.build_browser_artifacts(
+'''
+    if source.count(headful_launch_anchor) != 1:
+        raise RuntimeError("Pinned headful browser-factory launch block changed")
+    source = source.replace(headful_launch_anchor, headful_launch_replacement)
+    before_headful, headful_and_after = source.split(headful_launch_replacement, 1)
+    har_anchor = 'har_path=browser_args["record_har_path"]'
+    if har_anchor not in headful_and_after:
+        raise RuntimeError("Pinned headful HAR artifact anchor changed")
+    headful_and_after = headful_and_after.replace(har_anchor, "har_path=None", 1)
+    source = before_headful + headful_launch_replacement + headful_and_after
+    if source.count(headless_anchor) != 1:
+        raise RuntimeError("Pinned headless browser-factory anchor changed")
+    source = source.replace(headless_anchor, executable_assignment)
+    BROWSER_FACTORY.write_text(source, encoding="utf-8")
+
+
+def improve_local_stream_quality() -> None:
+    source = SCREENCAST.read_text(encoding="utf-8")
+    dimensions = "DEFAULT_WIDTH = 1280\nDEFAULT_HEIGHT = 720"
+    if source.count(dimensions) != 1:
+        raise RuntimeError("Pinned screencast dimensions changed")
+    source = source.replace(
+        dimensions,
+        "DEFAULT_WIDTH = 1920\nDEFAULT_HEIGHT = 1200",
+    )
+    scale_registry_anchor = "ACTIVE_PAGE_POLL_INTERVAL = 0.5\n"
+    scale_registry = scale_registry_anchor + '''
+_viewer_device_scales: dict[str, float] = {}
+
+
+def set_viewer_device_scale(entity_id: str, scale: float) -> None:
+    _viewer_device_scales[entity_id] = max(1.0, min(float(scale), 3.0))
+'''
+    if source.count(scale_registry_anchor) != 1:
+        raise RuntimeError("Pinned screencast scale registry anchor changed")
+    source = source.replace(scale_registry_anchor, scale_registry)
+    if source.count('"format": "jpeg"') != 3 or source.count('"quality": 60') != 2:
+        raise RuntimeError("Pinned screencast format settings changed")
+    source = source.replace('"format": "jpeg"', '"format": "png"')
+    source = source.replace('                    "quality": 60,\n', "")
+
+    state_anchor = '''    viewport_info: dict[str, int] = {"width": DEFAULT_WIDTH, "height": DEFAULT_HEIGHT}
+'''
+    state_replacement = state_anchor + '''    hidpi_capture_in_flight = False
+    last_hidpi_capture_at = 0.0
+    hashnode_login_streak = 0
+    hashnode_login_complete = False
+'''
+    if source.count(state_anchor) != 1:
+        raise RuntimeError("Pinned screencast state anchor changed")
+    source = source.replace(state_anchor, state_replacement)
+
+    frame_anchor = '''    async def _on_frame(session: CDPSession, params: dict) -> None:
+        if session is not cdp_session:
+            return
+        data = params.get("data", "")
+        session_id = params.get("sessionId", 0)
+        metadata = params.get("metadata", {})
+        if metadata:
+            _update_viewport_from_metadata(metadata)
+        asyncio.create_task(_ack_frame(session, session_id))
+        _queue_frame(data)
+'''
+    frame_replacement = '''    async def _capture_hidpi_frame(session: CDPSession) -> None:
+        nonlocal hidpi_capture_in_flight
+        try:
+            metrics = await session.send("Page.getLayoutMetrics", {})
+            viewport = metrics.get("cssVisualViewport") or metrics.get("visualViewport") or {}
+            width = viewport.get("clientWidth")
+            height = viewport.get("clientHeight")
+            if not isinstance(width, (int, float)) or not isinstance(height, (int, float)):
+                return
+            result = await session.send(
+                "Page.captureScreenshot",
+                {
+                    "format": "png",
+                    "captureBeyondViewport": False,
+                    "optimizeForSpeed": True,
+                    "clip": {
+                        "x": viewport.get("pageX", 0),
+                        "y": viewport.get("pageY", 0),
+                        "width": width,
+                        "height": height,
+                        "scale": _viewer_device_scales.get(entity_id, 1.0),
+                    },
+                },
+            )
+            _queue_frame(result.get("data", ""))
+        except Exception:
+            LOG.debug("Could not capture HiDPI screencast frame", exc_info=True)
+        finally:
+            hidpi_capture_in_flight = False
+
+    async def _on_frame(session: CDPSession, params: dict) -> None:
+        nonlocal hidpi_capture_in_flight, last_hidpi_capture_at
+        if session is not cdp_session:
+            return
+        data = params.get("data", "")
+        session_id = params.get("sessionId", 0)
+        metadata = params.get("metadata", {})
+        if metadata:
+            _update_viewport_from_metadata(metadata)
+        asyncio.create_task(_ack_frame(session, session_id))
+        now = asyncio.get_running_loop().time()
+        # captureScreenshot itself can emit a screencast frame. Suppress that
+        # feedback and cap expensive lossless HiDPI captures at two per second.
+        if hidpi_capture_in_flight or now - last_hidpi_capture_at < 0.5:
+            return
+        last_hidpi_capture_at = now
+        hidpi_capture_in_flight = True
+        asyncio.create_task(_capture_hidpi_frame(session))
+'''
+    if source.count(frame_anchor) != 1:
+        raise RuntimeError("Pinned screencast frame handler changed")
+    source = source.replace(frame_anchor, frame_replacement)
+
+    stop_anchor = '''        try:
+            await session.send("Page.stopScreencast", {})
+        except Exception:
+            pass
+        try:
+            await session.detach()
+'''
+    stop_replacement = '''        try:
+            await session.detach()
+'''
+    if source.count(stop_anchor) != 1:
+        raise RuntimeError("Pinned screencast cleanup changed")
+    source = source.replace(stop_anchor, stop_replacement)
+
+    attach_anchor = '''        next_session.on("Page.screencastFrame", lambda params: asyncio.create_task(_on_frame(next_session, params)))
+        try:
+            await next_session.send(
+                "Page.startScreencast",
+                {
+                    "format": "png",
+                    "maxWidth": DEFAULT_WIDTH,
+                    "maxHeight": DEFAULT_HEIGHT,
+                },
+            )
+        except (asyncio.CancelledError, Exception):
+            await _stop_current_screencast()
+            raise
+        attached_page = page
+        await _prime_current_frame(next_session, page)
+        LOG.info(
+            "CDP screencast started",
+            entity_id=entity_id,
+            entity_type=entity_type,
+            url=getattr(page, "url", ""),
+        )
+'''
+    attach_replacement = '''        attached_page = page
+        await _prime_current_frame(next_session, page)
+        LOG.info(
+            "CDP screenshot stream started",
+            entity_id=entity_id,
+            entity_type=entity_type,
+            url=getattr(page, "url", ""),
+        )
+'''
+    if source.count(attach_anchor) != 1:
+        raise RuntimeError("Pinned screencast attachment changed")
+    source = source.replace(attach_anchor, attach_replacement)
+
+    forwarding_anchor = '''    async def _frame_forwarding_loop() -> None:
+'''
+    capture_loop = '''    async def _refresh_hashnode_login_state() -> None:
+        nonlocal hashnode_login_streak, hashnode_login_complete
+        page = attached_page
+        if entity_type != "browser_session" or page is None:
+            hashnode_login_streak = 0
+            hashnode_login_complete = False
+            return
+        try:
+            cookies = await page.context.cookies(["https://hashnode.com/"])
+            authenticated = any(
+                bool(cookie.get("value"))
+                and (
+                    cookie.get("name") in {"authjs.session-token", "hashnode-session"}
+                    or str(cookie.get("name", "")).startswith("__Secure-authjs.session-token")
+                )
+                for cookie in cookies
+            )
+        except Exception:
+            authenticated = False
+        hashnode_login_streak = hashnode_login_streak + 1 if authenticated else 0
+        # OAuth callbacks can briefly expose a session cookie before the app
+        # rejects it. Require a sustained authenticated state before replacing
+        # the browser with BlogHub's success message.
+        current_url = str(getattr(page, "url", "") or "").lower()
+        outside_login = not any(part in current_url for part in ("/login", "/signin", "/onboard"))
+        hashnode_login_complete = hashnode_login_streak >= 20 and outside_login
+
+    async def _capture_polling_loop() -> None:
+        while True:
+            session = cdp_session
+            if session is not None:
+                await _capture_hidpi_frame(session)
+            await _refresh_hashnode_login_state()
+            await asyncio.sleep(0.5)
+
+'''
+    if source.count(forwarding_anchor) != 1:
+        raise RuntimeError("Pinned frame forwarding loop changed")
+    source = source.replace(forwarding_anchor, capture_loop + forwarding_anchor)
+
+    url_anchor = '''                try:
+                    current_url = getattr(attached_page, "url", "") or ""
+                except Exception:
+                    pass
+'''
+    url_replacement = url_anchor + '''            if hashnode_login_complete and current_url.startswith(
+                ("https://hashnode.com/", "https://www.hashnode.com/")
+            ):
+                current_url = current_url.split("#", 1)[0] + "#bloghub-authenticated"
+'''
+    if source.count(url_anchor) != 1:
+        raise RuntimeError("Pinned screencast URL forwarding changed")
+    source = source.replace(url_anchor, url_replacement)
+
+    task_anchor = '''        forward_task = asyncio.create_task(_frame_forwarding_loop())
+        poll_task = asyncio.create_task(_completion_polling_loop())
+        page_monitor_task = asyncio.create_task(_active_page_monitor_loop())
+
+        done, pending = await asyncio.wait(
+            [forward_task, poll_task, page_monitor_task],
+'''
+    task_replacement = '''        capture_task = asyncio.create_task(_capture_polling_loop())
+        forward_task = asyncio.create_task(_frame_forwarding_loop())
+        poll_task = asyncio.create_task(_completion_polling_loop())
+        page_monitor_task = asyncio.create_task(_active_page_monitor_loop())
+
+        done, pending = await asyncio.wait(
+            [capture_task, forward_task, poll_task, page_monitor_task],
+'''
+    if source.count(task_anchor) != 1:
+        raise RuntimeError("Pinned screencast task group changed")
+    source = source.replace(task_anchor, task_replacement)
+    SCREENCAST.write_text(source, encoding="utf-8")
+
+
+def add_viewport_sync() -> None:
+    source = CDP_INPUT.read_text(encoding="utf-8")
+    import_anchor = '''    release_browser_state,
+    wait_for_browser_state,
+)'''
+    import_replacement = '''    release_browser_state,
+    set_viewer_device_scale,
+    wait_for_browser_state,
+)'''
+    if source.count(import_anchor) != 1:
+        raise RuntimeError("Pinned CDP input screencast imports changed")
+    source = source.replace(import_anchor, import_replacement)
+
+    constants_anchor = "_MAX_URL_LEN = 2083\nACTIVE_PAGE_INPUT_REFRESH_INTERVAL = 0.5"
+    constants_replacement = """_MAX_URL_LEN = 2083
+_MIN_VIEWPORT_WIDTH = 320
+_MAX_VIEWPORT_WIDTH = 2560
+_MIN_VIEWPORT_HEIGHT = 240
+_MAX_VIEWPORT_HEIGHT = 1600
+_MIN_DEVICE_SCALE_FACTOR = 0.5
+_MAX_DEVICE_SCALE_FACTOR = 3.0
+ACTIVE_PAGE_INPUT_REFRESH_INTERVAL = 0.5"""
+    if source.count(constants_anchor) != 1:
+        raise RuntimeError("Pinned CDP input constants changed")
+    source = source.replace(constants_anchor, constants_replacement)
+
+    validator_anchor = "\n\nasync def _close_ws_safely("
+    validator = '''
+
+def _validate_viewport_event(msg: dict) -> dict | None:
+    width = msg.get("width")
+    height = msg.get("height")
+    scale = msg.get("deviceScaleFactor", 1)
+    if type(width) not in (int, float) or type(height) not in (int, float):
+        return None
+    if type(scale) not in (int, float):
+        return None
+    return {
+        "width": max(_MIN_VIEWPORT_WIDTH, min(round(width), _MAX_VIEWPORT_WIDTH)),
+        "height": max(_MIN_VIEWPORT_HEIGHT, min(round(height), _MAX_VIEWPORT_HEIGHT)),
+        "deviceScaleFactor": max(
+            _MIN_DEVICE_SCALE_FACTOR,
+            min(float(scale), _MAX_DEVICE_SCALE_FACTOR),
+        ),
+        "mobile": False,
+    }
+'''
+    if source.count(validator_anchor) != 1:
+        raise RuntimeError("Pinned CDP input validator anchor changed")
+    source = source.replace(validator_anchor, validator + validator_anchor)
+
+    dispatch_anchor = '''    if kind == "navigateEvent":
+        await _dispatch_navigate_event(page, msg, log_id_key, log_id_value, websocket)
+        return
+'''
+    dispatch_replacement = '''    if kind == "viewportEvent":
+        viewport = _validate_viewport_event(msg)
+        if viewport is None:
+            LOG.warning("CDP input: viewport validation failed", **{log_id_key: log_id_value})
+            return
+        await cdp_session.send("Emulation.setDeviceMetricsOverride", viewport)
+        set_viewer_device_scale(log_id_value, viewport["deviceScaleFactor"])
+        LOG.info("CDP input: viewport synchronized", **{log_id_key: log_id_value}, **viewport)
+        return
+
+''' + dispatch_anchor
+    if source.count(dispatch_anchor) != 1:
+        raise RuntimeError("Pinned CDP input dispatch anchor changed")
+    source = source.replace(dispatch_anchor, dispatch_replacement)
+
+    control_anchor = '        if channel.interactor != "user":\n'
+    if source.count(control_anchor) != 1:
+        raise RuntimeError("Pinned CDP input control gate changed")
+    source = source.replace(
+        control_anchor,
+        '        if channel.interactor != "user" and kind != "viewportEvent":\n',
+    )
+
+    viewport_state_anchor = '''        self.page_resolution_failed = False
+
+    async def get_session'''
+    viewport_state_replacement = '''        self.page_resolution_failed = False
+        self.viewport: dict | None = None
+
+    async def get_session'''
+    if source.count(viewport_state_anchor) != 1:
+        raise RuntimeError("Pinned CDP input session state changed")
+    source = source.replace(viewport_state_anchor, viewport_state_replacement)
+
+    page_rebind_anchor = '''        self.cdp_session = session
+        self.page = page
+        LOG.info(
+'''
+    page_rebind_replacement = '''        self.cdp_session = session
+        self.page = page
+        if self.viewport is not None:
+            await session.send("Emulation.setDeviceMetricsOverride", self.viewport)
+        LOG.info(
+'''
+    if source.count(page_rebind_anchor) != 1:
+        raise RuntimeError("Pinned CDP input page rebind changed")
+    source = source.replace(page_rebind_anchor, page_rebind_replacement)
+
+    dispatch_signature_anchor = '''async def _dispatch_event(
+    cdp_session: CDPSession,
+    page: object,
+'''
+    dispatch_signature_replacement = '''async def _dispatch_event(
+    cdp_session: CDPSession,
+    input_session: ActivePageCdpInputSession,
+    page: object,
+'''
+    if source.count(dispatch_signature_anchor) != 1:
+        raise RuntimeError("Pinned CDP event dispatch signature changed")
+    source = source.replace(dispatch_signature_anchor, dispatch_signature_replacement)
+
+    viewport_dispatch_anchor = '''        await cdp_session.send("Emulation.setDeviceMetricsOverride", viewport)
+        set_viewer_device_scale(log_id_value, viewport["deviceScaleFactor"])
+'''
+    viewport_dispatch_replacement = '''        input_session.viewport = viewport
+        await cdp_session.send("Emulation.setDeviceMetricsOverride", viewport)
+        set_viewer_device_scale(log_id_value, viewport["deviceScaleFactor"])
+'''
+    if source.count(viewport_dispatch_anchor) != 1:
+        raise RuntimeError("Pinned CDP viewport dispatch changed")
+    source = source.replace(viewport_dispatch_anchor, viewport_dispatch_replacement)
+
+    dispatch_call_anchor = '''            await _dispatch_event(cdp_session, input_session.page, kind, msg, log_id_key, log_id_value, websocket)'''
+    dispatch_call_replacement = '''            await _dispatch_event(cdp_session, input_session, input_session.page, kind, msg, log_id_key, log_id_value, websocket)'''
+    if source.count(dispatch_call_anchor) != 1:
+        raise RuntimeError("Pinned CDP event dispatch call changed")
+    source = source.replace(dispatch_call_anchor, dispatch_call_replacement)
+    CDP_INPUT.write_text(source, encoding="utf-8")
+
+
+def recover_streaming_page() -> None:
+    source = REAL_BROWSER_STATE.read_text(encoding="utf-8")
+    missing_page_anchor = '''        if len(pages) == 0:
+            LOG.info("No http, https or blank page found in the browser context, return None")
+            return None
+'''
+    missing_page_replacement = '''        if len(pages) == 0:
+            LOG.info("No active page found in the browser context; attempting recovery")
+            return await self._reopen_lost_working_page()
+'''
+    if source.count(missing_page_anchor) != 1:
+        raise RuntimeError("Pinned missing-page handling changed")
+    source = source.replace(missing_page_anchor, missing_page_replacement)
+    REAL_BROWSER_STATE.write_text(source, encoding="utf-8")
+
+
+def preserve_reused_browser_profile() -> None:
+    source = PERSISTENT_SESSIONS_MANAGER.read_text(encoding="utf-8")
+    artifacts_anchor = '''        browser_artifacts = browser_session.browser_state.browser_artifacts
+        if export_profile is not False and browser_artifacts and browser_artifacts.browser_session_dir:
+'''
+    artifacts_replacement = '''        browser_artifacts = browser_session.browser_state.browser_artifacts
+        browser_closed_before_export = False
+        if export_profile is not False and browser_artifacts and browser_artifacts.browser_session_dir:
+'''
+    if source.count(artifacts_anchor) != 1:
+        raise RuntimeError("Pinned browser-profile artifact setup changed")
+    source = source.replace(artifacts_anchor, artifacts_replacement)
+
+    snapshot_anchor = '''            await persist_session_cookies(
+                browser_session.browser_state.browser_context, browser_artifacts.browser_session_dir
+            )
+            if export_profile is None:
+'''
+    snapshot_replacement = '''            await persist_session_cookies(
+                browser_session.browser_state.browser_context, browser_artifacts.browser_session_dir
+            )
+            # Chromium may not flush newly issued persistent cookies to SQLite
+            # until its context closes. Export only after that flush completes.
+            try:
+                await browser_session.browser_state.close()
+                browser_closed_before_export = True
+            except TargetClosedError:
+                browser_closed_before_export = True
+                LOG.info(
+                    "Browser context already closed before profile export",
+                    organization_id=organization_id,
+                    session_id=browser_session_id,
+                )
+            except Exception:
+                LOG.warning(
+                    "Error closing browser before profile export; retrying after export",
+                    organization_id=organization_id,
+                    session_id=browser_session_id,
+                    exc_info=True,
+                )
+            if export_profile is None:
+'''
+    if source.count(snapshot_anchor) != 1:
+        raise RuntimeError("Pinned browser-profile cookie snapshot changed")
+    source = source.replace(snapshot_anchor, snapshot_replacement)
+
+    final_close_anchor = '''        try:
+            await browser_session.browser_state.close()
+        except TargetClosedError:
+            LOG.info(
+                "Browser context already closed",
+                organization_id=organization_id,
+                session_id=browser_session_id,
+            )
+        except Exception:
+            LOG.warning(
+                "Error while closing browser session",
+                organization_id=organization_id,
+                session_id=browser_session_id,
+                exc_info=True,
+            )
+'''
+    final_close_replacement = '''        if not browser_closed_before_export:
+            try:
+                await browser_session.browser_state.close()
+            except TargetClosedError:
+                LOG.info(
+                    "Browser context already closed",
+                    organization_id=organization_id,
+                    session_id=browser_session_id,
+                )
+            except Exception:
+                LOG.warning(
+                    "Error while closing browser session",
+                    organization_id=organization_id,
+                    session_id=browser_session_id,
+                    exc_info=True,
+                )
+'''
+    if source.count(final_close_anchor) != 1:
+        raise RuntimeError("Pinned final browser close block changed")
+    source = source.replace(final_close_anchor, final_close_replacement)
+
+    profile_id_anchor = '''                        profile_id=browser_session_id,
+                        directory=browser_artifacts.browser_session_dir,
+'''
+    profile_id_replacement = '''                        # A reused session must update the profile it loaded. Saving it
+                        # under the transient session ID loses new authentication state.
+                        profile_id=browser_artifacts.applied_browser_profile_id or browser_session_id,
+                        directory=browser_artifacts.browser_session_dir,
+'''
+    if source.count(profile_id_anchor) != 1:
+        raise RuntimeError("Pinned browser-profile export destination changed")
+    source = source.replace(profile_id_anchor, profile_id_replacement)
+    PERSISTENT_SESSIONS_MANAGER.write_text(source, encoding="utf-8")
+
+
+def main() -> None:
+    changed = rewrite_imports()
+    if changed < 50:
+        raise RuntimeError(f"Expected at least 50 Playwright import files, found {changed}")
+    add_browser_executable()
+    improve_local_stream_quality()
+    add_viewport_sync()
+    recover_streaming_page()
+    preserve_reused_browser_profile()
+    print(f"Rewrote Playwright imports in {changed} Skyvern files")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/skyvern/patch_skyvern_ui.cjs
+++ b/experiments/skyvern/patch_skyvern_ui.cjs
@@ -1,0 +1,183 @@
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+
+const assets = "/app/dist.template/assets";
+const indexPath = "/app/dist.template/index.html";
+let indexHtml = fs.readFileSync(indexPath, "utf8");
+const bundleMatch = indexHtml.match(/assets\/(index-[^"']+\.js)/);
+const bundleName = bundleMatch?.[1];
+if (!bundleName) throw new Error("Pinned Skyvern UI entry bundle was not found");
+
+const bundle = path.join(assets, bundleName);
+let source = fs.readFileSync(bundle, "utf8");
+const componentStart = source.indexOf("function X5e({inputWsUrl");
+const componentEnd = source.indexOf("function W5(", componentStart);
+if (componentStart < 0 || componentEnd < 0) {
+  throw new Error("Pinned Skyvern CDP viewer component changed");
+}
+
+let component = source.slice(componentStart, componentEnd);
+const controlState = "const[s,a]=x.useState(!1),[o,l]=x.useState(!1)";
+const disconnectedControlState = "l(!1),v.current=!1,a(!1),h.current=null";
+if (
+  component.split(controlState).length !== 2 ||
+  component.split(disconnectedControlState).length !== 2
+) {
+  throw new Error("Pinned Skyvern CDP control state changed");
+}
+
+// This image is the browser in BlogHub's dedicated login window. Acquire CDP
+// control immediately and retain that intent across websocket reconnects.
+component = component
+  .replace(controlState, "const[s,a]=x.useState(!0),[o,l]=x.useState(!1)")
+  .replace(
+    disconnectedControlState,
+    "l(!1),v.current=!0,a(!0),h.current=null",
+  );
+
+const pointerCoordinates =
+  "function tL(t,e,n){return W5e(t.clientX,t.clientY,t.currentTarget.getBoundingClientRect(),e,n)}";
+const displayedPointerCoordinates =
+  "function tL(t,e,n){const r=t.currentTarget.getBoundingClientRect();return W5e(t.clientX,t.clientY,r,r.width,r.height)}";
+const wheelCoordinates =
+  "const K=B.getBoundingClientRect(),U=W5e(M.clientX,M.clientY,K,n,r);";
+const displayedWheelCoordinates =
+  "const K=B.getBoundingClientRect(),U=W5e(M.clientX,M.clientY,K,K.width,K.height);";
+if (
+  source.split(pointerCoordinates).length !== 2 ||
+  component.split(wheelCoordinates).length !== 2
+) {
+  throw new Error("Pinned Skyvern CDP coordinate mapping changed");
+}
+
+// HiDPI screenshot polling produces bitmap dimensions that differ from the
+// browser's CSS viewport. Input.dispatchMouseEvent expects CSS coordinates,
+// so map pointer and wheel input against the displayed image instead of the
+// stale screencast metadata retained by the stock viewer.
+component = component.replace(wheelCoordinates, displayedWheelCoordinates);
+
+const anchor = "},[]),j=x.useCallback(P=>{if(!e||!s)return;";
+if (component.split(anchor).length !== 2) {
+  throw new Error("Pinned Skyvern CDP input hook changed");
+}
+
+const resizeEffect = `},[]);x.useEffect(()=>{
+  if(!e)return;
+  let I=null;
+  let A=null;
+  let P=null;
+  let L=null;
+  const M=()=>{
+    const B=p.current;
+    if(!B)return;
+    if(P!==B){
+      L?.disconnect();
+      P=B;
+      L=new ResizeObserver(M);
+      L.observe(P);
+    }
+    I!==null&&clearTimeout(I);
+    I=setTimeout(()=>{
+      const K=h.current;
+      if(!K||K.readyState!==WebSocket.OPEN||!P)return;
+      const U=P.getBoundingClientRect();
+      K.send(JSON.stringify({
+        kind:"viewportEvent",
+        width:Math.round(U.width),
+        height:Math.round(U.height),
+        deviceScaleFactor:window.devicePixelRatio||1
+      }));
+      A!==null&&(clearInterval(A),A=null);
+    },100);
+  };
+  window.visualViewport?.addEventListener("resize",M);
+  M();
+  A=setInterval(M,250);
+  return()=>{
+    I!==null&&clearTimeout(I);
+    A!==null&&clearInterval(A);
+    L?.disconnect();
+    window.visualViewport?.removeEventListener("resize",M);
+  };
+},[e]);const j=x.useCallback(P=>{if(!e||!s)return;`;
+
+component = component.replace(anchor, resizeEffect);
+source = source.slice(0, componentStart) + component + source.slice(componentEnd);
+source = source.replace(pointerCoordinates, displayedPointerCoordinates);
+
+const browserSessionStart = source.indexOf("function X5({browserSessionId:");
+const browserSessionEnd = source.indexOf("const H5e=", browserSessionStart);
+if (browserSessionStart < 0 || browserSessionEnd < 0) {
+  throw new Error("Pinned Skyvern browser-session component changed");
+}
+
+let browserSession = source.slice(browserSessionStart, browserSessionEnd);
+const backendWaitMessage = "Just waiting for the backend to hand us a browser.";
+if (browserSession.split(backendWaitMessage).length !== 2) {
+  throw new Error("Pinned Skyvern browser startup message changed");
+}
+browserSession = browserSession.replace(backendWaitMessage, "Starting the browser.");
+
+const readyState = "const H=u.length>0;return";
+const readyStateWithLogin =
+  "const H=u.length>0,Q=blogHubHashnodeLoginComplete(y);return";
+const streamRender = "H?i.jsx(q5e,{";
+const streamRenderWithLogin =
+  "Q?i.jsx(blogHubHashnodeLoginCompleteView,{}):H?i.jsx(q5e,{";
+if (
+  browserSession.split(readyState).length !== 2 ||
+  browserSession.split(streamRender).length !== 2
+) {
+  throw new Error("Pinned Skyvern browser-session render changed");
+}
+browserSession = browserSession
+  .replace(readyState, readyStateWithLogin)
+  .replace(streamRender, streamRenderWithLogin);
+
+const loginCompleteHelpers = `function blogHubHashnodeLoginComplete(t){
+  if(new URLSearchParams(window.location.search).get("purpose")!=="hashnode-login")return false;
+  try{
+    const e=new URL(t),n=e.hostname.toLowerCase();
+    return(n==="hashnode.com"||n==="www.hashnode.com")&&e.hash==="#bloghub-authenticated";
+  }catch{return false}
+}
+function blogHubHashnodeLoginCompleteView(){
+  return i.jsx("main",{style:{minHeight:"100vh",display:"grid",placeItems:"center",background:"#0d0f14",color:"#e7eaf2",fontFamily:"Inter,ui-sans-serif,system-ui,sans-serif"},children:i.jsxs("section",{style:{width:"min(460px,calc(100vw - 48px))",textAlign:"center"},children:[
+    i.jsx("div",{style:{display:"inline-block",marginBottom:"18px",padding:"6px 10px",border:"1px solid #2f7d4a",borderRadius:"5px",color:"#71d892",fontSize:"12px",fontWeight:700},children:"Signed in"}),
+    i.jsx("h1",{style:{margin:"0 0 12px",fontSize:"28px",lineHeight:1.2,fontWeight:700},children:"Hashnode login successful"}),
+    i.jsx("p",{style:{margin:"0 auto 24px",color:"#9aa3b7",fontSize:"15px",lineHeight:1.6},children:"Close this tab to save and verify the browser profile, then return to BlogHub."}),
+    i.jsx("button",{type:"button",onClick:()=>window.close(),style:{padding:"10px 18px",border:0,borderRadius:"5px",background:"#6366f1",color:"#fff",font:"inherit",fontWeight:600,cursor:"pointer"},children:"Close tab"})
+  ]})})
+}`;
+
+source =
+  source.slice(0, browserSessionStart) +
+  loginCompleteHelpers +
+  browserSession +
+  source.slice(browserSessionEnd);
+
+const authBootstrap =
+  'XUe().catch(t=>console.error("[ui-session] failed to initialize:",t));w7e.createRoot';
+if (source.split(authBootstrap).length !== 2) {
+  throw new Error("Pinned Skyvern UI session bootstrap changed");
+}
+
+// The stock bundle renders before its temporary UI credential is ready. On a
+// direct browser-session URL, that races the initial session query and leaves
+// the viewer displaying a false completed state after the query returns 403.
+source = source.replace(
+  authBootstrap,
+  'await XUe().catch(t=>console.error("[ui-session] failed to initialize:",t));w7e.createRoot',
+);
+fs.writeFileSync(bundle, source);
+
+// The base image's filename contains the upstream build hash. Since this
+// script changes its contents, retain content-addressed caching by giving the
+// patched file a new hash and updating the HTML reference. Otherwise normal
+// browsers can retain an older BlogHub viewer while clean test contexts work.
+const digest = crypto.createHash("sha256").update(source).digest("hex").slice(0, 12);
+const patchedBundleName = bundleName.replace(/\.js$/, `-bloghub-${digest}.js`);
+fs.renameSync(bundle, path.join(assets, patchedBundleName));
+indexHtml = indexHtml.replace(`assets/${bundleName}`, `assets/${patchedBundleName}`);
+fs.writeFileSync(indexPath, indexHtml);

--- a/experiments/skyvern/patchright-probe/.gitignore
+++ b/experiments/skyvern/patchright-probe/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/experiments/skyvern/patchright-probe/Dockerfile
+++ b/experiments/skyvern/patchright-probe/Dockerfile
@@ -1,0 +1,11 @@
+FROM public.ecr.aws/skyvern/skyvern@sha256:18defe240c49c79c749c57f7e9008b1a169aa34193b267002c7e5ee437e28887
+
+COPY patchright-requirements.txt /tmp/patchright-requirements.txt
+RUN pip install --no-cache-dir --no-deps --require-hashes \
+      -r /tmp/patchright-requirements.txt \
+    && rm /tmp/patchright-requirements.txt \
+    && test -x /root/.cache/ms-playwright/chromium-1134/chrome-linux/chrome
+
+COPY patchright-probe/probe.py /experiment/probe.py
+
+ENTRYPOINT ["xvfb-run", "-a", "python", "/experiment/probe.py"]

--- a/experiments/skyvern/patchright-probe/README.md
+++ b/experiments/skyvern/patchright-probe/README.md
@@ -1,0 +1,38 @@
+# Patchright Hashnode checkpoint probe
+
+This probe answers one question before Patchright is coupled to Skyvern: can a
+current, headed Google Chrome controlled by Patchright reach Hashnode's login
+screen from this machine without failing Vercel's browser verification?
+
+It uses a persistent headed profile, no fixed viewport, and no custom user agent
+or browser headers. For the minimal comparison, Patchright controls the Chromium
+already pinned in Skyvern's image. The probe does not enter credentials and
+cannot publish anything.
+
+Run it with:
+
+```bash
+docker compose -f compose.yml up --build --abort-on-container-exit
+cat artifacts/result.json
+```
+
+Inspect `artifacts/hashnode-login.png`. A useful result is `login_available` or
+`redirected_without_checkpoint`. Do not proceed to the Skyvern integration when
+the result begins with `blocked_`.
+
+Observed result on 2026-08-18:
+
+```json
+{
+  "classification": "login_available",
+  "final_url": "https://hashnode.com/login",
+  "title": "Log In | Hashnode",
+  "browser_mode": "custom_executable"
+}
+```
+
+The image pins Patchright `1.62.1` and derives from the same pinned Skyvern image
+as the baseline experiment. On 2026-08-18 this combination reached Hashnode's
+real login form without the Vercel code-19 failure seen with stock Playwright.
+The profile is stored in a Docker named volume; the screenshot and
+classification are disposable local artifacts.

--- a/experiments/skyvern/patchright-probe/compose.yml
+++ b/experiments/skyvern/patchright-probe/compose.yml
@@ -1,0 +1,17 @@
+services:
+  hashnode-checkpoint:
+    build:
+      context: ..
+      dockerfile: patchright-probe/Dockerfile
+    init: true
+    environment:
+      PROBE_URL: https://hashnode.com/login
+      PROBE_ARTIFACT_DIR: /artifacts
+      PROBE_EXECUTABLE_PATH: /root/.cache/ms-playwright/chromium-1134/chrome-linux/chrome
+      PROBE_PROFILE_DIR: /profile
+    volumes:
+      - ./artifacts:/artifacts
+      - patchright-profile:/profile
+
+volumes:
+  patchright-profile:

--- a/experiments/skyvern/patchright-probe/probe.py
+++ b/experiments/skyvern/patchright-probe/probe.py
@@ -1,0 +1,78 @@
+"""Open Hashnode's login checkpoint with a headed Patchright Chrome profile."""
+
+import json
+import os
+from pathlib import Path
+
+from patchright.sync_api import sync_playwright
+
+
+ARTIFACT_DIR = Path(os.environ.get("PROBE_ARTIFACT_DIR", "/artifacts"))
+PROFILE_DIR = Path(os.environ.get("PROBE_PROFILE_DIR", "/profile"))
+TARGET_URL = os.environ.get("PROBE_URL", "https://hashnode.com/login")
+EXECUTABLE_PATH = os.environ.get("PROBE_EXECUTABLE_PATH")
+
+
+def classify(page_text: str, final_url: str, title: str) -> str:
+    normalized = page_text.lower()
+    if "failed to verify your browser" in normalized:
+        return "blocked_browser_verification"
+    if "vercel security checkpoint" in normalized:
+        return "blocked_security_checkpoint"
+    if any(
+        marker in normalized
+        for marker in (
+            "continue with github",
+            "continue with google",
+            "sign in with github",
+            "sign in with google",
+        )
+    ):
+        return "login_available"
+    if title.lower().startswith("log in") and "hashnode" in title.lower():
+        return "login_available"
+    if "/login" not in final_url:
+        return "redirected_without_checkpoint"
+    return "unknown"
+
+
+def main() -> None:
+    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+    PROFILE_DIR.mkdir(parents=True, exist_ok=True)
+
+    with sync_playwright() as playwright:
+        browser_options = {
+            "user_data_dir": PROFILE_DIR,
+            "headless": False,
+            "no_viewport": True,
+        }
+        if EXECUTABLE_PATH:
+            browser_options["executable_path"] = EXECUTABLE_PATH
+        else:
+            browser_options["channel"] = "chrome"
+        context = playwright.chromium.launch_persistent_context(
+            **browser_options,
+        )
+        page = context.pages[0] if context.pages else context.new_page()
+        page.goto(TARGET_URL, wait_until="domcontentloaded", timeout=90_000)
+        page.wait_for_timeout(15_000)
+
+        page_text = page.locator("body").inner_text(timeout=15_000)
+        title = page.title()
+        result = {
+            "classification": classify(page_text, page.url, title),
+            "final_url": page.url,
+            "title": title,
+            "browser_mode": "custom_executable" if EXECUTABLE_PATH else "chrome",
+        }
+        page.screenshot(path=ARTIFACT_DIR / "hashnode-login.png", full_page=True)
+        (ARTIFACT_DIR / "result.json").write_text(
+            json.dumps(result, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        print(json.dumps(result), flush=True)
+        context.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/skyvern/patchright-requirements.txt
+++ b/experiments/skyvern/patchright-requirements.txt
@@ -1,0 +1,6 @@
+patchright==1.62.1 \
+    --hash=sha256:ae908d0a69885f344bc36404a02bbfd772fc64c281f9bb77957dbc51be395592
+pyee==13.0.1 \
+    --hash=sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228
+greenlet==3.5.5 \
+    --hash=sha256:74cc6df89ec5302337adc9cf096221cbed2510fd444b0e0f1586cf0470740864

--- a/experiments/skyvern/skyvern_1_0_50_schema_workaround.py
+++ b/experiments/skyvern/skyvern_1_0_50_schema_workaround.py
@@ -1,0 +1,62 @@
+"""Work around a migration-check mismatch in the pinned Skyvern 1.0.50 image."""
+
+import os
+import time
+
+import psycopg
+
+
+DATABASE_URL = os.environ.get(
+    "SKYVERN_SCHEMA_WORKAROUND_DATABASE_URL",
+    "postgresql://skyvern:skyvern@postgres:5432/skyvern",
+)
+CONSTRAINT = "ck_google_oauth_credentials_state"
+
+
+def constraint_exists(connection: psycopg.Connection) -> bool:
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "select exists(select 1 from pg_constraint where conname = %s)",
+            (CONSTRAINT,),
+        )
+        return bool(cursor.fetchone()[0])
+
+
+def table_exists(connection: psycopg.Connection) -> bool:
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "select to_regclass('public.google_oauth_credentials') is not null"
+        )
+        return bool(cursor.fetchone()[0])
+
+
+def drop_constraint(connection: psycopg.Connection) -> None:
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "alter table google_oauth_credentials "
+            f"drop constraint if exists {CONSTRAINT}"
+        )
+
+
+def main() -> None:
+    deadline = time.monotonic() + 300
+    while time.monotonic() < deadline:
+        try:
+            with psycopg.connect(DATABASE_URL, autocommit=True) as connection:
+                if table_exists(connection):
+                    drop_constraint(connection)
+                    print("Skyvern 1.0.50 schema workaround complete", flush=True)
+                    return
+                while time.monotonic() < deadline:
+                    if constraint_exists(connection):
+                        drop_constraint(connection)
+                        print("Skyvern 1.0.50 schema workaround complete", flush=True)
+                        return
+                    time.sleep(1)
+        except psycopg.OperationalError:
+            time.sleep(1)
+    raise RuntimeError("Timed out waiting for Skyvern's 1.0.50 schema migration")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/skyvern/skyvern_ui_browser_embed.css
+++ b/experiments/skyvern/skyvern_ui_browser_embed.css
@@ -1,0 +1,29 @@
+
+/* BlogHub opens this dedicated UI as a login popup, so the browser is the UI. */
+#root > .h-screen.w-full.gap-4.p-6 {
+  padding: 0 !important;
+}
+
+#root > .h-screen.w-full.gap-4.p-6 > .mx-auto.flex.h-full.min-w-0 {
+  width: 100% !important;
+}
+
+#root > .h-screen.w-full.gap-4.p-6 > .mx-auto.flex.h-full.min-w-0 > :first-child,
+#root > .h-screen.w-full.gap-4.p-6 > .mx-auto.flex.h-full.min-w-0 > :nth-child(2) {
+  display: none !important;
+}
+
+#root > .h-screen.w-full.gap-4.p-6 > .mx-auto.flex.h-full.min-w-0 > :nth-child(3) {
+  border: 0 !important;
+  border-radius: 0 !important;
+}
+
+/* The outer popup already supplies navigation; keep only the remote page. */
+#root .bg-slate-800.px-2.py-1\.5 {
+  display: none !important;
+}
+
+/* BlogHub's dedicated viewer always owns input, so this toggle is redundant. */
+#root button.absolute.bottom-2.left-1\/2 {
+  display: none !important;
+}

--- a/screens/settings/v2.html
+++ b/screens/settings/v2.html
@@ -54,6 +54,19 @@
       display: flex; align-items: center; justify-content: space-between;
       gap: 16px; padding: 16px 20px;
     }
+    .hashnode-methods {
+      position: absolute; right: 0; top: calc(100% + 6px); z-index: 30;
+      width: 272px; padding: 6px; display: grid; gap: 4px;
+      background: #151925; border: 1px solid #30364a; border-radius: 6px;
+      box-shadow: 0 8px 24px rgba(0,0,0,.5);
+    }
+    .hashnode-method {
+      width: 100%; display: flex; align-items: center; gap: 10px;
+      padding: 10px 12px; border: 0; border-radius: 5px;
+      background: transparent; color: #c9cfe0; cursor: pointer;
+      font: inherit; text-align: left;
+    }
+    .hashnode-method:hover { background: #1e2332; }
 
     /* ── CliProviderCard C ──────────────────────────────────── */
     .ai-card {
@@ -198,6 +211,10 @@ const ICON_STYLE = {
 };
 
 let _connections = [];
+let _hashnodeBrowserConnection = { platform: 'hashnode', status: 'disconnected' };
+let _hashnodeMethodMenuOpen = false;
+let _hashnodeLoginTab = null;
+let _hashnodeLoginTabTimer = null;
 const _authTimers = new Map();
 
 const AUTH_STATES = {
@@ -237,6 +254,10 @@ async function loadConnections() {
     console.warn('API unavailable, using static fallback:', e.message);
     _connections = buildStaticConns();
   }
+  try {
+    const browserRes = await fetch('/api/connections/hashnode/browser-connection');
+    if (browserRes.ok) _hashnodeBrowserConnection = await browserRes.json();
+  } catch { /* The PAT path remains usable while browser automation is offline. */ }
   renderPlatforms(_connections.filter(c => c.type === 'blog'));
   renderAI(_connections.filter(c => c.type === 'ai'));
   updateCount(_connections);
@@ -254,7 +275,9 @@ function buildStaticConns() {
 }
 
 function updateCount(conns) {
-  const n = conns.filter(c => c.status === 'connected').length;
+  const n = conns.filter(c => c.id !== 'hashnode' && c.status === 'connected').length +
+    (conns.some(c => c.id === 'hashnode' && c.status === 'connected') ||
+      _hashnodeBrowserConnection.status === 'connected' ? 1 : 0);
   document.getElementById('count-dot').style.background = n > 0 ? '#4ade80' : '#5a6080';
   document.getElementById('count-label').textContent    = `${n} connection${n !== 1 ? 's' : ''} active`;
 }
@@ -265,6 +288,8 @@ function renderPlatforms(conns) {
 }
 
 function platCard(conn) {
+  if (conn.id === 'hashnode') return hashnodeCard(conn);
+
   const ic   = ICON_STYLE[conn.id] || { bg: '#25293840', color: '#5a6080', letter: '?' };
   const meta = CONN_META[conn.id] || {};
   const ok   = conn.status === 'connected';
@@ -364,6 +389,195 @@ function platCard(conn) {
           onmouseover="this.style.color='#c9cfe0'" onmouseout="this.style.color='#5a6080'">Get your ${(meta.tokenLabel || 'token').toLowerCase()} →</a>
       </div>
     </div>`;
+}
+
+function hashnodeCard(conn) {
+  const apiConnected = conn.status === 'connected';
+  const browserStatus = _hashnodeBrowserConnection.status || 'disconnected';
+  const browserConnected = browserStatus === 'connected';
+  const connected = apiConnected || browserConnected;
+  const waiting = ['waiting_for_login', 'verifying'].includes(browserStatus) && !apiConnected;
+  const failed = browserStatus === 'failed' && !apiConnected;
+  const statusColor = connected ? '#4ade80' : waiting ? '#fbbf24' : failed ? '#f87171' : '#5a6080';
+  const statusLabel = connected ? 'Connected' : waiting
+    ? (browserStatus === 'verifying' ? 'Verifying login' : 'Finish signing in')
+    : failed ? 'Login failed' : 'Not connected';
+  const method = apiConnected && browserConnected ? 'API token + browser login' : apiConnected
+    ? 'API token · Hashnode Plus' : browserConnected
+    ? 'Browser login · Persistent profile' : '';
+  const helper = connected ? (browserConnected ? 'Browser session verified' : 'Token stored securely')
+    : waiting ? 'Close the login tab after Hashnode confirms sign-in.'
+    : failed ? esc(_hashnodeBrowserConnection.error || 'Hashnode sign-in was not completed.')
+    : 'Choose API token or browser login.';
+
+  let actions = '';
+  if (connected) {
+    const connectedMethod = apiConnected && browserConnected ? 'both' : apiConnected ? 'api' : 'browser';
+    actions = `<button onclick="disconnectHashnodeConnection('${connectedMethod}')"
+      style="font-size:11px;color:#f87171;background:transparent;border:none;cursor:pointer;font-family:inherit;">Disconnect</button>`;
+  } else if (waiting) {
+    actions = `<button onclick="openHashnodeBrowserLogin()"
+      style="font-size:11px;padding:4px 10px;border-radius:4px;border:1px solid #252a38;background:transparent;color:#c9cfe0;cursor:pointer;font-family:inherit;">Open login</button>
+      <button onclick="disconnectHashnodeBrowser()"
+      style="font-size:11px;color:#f87171;background:transparent;border:none;cursor:pointer;font-family:inherit;">Cancel</button>`;
+  } else {
+    actions = `<button id="hashnode-connect" onclick="toggleHashnodeMethods()" aria-label="Connect" aria-haspopup="menu" aria-expanded="${_hashnodeMethodMenuOpen}"
+      style="font-size:12px;font-weight:500;padding:5px 12px 5px 14px;border-radius:5px;background:#6366f1;color:#fff;border:none;cursor:pointer;font-family:inherit;">Connect <span aria-hidden="true" style="margin-left:3px;">▾</span></button>`;
+  }
+
+  const methodMenu = !connected && !waiting && _hashnodeMethodMenuOpen ? `
+    <div class="hashnode-methods" id="hashnode-method-menu">
+      <button class="hashnode-method" onclick="chooseHashnodeApiToken()">
+        <span style="width:30px;height:30px;border-radius:5px;background:#1d2945;color:#7fa4ff;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;">API</span>
+        <span style="flex:1;"><span style="display:block;font-size:12px;font-weight:600;color:#e8eaf2;">API token</span><span style="display:block;font-size:10px;color:#69708a;margin-top:2px;">Deterministic publishing for Hashnode Plus</span></span>
+        <span style="font-size:9px;font-weight:600;color:#a5b4fc;border:1px solid #3b4670;border-radius:3px;padding:2px 5px;">PLUS</span>
+      </button>
+      <button class="hashnode-method" onclick="chooseHashnodeBrowserLogin()">
+        <span style="width:30px;height:30px;border-radius:5px;background:#173127;color:#71d892;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;">WEB</span>
+        <span style="flex:1;"><span style="display:block;font-size:12px;font-weight:600;color:#e8eaf2;">Browser login</span><span style="display:block;font-size:10px;color:#69708a;margin-top:2px;">Isolated persistent browser for free accounts</span></span>
+        <span style="font-size:9px;font-weight:600;color:#71d892;border:1px solid #285b43;border-radius:3px;padding:2px 5px;">FREE</span>
+      </button>
+    </div>` : '';
+
+  return `<div id="plat-card-hashnode" style="position:relative;">
+    <div class="plat-card" style="position:relative;">
+      ${connected ? '<div style="position:absolute;left:0;top:0;bottom:0;width:3px;background:#4ade80;"></div>' : ''}
+      <div class="plat-row">
+        <div style="display:flex;align-items:center;gap:10px;flex:1;min-width:0;">
+          <div style="width:28px;height:28px;border-radius:6px;background:#1e2438;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;color:${connected ? '#4f6cae' : '#5a6080'};flex-shrink:0;">H</div>
+          <div style="min-width:0;">
+            <div style="display:flex;align-items:center;gap:6px;">
+              <span style="font-size:14px;font-weight:600;color:#e8eaf2;">Hashnode</span>
+              <span style="width:6px;height:6px;border-radius:50%;background:${statusColor};"></span>
+              <span style="font-size:11px;color:${statusColor};">${statusLabel}</span>
+            </div>
+            ${method ? `<div style="font-size:11px;color:#c9cfe0;margin-top:3px;">${method}</div>` : ''}
+            <div style="font-size:10px;color:#5a6080;margin-top:3px;">${helper}</div>
+          </div>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px;flex-shrink:0;">${actions}</div>
+      </div>
+      <div class="expand-row" id="expand-hashnode">
+        <div style="display:flex;gap:6px;align-items:center;">
+          <input id="key-input-hashnode" type="password" autocomplete="off" placeholder="Paste personal access token…"
+            style="flex:1;background:#0f1117;border:1px solid #252a38;border-radius:5px;padding:7px 10px;font-size:12px;color:#c9cfe0;font-family:inherit;"
+            onkeydown="if(event.key==='Enter')saveKey('hashnode')" />
+          <button onclick="saveKey('hashnode')" style="font-size:12px;font-weight:500;padding:7px 14px;border-radius:5px;background:#6366f1;color:#fff;border:none;cursor:pointer;font-family:inherit;">Save</button>
+          <button onclick="collapseKey('hashnode')" style="font-size:12px;padding:7px 10px;border-radius:5px;border:1px solid #252a38;background:transparent;color:#5a6080;cursor:pointer;font-family:inherit;">Cancel</button>
+        </div>
+        <a href="${CONN_META.hashnode.helpUrl}" target="_blank" rel="noopener noreferrer" style="font-size:11px;color:#5a6080;text-decoration:none;display:block;margin-top:6px;">Get your personal access token →</a>
+      </div>
+    </div>
+    ${methodMenu}
+  </div>`;
+}
+
+function toggleHashnodeMethods() {
+  _hashnodeMethodMenuOpen = !_hashnodeMethodMenuOpen;
+  renderPlatforms(_connections.filter(c => c.type === 'blog'));
+}
+
+function chooseHashnodeApiToken() {
+  _hashnodeMethodMenuOpen = false;
+  renderPlatforms(_connections.filter(c => c.type === 'blog'));
+  expandKey('hashnode');
+}
+
+function chooseHashnodeBrowserLogin() {
+  _hashnodeMethodMenuOpen = false;
+  startHashnodeBrowserLogin();
+}
+
+function createHashnodeLoginTab(url='about:blank') {
+  // Omitting window features lets the browser open a normal tab. Open the
+  // blank tab synchronously so the later API response is not popup-blocked.
+  return window.open(url, '_blank');
+}
+
+function hashnodeLoginUrl(url) {
+  const target = new URL(url, window.location.href);
+  target.searchParams.set('purpose', 'hashnode-login');
+  return target.href;
+}
+
+function watchHashnodeLoginTab(tab) {
+  if (_hashnodeLoginTabTimer) clearInterval(_hashnodeLoginTabTimer);
+  _hashnodeLoginTab = tab;
+  if (!tab) return;
+  _hashnodeLoginTabTimer = setInterval(() => {
+    if (!tab.closed) return;
+    clearInterval(_hashnodeLoginTabTimer);
+    _hashnodeLoginTabTimer = null;
+    _hashnodeLoginTab = null;
+    if (_hashnodeBrowserConnection.status === 'waiting_for_login') {
+      completeHashnodeBrowserLogin();
+    }
+  }, 500);
+}
+
+async function startHashnodeBrowserLogin() {
+  const loginTab = createHashnodeLoginTab();
+  try {
+    const res = await fetch('/api/connections/hashnode/browser-connection', { method: 'POST' });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.detail || `HTTP ${res.status}`);
+    _hashnodeBrowserConnection = data;
+    renderPlatforms(_connections.filter(c => c.type === 'blog'));
+    if (data.authorizationUrl && loginTab) {
+      loginTab.location.href = hashnodeLoginUrl(data.authorizationUrl);
+      loginTab.focus();
+      watchHashnodeLoginTab(loginTab);
+    } else if (data.authorizationUrl) {
+      const fallback = window.open(hashnodeLoginUrl(data.authorizationUrl), '_blank', 'noopener');
+      watchHashnodeLoginTab(fallback);
+    }
+    else loginTab?.close();
+  } catch (error) {
+    loginTab?.close();
+    alert(error.message);
+  }
+}
+
+function openHashnodeBrowserLogin() {
+  if (_hashnodeBrowserConnection.authorizationUrl) {
+    const tab = createHashnodeLoginTab(hashnodeLoginUrl(_hashnodeBrowserConnection.authorizationUrl));
+    tab?.focus();
+    watchHashnodeLoginTab(tab);
+  }
+}
+
+async function completeHashnodeBrowserLogin() {
+  _hashnodeBrowserConnection = { ..._hashnodeBrowserConnection, status: 'verifying' };
+  if (_hashnodeLoginTabTimer) clearInterval(_hashnodeLoginTabTimer);
+  _hashnodeLoginTabTimer = null;
+  _hashnodeLoginTab?.close();
+  _hashnodeLoginTab = null;
+  renderPlatforms(_connections.filter(c => c.type === 'blog'));
+  try {
+    const res = await fetch('/api/connections/hashnode/browser-connection/complete', { method: 'POST' });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.detail || `HTTP ${res.status}`);
+    _hashnodeBrowserConnection = data;
+  } catch (error) {
+    _hashnodeBrowserConnection = { platform: 'hashnode', status: 'failed', error: error.message };
+  }
+  renderPlatforms(_connections.filter(c => c.type === 'blog'));
+}
+
+async function disconnectHashnodeBrowser() {
+  if (_hashnodeLoginTabTimer) clearInterval(_hashnodeLoginTabTimer);
+  _hashnodeLoginTabTimer = null;
+  _hashnodeLoginTab?.close();
+  _hashnodeLoginTab = null;
+  await fetch('/api/connections/hashnode/browser-connection', { method: 'DELETE' });
+  _hashnodeBrowserConnection = { platform: 'hashnode', status: 'disconnected' };
+  renderPlatforms(_connections.filter(c => c.type === 'blog'));
+  updateCount(_connections);
+}
+
+async function disconnectHashnodeConnection(method) {
+  if (method === 'browser' || method === 'both') await disconnectHashnodeBrowser();
+  if (method === 'api' || method === 'both') await doDisconnect('hashnode');
 }
 
 // ─── CliProviderCard C ─────────────────────────────────────────────────────────
@@ -782,6 +996,10 @@ function _doOAuthPopup(id, url) {
 // ─── Close popovers on outside click ──────────────────────────────────────────
 document.addEventListener('click', (e) => {
   if (!e.target.closest('.confirm-anchor')) closeAllConfirm();
+  if (_hashnodeMethodMenuOpen && !e.target.closest('#plat-card-hashnode')) {
+    _hashnodeMethodMenuOpen = false;
+    renderPlatforms(_connections.filter(c => c.type === 'blog'));
+  }
 });
 
 // ─── Init ──────────────────────────────────────────────────────────────────────

--- a/screens/settings/v2.html
+++ b/screens/settings/v2.html
@@ -519,6 +519,11 @@ async function startHashnodeBrowserLogin() {
   const loginTab = createHashnodeLoginTab();
   try {
     const res = await fetch('/api/connections/hashnode/browser-connection', { method: 'POST' });
+    if (res.status === 401) {
+      loginTab?.close();
+      redirectToLogin();
+      return;
+    }
     const data = await res.json();
     if (!res.ok) throw new Error(data.detail || `HTTP ${res.status}`);
     _hashnodeBrowserConnection = data;
@@ -555,6 +560,10 @@ async function completeHashnodeBrowserLogin() {
   renderPlatforms(_connections.filter(c => c.type === 'blog'));
   try {
     const res = await fetch('/api/connections/hashnode/browser-connection/complete', { method: 'POST' });
+    if (res.status === 401) {
+      redirectToLogin();
+      return;
+    }
     const data = await res.json();
     if (!res.ok) throw new Error(data.detail || `HTTP ${res.status}`);
     _hashnodeBrowserConnection = data;
@@ -569,10 +578,20 @@ async function disconnectHashnodeBrowser() {
   _hashnodeLoginTabTimer = null;
   _hashnodeLoginTab?.close();
   _hashnodeLoginTab = null;
-  await fetch('/api/connections/hashnode/browser-connection', { method: 'DELETE' });
-  _hashnodeBrowserConnection = { platform: 'hashnode', status: 'disconnected' };
-  renderPlatforms(_connections.filter(c => c.type === 'blog'));
-  updateCount(_connections);
+  try {
+    const res = await fetch('/api/connections/hashnode/browser-connection', { method: 'DELETE' });
+    if (res.status === 401) {
+      redirectToLogin();
+      return;
+    }
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.detail || `HTTP ${res.status}`);
+    _hashnodeBrowserConnection = { platform: 'hashnode', status: 'disconnected' };
+    renderPlatforms(_connections.filter(c => c.type === 'blog'));
+    updateCount(_connections);
+  } catch (error) {
+    alert(error.message);
+  }
 }
 
 async function disconnectHashnodeConnection(method) {

--- a/start.py
+++ b/start.py
@@ -218,7 +218,7 @@ def main(argv: list[str] | None = None) -> int:
                 f"\n  BlogHub stack: http://127.0.0.1:{port}/screens/login/v1.html"
                 "?next=%2Fscreens%2Fsettings%2Fv2.html"
             )
-            print("  Runtime:       Docker Compose (backend + cli-runner)\n")
+            print("  Runtime:       Docker Compose (backend + cli-runner + Skyvern)\n")
             return run_compose_stack(compose_command, port)
 
         handle, health = ensure_runner(runner_url, args.runner)

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -19,6 +19,15 @@ def test_compose_wires_backend_to_healthy_runner_and_separate_storage():
     assert services["backend"]["healthcheck"]
 
 
+def test_skyvern_is_opt_in_and_does_not_gate_agent_runner_startup():
+    compose = yaml.safe_load((ROOT / "docker-compose.yml").read_text(encoding="utf-8"))
+    services = compose["services"]
+
+    assert "depends_on" not in services["cli-runner"]
+    for service in ("skyvern-postgres", "skyvern", "skyvern-ui"):
+        assert services[service]["profiles"] == ["hashnode-browser"]
+
+
 def test_cli_runner_installs_callback_http_client():
     requirements = (ROOT / "cli-runner" / "requirements.txt").read_text(
         encoding="utf-8"

--- a/tests/tests_backend/test_browser_connections.py
+++ b/tests/tests_backend/test_browser_connections.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import backend.routers.connections as connections_router
+import backend.store as store
+
+
+def test_hashnode_browser_login_persists_only_profile_references(client, monkeypatch):
+    monkeypatch.setattr(
+        connections_router.runner,
+        "start_hashnode_browser_login",
+        lambda *_args: {
+            "session_id": "pbs_session",
+            "organization_id": "o_org",
+            "app_url": "http://localhost:8083/browser-session/pbs_session",
+        },
+    )
+    monkeypatch.setattr(
+        connections_router.runner,
+        "complete_hashnode_browser_login",
+        lambda *args, **kwargs: {
+            "authenticated": True,
+            "profile_id": "bp_profile",
+            "organization_id": "o_org",
+        },
+    )
+
+    started = client.post("/api/connections/hashnode/browser-connection")
+    assert started.status_code == 201
+    assert started.json()["status"] == "waiting_for_login"
+    assert started.json()["authorizationUrl"].endswith("pbs_session")
+
+    completed = client.post(
+        "/api/connections/hashnode/browser-connection/complete"
+    )
+    assert completed.status_code == 200
+    assert completed.json()["status"] == "connected"
+    assert "profile_id" not in completed.json()
+    persisted = store.get_browser_connection("user_seed", "hashnode")
+    assert persisted["skyvern_profile_id"] == "bp_profile"
+
+
+def test_hashnode_browser_login_rejects_unverified_profile(client, monkeypatch):
+    monkeypatch.setattr(
+        connections_router.runner,
+        "start_hashnode_browser_login",
+        lambda *_args: {
+            "session_id": "pbs_session",
+            "organization_id": "o_org",
+            "app_url": "http://localhost:8083/browser-session/pbs_session",
+        },
+    )
+    monkeypatch.setattr(
+        connections_router.runner,
+        "complete_hashnode_browser_login",
+        lambda *args, **kwargs: {
+            "authenticated": False,
+            "profile_id": "bp_failed",
+            "organization_id": "o_org",
+        },
+    )
+    client.post("/api/connections/hashnode/browser-connection")
+    completed = client.post(
+        "/api/connections/hashnode/browser-connection/complete"
+    )
+    assert completed.json()["status"] == "failed"
+    assert "not completed" in completed.json()["error"]
+    persisted = store.get_browser_connection("user_seed", "hashnode")
+    assert persisted["skyvern_profile_id"] == "bp_failed"
+
+
+def test_hashnode_browser_retry_reuses_provider_session_profile(client, monkeypatch):
+    store.start_browser_connection(
+        "user_seed", "hashnode", session_id="pbs_previous",
+        organization_id="o_org", app_url="http://localhost/previous",
+        profile_id="bp_identity",
+    )
+    store.update_browser_connection("user_seed", "hashnode", "failed")
+    reused = []
+    monkeypatch.setattr(
+        connections_router.runner,
+        "start_hashnode_browser_login",
+        lambda profile_id: reused.append(profile_id) or {
+            "session_id": "pbs_retry",
+            "organization_id": "o_org",
+            "app_url": "http://localhost:8083/browser-session/pbs_retry",
+        },
+    )
+
+    started = client.post("/api/connections/hashnode/browser-connection")
+
+    assert started.status_code == 201
+    assert reused == ["bp_identity"]
+    persisted = store.get_browser_connection("user_seed", "hashnode")
+    assert persisted["skyvern_profile_id"] == "bp_identity"
+
+
+def test_hashnode_browser_disconnect_deletes_remote_profile(client, monkeypatch):
+    store.start_browser_connection(
+        "user_seed", "hashnode", session_id="pbs_session",
+        organization_id="o_org", app_url="http://localhost/login",
+    )
+    store.update_browser_connection(
+        "user_seed", "hashnode", "connected", profile_id="bp_profile"
+    )
+    deleted = []
+    monkeypatch.setattr(
+        connections_router.runner,
+        "delete_hashnode_browser_profile",
+        lambda profile_id: deleted.append(profile_id),
+    )
+    response = client.delete("/api/connections/hashnode/browser-connection")
+    assert response.status_code == 200
+    assert deleted == ["bp_profile"]
+    assert store.get_browser_connection("user_seed", "hashnode") is None

--- a/tests/tests_backend/test_browser_connections.py
+++ b/tests/tests_backend/test_browser_connections.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import backend.routers.connections as connections_router
+import backend.services.cli_runner as runner
 import backend.store as store
 
 
@@ -37,6 +38,12 @@ def test_hashnode_browser_login_persists_only_profile_references(client, monkeyp
     assert "profile_id" not in completed.json()
     persisted = store.get_browser_connection("user_seed", "hashnode")
     assert persisted["skyvern_profile_id"] == "bp_profile"
+    raw_url = store._backend._con.execute(
+        """SELECT app_url FROM browser_connections
+           WHERE user_id='user_seed' AND platform='hashnode'"""
+    ).fetchone()[0]
+    assert raw_url.startswith("enc:v1:")
+    assert "pbs_session" not in raw_url
 
 
 def test_hashnode_browser_login_rejects_unverified_profile(client, monkeypatch):
@@ -112,3 +119,29 @@ def test_hashnode_browser_disconnect_deletes_remote_profile(client, monkeypatch)
     assert response.status_code == 200
     assert deleted == ["bp_profile"]
     assert store.get_browser_connection("user_seed", "hashnode") is None
+
+
+def test_hashnode_browser_disconnect_retains_profile_when_remote_cleanup_fails(
+    client, monkeypatch,
+):
+    store.start_browser_connection(
+        "user_seed", "hashnode", session_id="pbs_session",
+        organization_id="o_org", app_url="http://localhost/login",
+    )
+    store.update_browser_connection(
+        "user_seed", "hashnode", "connected", profile_id="bp_profile"
+    )
+
+    def unavailable(_profile_id):
+        raise runner.RunnerUnavailable("Skyvern unavailable")
+
+    monkeypatch.setattr(
+        connections_router.runner, "delete_hashnode_browser_profile", unavailable,
+    )
+
+    response = client.delete("/api/connections/hashnode/browser-connection")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Skyvern unavailable"
+    persisted = store.get_browser_connection("user_seed", "hashnode")
+    assert persisted["skyvern_profile_id"] == "bp_profile"

--- a/tests/tests_backend/test_credential_storage.py
+++ b/tests/tests_backend/test_credential_storage.py
@@ -77,6 +77,34 @@ def test_startup_migrates_plaintext_and_disconnect_erases_it(credential_environm
     assert tuple(row) == ("", "disconnected")
 
 
+def test_startup_encrypts_existing_browser_stream_url(credential_environment):
+    tmp_path, _ = credential_environment
+    store = _store(tmp_path)
+    store.start_browser_connection(
+        store.SEED_USER_ID,
+        "hashnode",
+        session_id="pbs_session",
+        organization_id="o_org",
+        app_url="http://localhost:8083/browser-session/pbs_session",
+    )
+    store._con.execute(
+        "UPDATE browser_connections SET app_url='http://localhost/legacy-stream'"
+    )
+    store._con.commit()
+    store._con.close()
+
+    reopened = _store(tmp_path)
+    raw = reopened._con.execute(
+        "SELECT app_url FROM browser_connections WHERE platform='hashnode'"
+    ).fetchone()[0]
+
+    assert raw.startswith("enc:v1:")
+    assert "legacy-stream" not in raw
+    assert reopened.get_browser_connection(
+        reopened.SEED_USER_ID, "hashnode"
+    )["app_url"] == "http://localhost/legacy-stream"
+
+
 def test_startup_migrates_legacy_fernet_ciphertext(credential_environment):
     tmp_path, _ = credential_environment
     store = _store(tmp_path)

--- a/tests/tests_backend/test_hashnode_browser.py
+++ b/tests/tests_backend/test_hashnode_browser.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sqlite3
+import sys
+
+
+RUNNER = Path(__file__).resolve().parents[2] / "cli-runner"
+sys.path.insert(0, str(RUNNER))
+spec = importlib.util.spec_from_file_location("hashnode_browser_under_test", RUNNER / "hashnode_browser.py")
+hashnode_browser = importlib.util.module_from_spec(spec)
+assert spec.loader
+spec.loader.exec_module(hashnode_browser)
+
+
+def _write_cookie_snapshot(profile_dir, cookies):
+    (profile_dir / ".skyvern_session_cookies.json").write_text(
+        __import__("json").dumps(cookies), encoding="utf-8"
+    )
+
+
+def test_profile_check_rejects_a_profile_without_session_cookie(tmp_path):
+    _write_cookie_snapshot(tmp_path, [
+        {"domain": "hashnode.com", "name": "__Host-authjs.csrf-token", "value": "opaque"},
+    ])
+    result = hashnode_browser.check_hashnode_profile(profile_dir=str(tmp_path))
+    assert result == {"authenticated": False, "status": "login_required"}
+
+
+def test_profile_check_accepts_hashnode_session_snapshot(tmp_path):
+    _write_cookie_snapshot(tmp_path, [
+        {"domain": "hashnode.com", "name": "hashnode-session", "value": "opaque", "expires": -1},
+    ])
+
+    result = hashnode_browser.check_hashnode_profile(profile_dir=str(tmp_path))
+
+    assert result == {"authenticated": True, "status": "connected"}
+
+
+def test_profile_check_accepts_chunked_authjs_session_snapshot(tmp_path):
+    _write_cookie_snapshot(tmp_path, [
+        {"domain": ".hashnode.com", "name": "__Secure-authjs.session-token.0", "value": "opaque"},
+    ])
+
+    result = hashnode_browser.check_hashnode_profile(profile_dir=str(tmp_path))
+
+    assert result == {"authenticated": True, "status": "connected"}
+
+
+def test_profile_check_rejects_expired_session_cookie(tmp_path):
+    _write_cookie_snapshot(tmp_path, [
+        {"domain": "hashnode.com", "name": "hashnode-session", "value": "expired", "expires": 1},
+    ])
+
+    result = hashnode_browser.check_hashnode_profile(profile_dir=str(tmp_path))
+
+    assert result == {"authenticated": False, "status": "login_required"}
+
+
+def test_profile_check_accepts_encrypted_chromium_hashnode_session(tmp_path):
+    cookie_db = tmp_path / "Default" / "Cookies"
+    cookie_db.parent.mkdir()
+    connection = sqlite3.connect(cookie_db)
+    connection.execute(
+        "CREATE TABLE cookies (host_key TEXT, name TEXT, expires_utc INTEGER, "
+        "value TEXT, encrypted_value BLOB)"
+    )
+    connection.execute(
+        "INSERT INTO cookies VALUES (?, ?, ?, ?, ?)",
+        ("hashnode.com", "hashnode-session", 99_999_999_999_999_999, "", b"encrypted"),
+    )
+    connection.commit()
+    connection.close()
+
+    result = hashnode_browser.check_hashnode_profile(profile_dir=str(tmp_path))
+
+    assert result == {"authenticated": True, "status": "connected"}

--- a/tests/tests_backend/test_skyvern_browser.py
+++ b/tests/tests_backend/test_skyvern_browser.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+RUNNER = Path(__file__).resolve().parents[2] / "cli-runner"
+spec = importlib.util.spec_from_file_location(
+    "skyvern_browser_under_test", RUNNER / "skyvern_browser.py"
+)
+skyvern_browser = importlib.util.module_from_spec(spec)
+assert spec.loader
+spec.loader.exec_module(skyvern_browser)
+
+
+class FakeResponse:
+    def __init__(self, payload=None):
+        self.payload = payload
+        self.content = b"" if payload is None else b"json"
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+def test_start_login_uses_non_expiring_live_profile_session(monkeypatch):
+    seen = {}
+
+    def request(method, url, **kwargs):
+        seen.update(method=method, url=url, payload=kwargs["json"])
+        return FakeResponse({
+            "browser_session_id": "pbs_session123",
+            "organization_id": "o_org123",
+            "app_url": "http://skyvern-ui:8080/browser-session/pbs_session123",
+            "status": "created",
+        })
+
+    monkeypatch.setenv("SKYVERN_API_KEY", "local-key")
+    monkeypatch.setattr(skyvern_browser.httpx, "request", request)
+    result = skyvern_browser.start_hashnode_login()
+    assert result["app_url"] == (
+        "http://localhost:8083/browser-session/pbs_session123/stream"
+        "?embed=true&purpose=hashnode-login"
+    )
+    assert seen["payload"]["generate_browser_profile"] is True
+    assert seen["payload"]["needs_live_view"] is True
+    assert seen["payload"]["url"] == "https://hashnode.com/login"
+    assert seen["payload"]["timeout"] is None
+
+
+def test_start_login_reuses_identity_provider_profile(monkeypatch):
+    seen = {}
+
+    def request(method, url, **kwargs):
+        seen.update(method=method, url=url, payload=kwargs["json"])
+        return FakeResponse({
+            "browser_session_id": "pbs_session123",
+            "organization_id": "o_org123",
+            "status": "created",
+        })
+
+    monkeypatch.setenv("SKYVERN_API_KEY", "local-key")
+    monkeypatch.setattr(skyvern_browser.httpx, "request", request)
+
+    skyvern_browser.start_hashnode_login("bp_identity123")
+
+    assert seen["payload"]["browser_profile_id"] == "bp_identity123"
+    assert seen["payload"]["generate_browser_profile"] is False
+
+
+def test_finish_login_accepts_empty_close_response(monkeypatch, tmp_path):
+    calls = []
+
+    def request(method, url, **kwargs):
+        calls.append((method, url, kwargs.get("json")))
+        if url.endswith("/close"):
+            return FakeResponse()
+        return FakeResponse({
+            "browser_profile_id": "bp_profile123",
+            "organization_id": "o_org123",
+        })
+
+    monkeypatch.setenv("SKYVERN_API_KEY", "local-key")
+    monkeypatch.setattr(skyvern_browser.httpx, "request", request)
+    monkeypatch.setattr(skyvern_browser, "SKYVERN_BROWSER_SESSION_ROOT", tmp_path)
+    result = skyvern_browser.finish_hashnode_login("pbs_session123", "BlogHub user")
+    assert result["profile_id"] == "bp_profile123"
+    assert result["profile_dir"] == str(
+        tmp_path / "o_org123" / "profiles" / "bp_profile123"
+    )
+    assert [call[0] for call in calls] == ["POST", "POST"]
+
+
+def test_finish_login_reuses_profile_without_creating_a_duplicate(monkeypatch, tmp_path):
+    calls = []
+
+    def request(method, url, **kwargs):
+        calls.append((method, url, kwargs.get("json")))
+        return FakeResponse()
+
+    monkeypatch.setenv("SKYVERN_API_KEY", "local-key")
+    monkeypatch.setattr(skyvern_browser.httpx, "request", request)
+    monkeypatch.setattr(skyvern_browser, "SKYVERN_BROWSER_SESSION_ROOT", tmp_path)
+
+    result = skyvern_browser.finish_hashnode_login(
+        "pbs_session123",
+        "BlogHub user",
+        profile_id="bp_identity123",
+        organization_id="o_org123",
+    )
+
+    assert result["profile_id"] == "bp_identity123"
+    assert result["profile_dir"] == str(
+        tmp_path / "o_org123" / "profiles" / "bp_identity123"
+    )
+    assert len(calls) == 1
+    assert calls[0][1].endswith("/v1/browser_sessions/pbs_session123/close")
+
+
+def test_profile_directory_rejects_path_components():
+    try:
+        skyvern_browser.profile_directory("o_org123", "../../cookies")
+    except ValueError as exc:
+        assert "Invalid" in str(exc)
+    else:
+        raise AssertionError("unsafe profile id was accepted")

--- a/tests/tests_backend/test_store/test_schema.py
+++ b/tests/tests_backend/test_store/test_schema.py
@@ -36,6 +36,7 @@ def test_fresh_database_has_current_schema_and_seed_user(tmp_path):
             "agent_approvals",
             "agent_checkpoints",
             "agent_session_outputs",
+            "browser_connections",
         } <= tables
         assert store._con.execute(
             "SELECT COUNT(*) FROM users WHERE id=?", (SEED_USER_ID,)

--- a/tests/tests_ui/screens/test_settings.py
+++ b/tests/tests_ui/screens/test_settings.py
@@ -23,6 +23,25 @@ from tests.tests_ui.conftest import BASE_URL, RUNNER_URL, SETTINGS_URL
 
 pytestmark = pytest.mark.browser
 
+
+def _hashnode_browser_payload(status="disconnected", authorization_url=None):
+    return {
+        "platform": "hashnode",
+        "status": status,
+        "authorizationUrl": authorization_url,
+        "verifiedAt": None,
+        "error": None,
+    }
+
+
+def _show_disconnected_hashnode(page):
+    page.route(
+        f"{BASE_URL}/api/connections/hashnode/browser-connection",
+        lambda route: route.fulfill(json=_hashnode_browser_payload()),
+    )
+    page.reload()
+    page.locator("#plat-card-hashnode").get_by_role("button", name="Connect").wait_for()
+
 # ── 1. Initial load ────────────────────────────────────────────────────────────
 
 
@@ -41,6 +60,112 @@ def test_renders_platforms_section_by_default(settings_page):
 def test_ai_providers_tab_renders_both_cards(ai_providers_page):
     assert ai_providers_page.locator("#ai-wrap-anthropic").is_visible()
     assert ai_providers_page.locator("#ai-wrap-openai").is_visible()
+
+
+def test_hashnode_connect_opens_method_chooser(settings_page):
+    _show_disconnected_hashnode(settings_page)
+    card = settings_page.locator("#plat-card-hashnode")
+
+    card.get_by_role("button", name="Connect").click()
+
+    menu = card.locator("#hashnode-method-menu")
+    assert menu.get_by_role("button", name=re.compile(r"API token")).is_visible()
+    assert menu.get_by_role("button", name=re.compile(r"Browser login")).is_visible()
+
+
+def test_hashnode_api_token_choice_opens_credential_input(settings_page):
+    _show_disconnected_hashnode(settings_page)
+    card = settings_page.locator("#plat-card-hashnode")
+    card.get_by_role("button", name="Connect").click()
+    card.get_by_role("button", name=re.compile(r"API token")).click()
+
+    assert card.locator("#key-input-hashnode").is_visible()
+
+
+def test_hashnode_browser_login_opens_normal_tab(settings_page, context):
+    page = settings_page
+
+    def browser_connection(route):
+        if route.request.method == "POST":
+            route.fulfill(
+                status=201,
+                json=_hashnode_browser_payload(
+                    "waiting_for_login", f"{BASE_URL}/health"
+                ),
+            )
+        else:
+            route.fulfill(json=_hashnode_browser_payload())
+
+    page.route(
+        f"{BASE_URL}/api/connections/hashnode/browser-connection",
+        browser_connection,
+    )
+    page.reload()
+    page.evaluate("""
+      window.__hashnodeOpenCalls = [];
+      const nativeOpen = window.open;
+      window.open = (...args) => {
+        window.__hashnodeOpenCalls.push(args);
+        return nativeOpen.apply(window, args);
+      };
+    """)
+
+    with context.expect_page() as login_tab_info:
+        card = page.locator("#plat-card-hashnode")
+        card.get_by_role("button", name="Connect").click()
+        card.get_by_role("button", name=re.compile(r"Browser login")).click()
+
+    login_tab = login_tab_info.value
+    login_tab.wait_for_url(f"{BASE_URL}/health?purpose=hashnode-login")
+    open_call = page.evaluate("window.__hashnodeOpenCalls[0]")
+    assert open_call == ["about:blank", "_blank"]
+    assert page.get_by_role("button", name="I've signed in").count() == 0
+
+    page.route(
+        f"{BASE_URL}/api/connections/hashnode/browser-connection/complete",
+        lambda route: route.fulfill(
+            status=200,
+            json={
+                "platform": "hashnode",
+                "status": "connected",
+                "authorizationUrl": None,
+                "verifiedAt": "2026-08-19T00:00:00Z",
+                "error": None,
+            },
+        ),
+    )
+    login_tab.close()
+    card = page.locator("#plat-card-hashnode")
+    card.get_by_text("Connected", exact=True).wait_for(timeout=5000)
+    card.get_by_text("Browser login · Persistent profile", exact=True).wait_for()
+    assert login_tab.is_closed()
+
+
+def test_hashnode_connected_card_only_offers_disconnect(page):
+    page.request.post(
+        f"{BASE_URL}/api/auth/login",
+        data={"email": "seed@example.com", "password": "seed1234", "remember_me": False},
+    )
+    page.route(
+        f"{BASE_URL}/api/connections/hashnode/browser-connection",
+        lambda route: route.fulfill(json={
+            "platform": "hashnode",
+            "status": "connected",
+            "authorizationUrl": None,
+            "verifiedAt": "2026-08-19T00:00:00Z",
+            "error": None,
+        }),
+    )
+
+    page.goto(SETTINGS_URL)
+    card = page.locator("#plat-card-hashnode")
+    card.get_by_text("Browser login · Persistent profile", exact=True).wait_for()
+
+    actions = card.get_by_role("button")
+    assert actions.count() == 1
+    assert actions.first.inner_text() == "Disconnect"
+    assert card.get_by_text("Test", exact=True).count() == 0
+    assert card.get_by_text("Refresh login", exact=True).count() == 0
 
 
 def test_claude_card_shows_not_configured_on_fresh_store(ai_providers_page):

--- a/tests/tests_ui/screens/test_settings.py
+++ b/tests/tests_ui/screens/test_settings.py
@@ -168,6 +168,33 @@ def test_hashnode_connected_card_only_offers_disconnect(page):
     assert card.get_by_text("Refresh login", exact=True).count() == 0
 
 
+@pytest.mark.parametrize(
+    ("function_name", "endpoint"),
+    [
+        ("startHashnodeBrowserLogin", "/api/connections/hashnode/browser-connection"),
+        (
+            "completeHashnodeBrowserLogin",
+            "/api/connections/hashnode/browser-connection/complete",
+        ),
+        ("disconnectHashnodeBrowser", "/api/connections/hashnode/browser-connection"),
+    ],
+)
+def test_hashnode_browser_actions_redirect_expired_sessions(
+    settings_page, function_name, endpoint,
+):
+    settings_page.route(
+        f"{BASE_URL}{endpoint}",
+        lambda route: route.fulfill(status=401, json={"detail": "Authentication required"}),
+    )
+
+    settings_page.evaluate(f"void {function_name}()")
+
+    settings_page.wait_for_url("**/screens/login/v1.html?next=**")
+    assert settings_page.url.endswith(
+        "/screens/login/v1.html?next=%2Fscreens%2Fsettings%2Fv2.html"
+    )
+
+
 def test_claude_card_shows_not_configured_on_fresh_store(ai_providers_page):
     card = ai_providers_page.locator("#ai-wrap-anthropic")
     assert card.get_by_text("Not configured").is_visible()


### PR DESCRIPTION
## Summary

- add a free-account Hashnode login path backed by a self-hosted Skyvern browser
- persist opaque browser profile references while keeping cookies and browser storage inside the isolated profile volume
- verify Hashnode authentication before marking the connection connected
- support profile reuse, manual tab-close handoff, disconnect, and cleanup
- replace the Settings card with Connect, login-method selection, and connected states
- integrate Skyvern, its UI, PostgreSQL, and persistent browser-profile volumes into common startup

## Scope

This PR contains browser login and profile lifecycle only. Deterministic Playwright publishing and the API for accessing article content and metadata are split into `feat/41`.

## Validation

- focused login/profile/backend suite: 16 passed
- Python source compilation: 139 files
- Settings login states were visually and interactively validated with Playwright before the split

Closes #40