### PR TITLE
feat: add deterministic Hashnode browser publishing

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -45,6 +45,7 @@ def startup_cleanup():
     store.delete_expired_sessions()
     store.expire_connection_auth_flows()
     store.recover_agent_sessions()
+    store.recover_browser_publish_runs()
     store.cleanup_agent_sessions(
         retention_days=int(os.environ.get("BLOGHUB_AGENT_SESSION_RETENTION_DAYS", "90"))
     )

--- a/backend/routers/articles.py
+++ b/backend/routers/articles.py
@@ -2,7 +2,7 @@ import io
 import zipfile
 from pathlib import Path
 
-from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile
+from fastapi import APIRouter, BackgroundTasks, File, HTTPException, Query, Request, UploadFile
 from typing import Optional
 
 from pydantic import BaseModel
@@ -22,6 +22,7 @@ from backend.schemas.overview import (
 )
 import backend.store as store
 import backend.services.cli_runner as runner
+import backend.services.browser_publish as browser_publish
 from backend.services.push import push_article_to_platforms
 from backend.store.article_revisions import RevisionConflict
 
@@ -471,6 +472,53 @@ def push_article(request: Request, article_id: str, body: dict = {}):
     store.complete_job(user_id, job["job_id"], result=job_result)
 
     return AsyncAccepted(jobId=job["job_id"], status=JobStatus.done)
+
+
+@router.post("/{article_id}/browser-publish/hashnode", status_code=201)
+def request_hashnode_browser_publish(
+    request: Request, article_id: str,
+):
+    if store.get_article(request.state.user_id, article_id) is None:
+        raise HTTPException(status_code=404, detail="Article not found")
+    browser_connection = store.get_browser_connection(
+        request.state.user_id, "hashnode"
+    )
+    if not browser_connection or browser_connection["status"] != "connected":
+        raise HTTPException(
+            status_code=409,
+            detail="Connect Hashnode with browser login before browser publishing",
+        )
+    return store.create_browser_publish_run(
+        request.state.user_id, article_id,
+        platform="hashnode",
+    )
+
+
+@router.get("/{article_id}/browser-publish/{run_id}")
+def get_browser_publish(request: Request, article_id: str, run_id: str):
+    run = store.get_browser_publish_run(request.state.user_id, run_id)
+    if run is None or run["article_id"] != article_id:
+        raise HTTPException(status_code=404, detail="Browser publish run not found")
+    return run
+
+
+@router.post("/{article_id}/browser-publish/{run_id}/approve", status_code=202)
+def approve_hashnode_browser_publish(
+    request: Request, article_id: str, run_id: str,
+    background_tasks: BackgroundTasks,
+):
+    run = store.get_browser_publish_run(request.state.user_id, run_id)
+    if run is None or run["article_id"] != article_id:
+        raise HTTPException(status_code=404, detail="Browser publish run not found")
+    try:
+        approved = store.approve_browser_publish_run(request.state.user_id, run_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    background_tasks.add_task(
+        browser_publish.execute_hashnode_run,
+        user_id=request.state.user_id, run_id=run_id,
+    )
+    return approved
 
 
 # ── Import ────────────────────────────────────────────────────────────────────

--- a/backend/routers/articles.py
+++ b/backend/routers/articles.py
@@ -3,7 +3,7 @@ import zipfile
 from pathlib import Path
 
 from fastapi import APIRouter, BackgroundTasks, File, HTTPException, Query, Request, UploadFile
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel
 
@@ -474,9 +474,15 @@ def push_article(request: Request, article_id: str, body: dict = {}):
     return AsyncAccepted(jobId=job["job_id"], status=JobStatus.done)
 
 
+class HashnodeBrowserPublishRequest(BaseModel):
+    mode: Literal["draft", "publish"] = "draft"
+
+
 @router.post("/{article_id}/browser-publish/hashnode", status_code=201)
 def request_hashnode_browser_publish(
-    request: Request, article_id: str,
+    request: Request,
+    article_id: str,
+    body: HashnodeBrowserPublishRequest = HashnodeBrowserPublishRequest(),
 ):
     if store.get_article(request.state.user_id, article_id) is None:
         raise HTTPException(status_code=404, detail="Article not found")
@@ -490,7 +496,7 @@ def request_hashnode_browser_publish(
         )
     return store.create_browser_publish_run(
         request.state.user_id, article_id,
-        platform="hashnode",
+        platform="hashnode", mode=body.mode,
     )
 
 

--- a/backend/services/browser_publish.py
+++ b/backend/services/browser_publish.py
@@ -26,6 +26,7 @@ def execute_hashnode_run(*, user_id: str, run_id: str) -> None:
             organization_id=browser_connection["skyvern_organization_id"],
             profile_id=browser_connection["skyvern_profile_id"],
             title=revision["title"], article_md=revision["content"],
+            publish=run["mode"] == "publish",
         )
         if not result.get("success"):
             error = result.get("error") or "Hashnode upload failed"
@@ -40,7 +41,8 @@ def execute_hashnode_run(*, user_id: str, run_id: str) -> None:
         store.apply_push_result(
             user_id, run["article_id"], "hashnode", success=True,
             url=result.get("url"), draft_id=result.get("draft_id"),
-            label="Draft",
+            label="Published" if run["mode"] == "publish" else "Draft",
+            status="published" if run["mode"] == "publish" else "draft",
         )
         store.complete_browser_publish_run(user_id, run_id, result=result)
     except Exception as exc:

--- a/backend/services/browser_publish.py
+++ b/backend/services/browser_publish.py
@@ -1,0 +1,51 @@
+"""Orchestrate an approved browser publish without exposing browser credentials."""
+from __future__ import annotations
+
+import backend.services.cli_runner as runner
+import backend.store as store
+
+
+def execute_hashnode_run(*, user_id: str, run_id: str) -> None:
+    run = store.get_browser_publish_run(user_id, run_id)
+    if run is None or run["status"] != "running":
+        return
+    revision = store.get_article_revision(
+        user_id, run["article_id"], run["article_revision_id"]
+    )
+    if revision is None:
+        store.complete_browser_publish_run(user_id, run_id, error="Article revision not found")
+        return
+    browser_connection = store.get_browser_connection(user_id, "hashnode")
+    if not browser_connection or browser_connection["status"] != "connected":
+        store.complete_browser_publish_run(
+            user_id, run_id, error="Hashnode browser login required"
+        )
+        return
+    try:
+        result = runner.hashnode_browser_upload(
+            organization_id=browser_connection["skyvern_organization_id"],
+            profile_id=browser_connection["skyvern_profile_id"],
+            title=revision["title"], article_md=revision["content"],
+        )
+        if not result.get("success"):
+            error = result.get("error") or "Hashnode upload failed"
+            store.apply_push_result(
+                user_id, run["article_id"], "hashnode", success=False,
+                error=error, label="Browser upload failed",
+            )
+            store.complete_browser_publish_run(
+                user_id, run_id, result=result, error=error
+            )
+            return
+        store.apply_push_result(
+            user_id, run["article_id"], "hashnode", success=True,
+            url=result.get("url"), draft_id=result.get("draft_id"),
+            label="Draft",
+        )
+        store.complete_browser_publish_run(user_id, run_id, result=result)
+    except Exception as exc:
+        store.apply_push_result(
+            user_id, run["article_id"], "hashnode", success=False,
+            error=str(exc)[:500], label="Browser upload failed",
+        )
+        store.complete_browser_publish_run(user_id, run_id, error=str(exc)[:500])

--- a/backend/services/cli_runner.py
+++ b/backend/services/cli_runner.py
@@ -141,6 +141,26 @@ def cancel_chat(session_id: str) -> None:
     _post(f"/chat/{session_id}/cancel")
 
 
+def hashnode_browser_upload(
+    *, organization_id: str, profile_id: str, title: str, article_md: str,
+) -> dict:
+    """Create a Hashnode draft through the approval-gated browser runner."""
+    payload = {
+        "organization_id": organization_id, "profile_id": profile_id,
+        "title": title, "article_md": article_md,
+    }
+    try:
+        with _client() as client:
+            response = client.post(
+                "/browser/hashnode/upload", json=payload,
+                timeout=httpx.Timeout(connect=3, read=300, write=30, pool=5),
+            )
+            response.raise_for_status()
+            return response.json()
+    except (httpx.ConnectError, httpx.HTTPStatusError, httpx.ReadTimeout) as exc:
+        raise RunnerUnavailable(f"Browser runner unavailable: {exc}") from exc
+
+
 def start_hashnode_browser_login(profile_id: str | None = None) -> dict:
     if profile_id:
         return _post("/browser/hashnode/login", profile_id=profile_id)

--- a/backend/services/cli_runner.py
+++ b/backend/services/cli_runner.py
@@ -143,11 +143,12 @@ def cancel_chat(session_id: str) -> None:
 
 def hashnode_browser_upload(
     *, organization_id: str, profile_id: str, title: str, article_md: str,
+    publish: bool = False,
 ) -> dict:
-    """Create a Hashnode draft through the approval-gated browser runner."""
+    """Create or publish a Hashnode article through the browser runner."""
     payload = {
         "organization_id": organization_id, "profile_id": profile_id,
-        "title": title, "article_md": article_md,
+        "title": title, "article_md": article_md, "publish": publish,
     }
     try:
         with _client() as client:

--- a/backend/store/__init__.py
+++ b/backend/store/__init__.py
@@ -178,6 +178,29 @@ def complete_job(user_id: str, *a, **kw):
     return _backend.complete_job(user_id, *a, **kw)
 
 
+# ── Browser publishing ──────────────────────────────────────────────────────
+
+
+def create_browser_publish_run(user_id: str, *a, **kw):
+    return _backend.create_browser_publish_run(user_id, *a, **kw)
+
+
+def get_browser_publish_run(user_id: str, *a, **kw):
+    return _backend.get_browser_publish_run(user_id, *a, **kw)
+
+
+def approve_browser_publish_run(user_id: str, *a, **kw):
+    return _backend.approve_browser_publish_run(user_id, *a, **kw)
+
+
+def complete_browser_publish_run(user_id: str, *a, **kw):
+    return _backend.complete_browser_publish_run(user_id, *a, **kw)
+
+
+def recover_browser_publish_runs():
+    return _backend.recover_browser_publish_runs()
+
+
 # ── Browser connections ────────────────────────────────────────────────────
 
 

--- a/backend/store/backends/sqlite.py
+++ b/backend/store/backends/sqlite.py
@@ -609,9 +609,10 @@ class SQLiteStore(
         error: str | None = None,
         label: str | None = None,
         draft_id: str | None = None,
+        status: str | None = None,
     ) -> None:
         if success:
-            new_status = "draft"
+            new_status = status or "draft"
             new_label = label or "Draft"
             self._con.execute(
                 """UPDATE article_destinations
@@ -619,7 +620,8 @@ class SQLiteStore(
                    WHERE article_id=? AND platform=?""",
                 (new_status, new_label, url, draft_id, article_id, platform),
             )
-            self._add_timeline(article_id, f"Draft pushed to {platform.title()}")
+            event = "Published to" if new_status == "published" else "Draft pushed to"
+            self._add_timeline(article_id, f"{event} {platform.title()}")
         else:
             self._con.execute(
                 """UPDATE article_destinations

--- a/backend/store/backends/sqlite.py
+++ b/backend/store/backends/sqlite.py
@@ -32,6 +32,7 @@ from backend.store.locking import WorkspaceLock
 from backend.store.agent_sessions import AgentSessionStoreMixin
 from backend.store.article_revisions import ArticleRevisionStoreMixin
 from backend.store.connection_auth import ConnectionAuthStoreMixin
+from backend.store.browser_publish import BrowserPublishStoreMixin
 from backend.store.browser_connections import BrowserConnectionStoreMixin
 from backend.store.schema import (
     SEED_USER_EMAIL as DEFAULT_SEED_USER_EMAIL,
@@ -221,6 +222,7 @@ def _seed_articles() -> list[dict]:
 
 class SQLiteStore(
     BrowserConnectionStoreMixin,
+    BrowserPublishStoreMixin,
     ConnectionAuthStoreMixin,
     AgentSessionStoreMixin,
     ArticleRevisionStoreMixin,
@@ -982,6 +984,7 @@ class SQLiteStore(
             self._con.executescript("""
                 DELETE FROM article_chat_log;
                 DELETE FROM agent_sessions;
+                DELETE FROM browser_publish_runs;
                 DELETE FROM browser_connections;
                 DELETE FROM article_patch_revisions;
                 DELETE FROM article_patches;

--- a/backend/store/base.py
+++ b/backend/store/base.py
@@ -188,6 +188,28 @@ class ArticleStore(Protocol):
     def get_job(self, user_id: str, job_id: str) -> dict | None:
         ...
 
+    # ── Browser publishing ──────────────────────────────────────────────────
+
+    def create_browser_publish_run(
+        self, user_id: str, article_id: str, *, platform: str
+    ) -> dict:
+        ...
+
+    def get_browser_publish_run(self, user_id: str, run_id: str) -> dict | None:
+        ...
+
+    def approve_browser_publish_run(self, user_id: str, run_id: str) -> dict:
+        ...
+
+    def complete_browser_publish_run(
+        self, user_id: str, run_id: str, *, result: dict | None = None,
+        error: str | None = None,
+    ) -> dict:
+        ...
+
+    def recover_browser_publish_runs(self) -> int:
+        ...
+
     # ── Browser connections ────────────────────────────────────────────────
 
     def get_browser_connection(self, user_id: str, platform: str) -> dict | None:

--- a/backend/store/base.py
+++ b/backend/store/base.py
@@ -114,6 +114,7 @@ class ArticleStore(Protocol):
         error: str | None,
         label: str | None,
         draft_id: str | None,
+        status: str | None = None,
     ) -> None:
         ...
 
@@ -191,7 +192,8 @@ class ArticleStore(Protocol):
     # ── Browser publishing ──────────────────────────────────────────────────
 
     def create_browser_publish_run(
-        self, user_id: str, article_id: str, *, platform: str
+        self, user_id: str, article_id: str, *, platform: str,
+        mode: str = "draft",
     ) -> dict:
         ...
 

--- a/backend/store/browser_publish.py
+++ b/backend/store/browser_publish.py
@@ -1,0 +1,87 @@
+"""Durable state for approval-gated browser publishing runs."""
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class BrowserPublishStoreMixin:
+    def create_browser_publish_run(
+        self, user_id: str, article_id: str, *, platform: str
+    ) -> dict:
+        if self.get_article(user_id, article_id) is None:
+            raise KeyError("Article not found")
+        revision = self.get_current_article_revision(user_id, article_id)
+        if revision is None:
+            raise KeyError("Article revision not found")
+        run_id = f"bpr_{uuid.uuid4().hex}"
+        self._con.execute(
+            """INSERT INTO browser_publish_runs
+               (id, user_id, article_id, article_revision_id, platform,
+                status, created_at)
+               VALUES (?, ?, ?, ?, ?, 'awaiting_approval', ?)""",
+            (run_id, user_id, article_id, revision["id"], platform, _now()),
+        )
+        self._con.commit()
+        return self.get_browser_publish_run(user_id, run_id)
+
+    def get_browser_publish_run(self, user_id: str, run_id: str) -> dict | None:
+        row = self._con.execute(
+            "SELECT * FROM browser_publish_runs WHERE id=? AND user_id=?",
+            (run_id, user_id),
+        ).fetchone()
+        if row is None:
+            return None
+        result = dict(row)
+        result["result"] = json.loads(result.pop("result_json") or "null")
+        return result
+
+    def approve_browser_publish_run(self, user_id: str, run_id: str) -> dict:
+        with self._workspace_lock.acquire():
+            row = self._con.execute(
+                "SELECT status FROM browser_publish_runs WHERE id=? AND user_id=?",
+                (run_id, user_id),
+            ).fetchone()
+            if row is None:
+                raise KeyError("Browser publish run not found")
+            if row["status"] != "awaiting_approval":
+                raise ValueError(f"Browser publish run is {row['status']}")
+            self._con.execute(
+                """UPDATE browser_publish_runs
+                   SET status='running', approved_at=? WHERE id=? AND user_id=?""",
+                (_now(), run_id, user_id),
+            )
+            self._con.commit()
+        return self.get_browser_publish_run(user_id, run_id)
+
+    def complete_browser_publish_run(
+        self, user_id: str, run_id: str, *, result: dict | None = None,
+        error: str | None = None,
+    ) -> dict:
+        status = "failed" if error else "completed"
+        self._con.execute(
+            """UPDATE browser_publish_runs
+               SET status=?, result_json=?, error=?, completed_at=?
+               WHERE id=? AND user_id=?""",
+            (status, json.dumps(result) if result is not None else None,
+             error, _now(), run_id, user_id),
+        )
+        self._con.commit()
+        return self.get_browser_publish_run(user_id, run_id)
+
+    def recover_browser_publish_runs(self) -> int:
+        """Mark interrupted writes unknown; replaying an external write is unsafe."""
+        cursor = self._con.execute(
+            """UPDATE browser_publish_runs
+               SET status='unknown', error='Runner stopped before upload could be verified',
+                   completed_at=?
+               WHERE status='running'""",
+            (_now(),),
+        )
+        self._con.commit()
+        return cursor.rowcount

--- a/backend/store/browser_publish.py
+++ b/backend/store/browser_publish.py
@@ -12,8 +12,11 @@ def _now() -> str:
 
 class BrowserPublishStoreMixin:
     def create_browser_publish_run(
-        self, user_id: str, article_id: str, *, platform: str
+        self, user_id: str, article_id: str, *, platform: str,
+        mode: str = "draft",
     ) -> dict:
+        if mode not in {"draft", "publish"}:
+            raise ValueError(f"Unsupported browser publish mode: {mode}")
         if self.get_article(user_id, article_id) is None:
             raise KeyError("Article not found")
         revision = self.get_current_article_revision(user_id, article_id)
@@ -22,10 +25,10 @@ class BrowserPublishStoreMixin:
         run_id = f"bpr_{uuid.uuid4().hex}"
         self._con.execute(
             """INSERT INTO browser_publish_runs
-               (id, user_id, article_id, article_revision_id, platform,
+               (id, user_id, article_id, article_revision_id, platform, mode,
                 status, created_at)
-               VALUES (?, ?, ?, ?, ?, 'awaiting_approval', ?)""",
-            (run_id, user_id, article_id, revision["id"], platform, _now()),
+               VALUES (?, ?, ?, ?, ?, ?, 'awaiting_approval', ?)""",
+            (run_id, user_id, article_id, revision["id"], platform, mode, _now()),
         )
         self._con.commit()
         return self.get_browser_publish_run(user_id, run_id)

--- a/backend/store/schema.py
+++ b/backend/store/schema.py
@@ -16,7 +16,7 @@ SEED_USER_HASH = "$2b$12$BJsbJlf3SZUMUISLA8oASeFn.Q3U.Ar6TqoIFtu0F9OlYyev.DZLC"
 # Bump when sql/schema.sql changes in a way that isn't safe to layer onto an
 # existing database (e.g. a dropped/renamed column). Operators reset by
 # deleting the database file; there is no in-place upgrade path.
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 _SCHEMA_SQL_PATH = Path(__file__).resolve().parent / "sql" / "schema.sql"
 

--- a/backend/store/schema.py
+++ b/backend/store/schema.py
@@ -16,7 +16,7 @@ SEED_USER_HASH = "$2b$12$BJsbJlf3SZUMUISLA8oASeFn.Q3U.Ar6TqoIFtu0F9OlYyev.DZLC"
 # Bump when sql/schema.sql changes in a way that isn't safe to layer onto an
 # existing database (e.g. a dropped/renamed column). Operators reset by
 # deleting the database file; there is no in-place upgrade path.
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 _SCHEMA_SQL_PATH = Path(__file__).resolve().parent / "sql" / "schema.sql"
 

--- a/backend/store/sql/schema.sql
+++ b/backend/store/sql/schema.sql
@@ -239,6 +239,20 @@ CREATE TABLE IF NOT EXISTS agent_session_outputs (
     created_at    TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS browser_publish_runs (
+    id                 TEXT PRIMARY KEY,
+    user_id            TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    article_id         TEXT NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+    article_revision_id TEXT NOT NULL REFERENCES article_revisions(id) ON DELETE RESTRICT,
+    platform           TEXT NOT NULL,
+    status             TEXT NOT NULL,
+    result_json        TEXT,
+    error              TEXT,
+    created_at         TEXT NOT NULL,
+    approved_at        TEXT,
+    completed_at       TEXT
+);
+
 CREATE TABLE IF NOT EXISTS browser_connections (
     user_id                 TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     platform                TEXT NOT NULL,
@@ -316,6 +330,9 @@ CREATE INDEX IF NOT EXISTS idx_agent_checkpoints_session
 
 CREATE INDEX IF NOT EXISTS idx_agent_outputs_session
     ON agent_session_outputs(session_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_browser_publish_user_article
+    ON browser_publish_runs(user_id, article_id, created_at DESC);
 
 CREATE INDEX IF NOT EXISTS idx_browser_connections_status
     ON browser_connections(status, updated_at DESC);

--- a/backend/store/sql/schema.sql
+++ b/backend/store/sql/schema.sql
@@ -245,6 +245,7 @@ CREATE TABLE IF NOT EXISTS browser_publish_runs (
     article_id         TEXT NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
     article_revision_id TEXT NOT NULL REFERENCES article_revisions(id) ON DELETE RESTRICT,
     platform           TEXT NOT NULL,
+    mode               TEXT NOT NULL DEFAULT 'draft',
     status             TEXT NOT NULL,
     result_json        TEXT,
     error              TEXT,

--- a/cli-runner/Dockerfile
+++ b/cli-runner/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-# System deps: Node (for provider CLIs) + curl
+# System deps: Node (for provider CLIs) and browser prerequisites
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         ca-certificates \
@@ -18,10 +18,11 @@ RUN npm install -g @openai/codex
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY main.py hashnode_browser.py skyvern_browser.py ./
+RUN patchright install --with-deps chromium
+COPY main.py hashnode_browser.py skyvern_browser.py browser_selectors.json ./
 
 # Credential directories (will be overridden by named volumes in docker-compose)
-RUN mkdir -p /root/.claude /root/.config/openai /root/.config/gh /data/skyvern-browser-sessions
+RUN mkdir -p /root/.claude /root/.config/openai /data/skyvern-browser-sessions
 
 EXPOSE 8001
 

--- a/cli-runner/browser_selectors.json
+++ b/cli-runner/browser_selectors.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "editor_url": "https://hashnode.com/draft/new",
+  "title": ["textarea[placeholder*='title' i]", "input[placeholder*='title' i]"],
+  "content": ["[contenteditable='true'][role='textbox']", ".ProseMirror[contenteditable='true']"],
+  "save_draft": ["button:has-text('Save draft')", "button:has-text('Save as draft')"]
+}

--- a/cli-runner/browser_selectors.json
+++ b/cli-runner/browser_selectors.json
@@ -5,5 +5,7 @@
   "new_draft": ["button:has-text('New')"],
   "title": ["textarea[placeholder*='title' i]", "input[placeholder*='title' i]"],
   "markdown_mode": ["button:has-text('Markdown')"],
-  "content": ["textarea[placeholder*='writing markdown' i]"]
+  "content": ["textarea[placeholder*='writing markdown' i]"],
+  "publish_open": ["button:has-text('Publish')"],
+  "publish_confirm": ["[role='dialog'] button:has-text('Publish')"]
 }

--- a/cli-runner/browser_selectors.json
+++ b/cli-runner/browser_selectors.json
@@ -1,7 +1,9 @@
 {
   "version": 1,
-  "editor_url": "https://hashnode.com/draft/new",
+  "editor_url": "https://hashnode.com",
+  "editor_entry": ["button:has-text('Write')"],
+  "new_draft": ["button:has-text('New')"],
   "title": ["textarea[placeholder*='title' i]", "input[placeholder*='title' i]"],
-  "content": ["[contenteditable='true'][role='textbox']", ".ProseMirror[contenteditable='true']"],
-  "save_draft": ["button:has-text('Save draft')", "button:has-text('Save as draft')"]
+  "markdown_mode": ["button:has-text('Markdown')"],
+  "content": ["textarea[placeholder*='writing markdown' i]"]
 }

--- a/cli-runner/hashnode_browser.py
+++ b/cli-runner/hashnode_browser.py
@@ -42,6 +42,11 @@ def _draft_id(url: str) -> str | None:
     return url.rstrip("/").split(marker, 1)[1] if marker in url else None
 
 
+def _edit_id(url: str) -> str | None:
+    marker = "/edit/"
+    return url.rstrip("/").split(marker, 1)[1] if marker in url else None
+
+
 def _normalized_markdown(markdown: str) -> str:
     normalized = re.sub(
         r'(!\[[^\]]*\]\([^\s)]+)\s+align="center"(\))',
@@ -56,7 +61,7 @@ def _normalized_markdown(markdown: str) -> str:
 
 
 def upload_hashnode_draft(
-    *, profile_dir: str, title: str, article_md: str,
+    *, profile_dir: str, title: str, article_md: str, publish: bool = False,
 ) -> dict:
     from patchright.sync_api import sync_playwright
 
@@ -140,12 +145,76 @@ def upload_hashnode_draft(
                     "url": draft_url,
                     "draft_id": draft_id,
                 }
+            if publish:
+                publish_open, _ = _wait_first_visible(
+                    page, selectors["publish_open"]
+                )
+                if publish_open is None:
+                    raise SelectorFailure("publish_open")
+                publish_open.click()
+                publish_confirm, _ = _wait_first_visible(
+                    page, selectors["publish_confirm"]
+                )
+                if publish_confirm is None:
+                    raise SelectorFailure("publish_confirm")
+                publish_confirm.click()
+                deadline = time.monotonic() + 45
+                while "/draft/" in page.url and time.monotonic() < deadline:
+                    page.wait_for_timeout(250)
+                if "/draft/" in page.url:
+                    return {
+                        "success": False,
+                        "error": "Hashnode public publish could not be verified",
+                        "url": draft_url,
+                        "draft_id": draft_id,
+                    }
+                post_id = _edit_id(page.url)
+                if post_id is None:
+                    return {
+                        "success": False,
+                        "error": "Hashnode published post identifier was not returned",
+                        "url": page.url,
+                        "draft_id": draft_id,
+                    }
+                response = page.request.get(
+                    f"https://hashnode.com/api/posts/{post_id}"
+                )
+                metadata = response.json() if response.ok else {}
+                post = metadata.get("post") if metadata.get("success") else None
+                if (
+                    not post
+                    or not post.get("isActive")
+                    or post.get("title") != title
+                    or _normalized_markdown(post.get("contentMarkdown") or "")
+                    != _normalized_markdown(article_md)
+                ):
+                    return {
+                        "success": False,
+                        "error": "Hashnode published post could not be verified",
+                        "url": page.url,
+                        "draft_id": draft_id,
+                    }
+                publication = post.get("publication") or {}
+                publication_name = publication.get("username")
+                slug = post.get("slug")
+                if not publication_name or not slug:
+                    return {
+                        "success": False,
+                        "error": "Hashnode public article URL was not returned",
+                        "url": page.url,
+                        "draft_id": draft_id,
+                    }
+                public_url = f"https://{publication_name}.hashnode.dev/{slug}"
+
             result = {
                 "success": True,
                 "method": "deterministic",
-                "url": draft_url,
+                "status": "published" if publish else "draft",
+                "url": public_url if publish else draft_url,
                 "draft_id": draft_id,
             }
+            if publish:
+                result["post_id"] = post_id
         finally:
             context.close()
 

--- a/cli-runner/hashnode_browser.py
+++ b/cli-runner/hashnode_browser.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import re
 import sqlite3
 import time
 
 SELECTORS_PATH = Path(__file__).with_name("browser_selectors.json")
-_ALLOWED_ACTIONS = ("title", "content", "save_draft")
 
 
 class SelectorFailure(RuntimeError):
@@ -25,6 +25,34 @@ def _first_visible(page, selectors: list[str]):
         except Exception:
             continue
     return None, None
+
+
+def _wait_first_visible(page, selectors: list[str], *, timeout_ms: int = 20_000):
+    deadline = time.monotonic() + timeout_ms / 1000
+    while time.monotonic() < deadline:
+        locator, selector = _first_visible(page, selectors)
+        if locator is not None:
+            return locator, selector
+        page.wait_for_timeout(250)
+    return None, None
+
+
+def _draft_id(url: str) -> str | None:
+    marker = "/draft/"
+    return url.rstrip("/").split(marker, 1)[1] if marker in url else None
+
+
+def _normalized_markdown(markdown: str) -> str:
+    normalized = re.sub(
+        r'(!\[[^\]]*\]\([^\s)]+)\s+align="center"(\))',
+        r"\1\2",
+        markdown,
+    )
+    normalized = re.sub(r"^\*\s{3}", "- ", normalized, flags=re.MULTILINE)
+    normalized = re.sub(r"^\s+$", "", normalized, flags=re.MULTILINE)
+    normalized = re.sub(r"\n{3,}", "\n\n", normalized)
+    normalized = re.sub(r"(^- .+)\n\n(?=- )", r"\1\n", normalized, flags=re.MULTILINE)
+    return normalized.strip()
 
 
 def upload_hashnode_draft(
@@ -50,28 +78,73 @@ def upload_hashnode_draft(
                     },
                 }
 
-            controls = {}
-            for action in _ALLOWED_ACTIONS:
-                locator, _ = _first_visible(page, selectors[action])
-                if locator is None:
-                    raise SelectorFailure(action)
-                controls[action] = locator
+            editor_entry, _ = _wait_first_visible(page, selectors["editor_entry"])
+            if editor_entry is None:
+                raise SelectorFailure("editor_entry")
+            editor_entry.click()
+            page.wait_for_url("**/draft/**", timeout=30_000)
+            previous_draft_url = page.url
+            new_draft, _ = _wait_first_visible(
+                page, selectors["new_draft"], timeout_ms=60_000
+            )
+            if new_draft is None:
+                raise SelectorFailure("new_draft")
+            new_draft.click()
+            deadline = time.monotonic() + 30
+            while page.url == previous_draft_url and time.monotonic() < deadline:
+                page.wait_for_timeout(250)
+            if page.url == previous_draft_url:
+                raise SelectorFailure("new_draft")
 
-            controls["title"].fill(title)
-            controls["content"].fill(article_md)
-            before_url = page.url
-            controls["save_draft"].click()
-            page.wait_for_timeout(1800)
-            if page.locator("text=/error|failed/i").first.is_visible(timeout=500):
-                return {"success": False, "error": "Hashnode reported that the draft was not saved"}
-            saved_signal = page.locator("text=/draft saved|saved to drafts|saved successfully/i").first
-            if page.url == before_url and not saved_signal.is_visible(timeout=1200):
-                return {"success": False, "error": "Hashnode draft save could not be verified"}
+            title_control, _ = _wait_first_visible(page, selectors["title"])
+            markdown_mode, _ = _wait_first_visible(page, selectors["markdown_mode"])
+            if title_control is None:
+                raise SelectorFailure("title")
+            if markdown_mode is None:
+                raise SelectorFailure("markdown_mode")
+            markdown_mode.click()
+            content_control, _ = _wait_first_visible(page, selectors["content"])
+            if content_control is None:
+                raise SelectorFailure("content")
+
+            title_control.fill(title)
+            content_control.fill(article_md)
+            draft_url = page.url
+            draft_id = _draft_id(draft_url)
+
+            # Hashnode autosaves drafts. A reload is the strongest deterministic
+            # confirmation available without clicking the public Publish action.
+            page.wait_for_timeout(6_000)
+            page.reload(wait_until="domcontentloaded", timeout=45_000)
+            title_control, _ = _wait_first_visible(page, selectors["title"])
+            content_control, _ = _wait_first_visible(
+                page, selectors["content"], timeout_ms=2_000
+            )
+            if content_control is None:
+                markdown_mode, _ = _wait_first_visible(page, selectors["markdown_mode"])
+                if markdown_mode is not None:
+                    markdown_mode.click()
+                    content_control, _ = _wait_first_visible(
+                        page, selectors["content"]
+                    )
+            if (
+                title_control is None
+                or content_control is None
+                or title_control.input_value() != title
+                or _normalized_markdown(content_control.input_value())
+                != _normalized_markdown(article_md)
+            ):
+                return {
+                    "success": False,
+                    "error": "Hashnode draft autosave could not be verified",
+                    "url": draft_url,
+                    "draft_id": draft_id,
+                }
             result = {
                 "success": True,
                 "method": "deterministic",
-                "url": page.url if "/draft" in page.url else None,
-                "draft_id": page.url.rstrip("/").split("/")[-1] if "/draft/" in page.url else None,
+                "url": draft_url,
+                "draft_id": draft_id,
             }
         finally:
             context.close()

--- a/cli-runner/hashnode_browser.py
+++ b/cli-runner/hashnode_browser.py
@@ -1,10 +1,82 @@
-"""Verify persisted Hashnode browser profiles without exposing credentials."""
+"""Deterministic Hashnode draft upload through a persisted browser profile."""
 from __future__ import annotations
 
 import json
 from pathlib import Path
 import sqlite3
 import time
+
+SELECTORS_PATH = Path(__file__).with_name("browser_selectors.json")
+_ALLOWED_ACTIONS = ("title", "content", "save_draft")
+
+
+class SelectorFailure(RuntimeError):
+    def __init__(self, action: str):
+        super().__init__(f"Hashnode control not found: {action}")
+        self.action = action
+
+
+def _first_visible(page, selectors: list[str]):
+    for selector in selectors:
+        locator = page.locator(selector).first
+        try:
+            if locator.is_visible(timeout=1200):
+                return locator, selector
+        except Exception:
+            continue
+    return None, None
+
+
+def upload_hashnode_draft(
+    *, profile_dir: str, title: str, article_md: str,
+) -> dict:
+    from patchright.sync_api import sync_playwright
+
+    selectors = json.loads(SELECTORS_PATH.read_text(encoding="utf-8"))
+    with sync_playwright() as playwright:
+        context = playwright.chromium.launch_persistent_context(
+            profile_dir, headless=True, viewport={"width": 1440, "height": 1000},
+        )
+        page = context.pages[0] if context.pages else context.new_page()
+        try:
+            page.goto(selectors["editor_url"], wait_until="domcontentloaded", timeout=45000)
+            if any(part in page.url.lower() for part in ("signin", "login", "onboard")):
+                return {
+                    "success": False,
+                    "error": "Hashnode browser session is not authenticated",
+                    "manual_handoff": {
+                        "reason": "hashnode_login_required",
+                        "url": "https://hashnode.com/login",
+                    },
+                }
+
+            controls = {}
+            for action in _ALLOWED_ACTIONS:
+                locator, _ = _first_visible(page, selectors[action])
+                if locator is None:
+                    raise SelectorFailure(action)
+                controls[action] = locator
+
+            controls["title"].fill(title)
+            controls["content"].fill(article_md)
+            before_url = page.url
+            controls["save_draft"].click()
+            page.wait_for_timeout(1800)
+            if page.locator("text=/error|failed/i").first.is_visible(timeout=500):
+                return {"success": False, "error": "Hashnode reported that the draft was not saved"}
+            saved_signal = page.locator("text=/draft saved|saved to drafts|saved successfully/i").first
+            if page.url == before_url and not saved_signal.is_visible(timeout=1200):
+                return {"success": False, "error": "Hashnode draft save could not be verified"}
+            result = {
+                "success": True,
+                "method": "deterministic",
+                "url": page.url if "/draft" in page.url else None,
+                "draft_id": page.url.rstrip("/").split("/")[-1] if "/draft/" in page.url else None,
+            }
+        finally:
+            context.close()
+
+    return result
 
 
 def check_hashnode_profile(*, profile_dir: str) -> dict:

--- a/cli-runner/main.py
+++ b/cli-runner/main.py
@@ -32,13 +32,14 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
-from hashnode_browser import check_hashnode_profile
+from hashnode_browser import check_hashnode_profile, upload_hashnode_draft
 from skyvern_browser import (
     SkyvernUnavailable,
     close_hashnode_login,
     delete_hashnode_profile,
     finish_hashnode_login,
     get_hashnode_login,
+    profile_directory,
     start_hashnode_login,
 )
 
@@ -220,6 +221,13 @@ class ChatRequest(BaseModel):
     api_key: Optional[str] = None
 
 
+class HashnodeBrowserUploadRequest(BaseModel):
+    organization_id: str
+    profile_id: str
+    title: str
+    article_md: str
+
+
 class HashnodeBrowserLoginCompleteRequest(BaseModel):
     profile_name: str
     profile_id: Optional[str] = None
@@ -235,6 +243,22 @@ class HashnodeBrowserProfileRequest(BaseModel):
 
 
 _chat_processes: dict[str, subprocess.Popen] = {}
+
+
+@app.post("/browser/hashnode/upload")
+def hashnode_browser_upload(req: HashnodeBrowserUploadRequest):
+    try:
+        profile_dir = profile_directory(req.organization_id, req.profile_id)
+    except ValueError as exc:
+        raise HTTPException(422, str(exc)) from exc
+    if not profile_dir.is_dir():
+        raise HTTPException(409, "Hashnode browser profile is unavailable")
+    try:
+        return upload_hashnode_draft(
+            profile_dir=str(profile_dir), title=req.title, article_md=req.article_md,
+        )
+    except Exception as exc:
+        return {"success": False, "error": _safe_reason(str(exc))}
 
 
 @app.post("/browser/hashnode/login", status_code=201)

--- a/cli-runner/main.py
+++ b/cli-runner/main.py
@@ -226,6 +226,7 @@ class HashnodeBrowserUploadRequest(BaseModel):
     profile_id: str
     title: str
     article_md: str
+    publish: bool = False
 
 
 class HashnodeBrowserLoginCompleteRequest(BaseModel):
@@ -256,6 +257,7 @@ def hashnode_browser_upload(req: HashnodeBrowserUploadRequest):
     try:
         return upload_hashnode_draft(
             profile_dir=str(profile_dir), title=req.title, article_md=req.article_md,
+            publish=req.publish,
         )
     except Exception as exc:
         return {"success": False, "error": _safe_reason(str(exc))}

--- a/cli-runner/requirements.txt
+++ b/cli-runner/requirements.txt
@@ -2,3 +2,4 @@ fastapi>=0.111.0
 httpx>=0.27.0
 uvicorn[standard]>=0.29.0
 pydantic>=2.7.0
+patchright==1.62.1

--- a/tests/tests_backend/test_browser_publish.py
+++ b/tests/tests_backend/test_browser_publish.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import backend.services.browser_publish as browser_publish
+import backend.store as store
+
+
+def _connect() -> None:
+    store.start_browser_connection(
+        "user_seed", "hashnode", session_id="pbs_test",
+        organization_id="o_test", app_url="http://localhost/login",
+    )
+    store.update_browser_connection(
+        "user_seed", "hashnode", "connected", profile_id="bp_test"
+    )
+
+
+def test_browser_publish_requires_approval_and_completes(client, monkeypatch):
+    _connect()
+    seen = {}
+
+    def upload(**kwargs):
+        seen.update(kwargs)
+        return {
+            "success": True, "method": "deterministic",
+            "url": "https://hashnode.com/draft/example", "draft_id": "example",
+        }
+
+    monkeypatch.setattr(browser_publish.runner, "hashnode_browser_upload", upload)
+    created = client.post(
+        "/api/articles/art_001/browser-publish/hashnode",
+    )
+    assert created.status_code == 201
+    assert created.json()["status"] == "awaiting_approval"
+    run_id = created.json()["id"]
+
+    approved = client.post(f"/api/articles/art_001/browser-publish/{run_id}/approve")
+    assert approved.status_code == 202
+    persisted = client.get(
+        f"/api/articles/art_001/browser-publish/{run_id}"
+    ).json()
+    assert persisted["status"] == "completed"
+    assert persisted["result"]["method"] == "deterministic"
+    assert seen["profile_id"] == "bp_test"
+    assert seen["organization_id"] == "o_test"
+
+
+def test_browser_publish_cannot_be_approved_twice(client, monkeypatch):
+    _connect()
+    monkeypatch.setattr(
+        browser_publish.runner, "hashnode_browser_upload",
+        lambda **_kwargs: {"success": True, "method": "deterministic"},
+    )
+    run = client.post(
+        "/api/articles/art_001/browser-publish/hashnode",
+    ).json()
+    assert client.post(
+        f"/api/articles/art_001/browser-publish/{run['id']}/approve"
+    ).status_code == 202
+    duplicate = client.post(
+        f"/api/articles/art_001/browser-publish/{run['id']}/approve"
+    )
+    assert duplicate.status_code == 409
+
+
+def test_browser_publish_requires_connected_browser_profile(client):
+    response = client.post(
+        "/api/articles/art_001/browser-publish/hashnode",
+    )
+    assert response.status_code == 409
+
+
+def test_manual_handoff_is_retained_on_failed_browser_login(client, monkeypatch):
+    _connect()
+    monkeypatch.setattr(
+        browser_publish.runner, "hashnode_browser_upload",
+        lambda **_kwargs: {
+            "success": False,
+            "error": "Hashnode browser session is not authenticated",
+            "manual_handoff": {
+                "reason": "hashnode_login_required",
+                "url": "https://hashnode.com/signin",
+            },
+        },
+    )
+    run = client.post(
+        "/api/articles/art_001/browser-publish/hashnode",
+    ).json()
+    client.post(f"/api/articles/art_001/browser-publish/{run['id']}/approve")
+    persisted = client.get(
+        f"/api/articles/art_001/browser-publish/{run['id']}"
+    ).json()
+    assert persisted["status"] == "failed"
+    assert persisted["result"]["manual_handoff"]["reason"] == "hashnode_login_required"
+
+
+def test_approved_run_uploads_the_revision_captured_at_request(client, monkeypatch):
+    _connect()
+    article = client.get("/api/articles/art_001").json()
+    seen = {}
+    monkeypatch.setattr(
+        browser_publish.runner, "hashnode_browser_upload",
+        lambda **kwargs: seen.update(kwargs) or {"success": True, "method": "deterministic"},
+    )
+    run = client.post(
+        "/api/articles/art_001/browser-publish/hashnode",
+    ).json()
+    client.patch("/api/articles/art_001", json={
+        "content": article["content"] + "\n\nNewer editor text.",
+        "base_revision_id": article["revision_id"],
+    })
+    client.post(f"/api/articles/art_001/browser-publish/{run['id']}/approve")
+    assert seen["article_md"] == article["content"]
+
+
+def test_interrupted_external_write_is_not_replayed(client):
+    _connect()
+    run = client.post(
+        "/api/articles/art_001/browser-publish/hashnode",
+    ).json()
+    store.approve_browser_publish_run("user_seed", run["id"])
+    assert store.recover_browser_publish_runs() == 1
+    recovered = store.get_browser_publish_run("user_seed", run["id"])
+    assert recovered["status"] == "unknown"
+    assert "verified" in recovered["error"]

--- a/tests/tests_backend/test_browser_publish.py
+++ b/tests/tests_backend/test_browser_publish.py
@@ -40,8 +40,41 @@ def test_browser_publish_requires_approval_and_completes(client, monkeypatch):
     ).json()
     assert persisted["status"] == "completed"
     assert persisted["result"]["method"] == "deterministic"
+    assert persisted["mode"] == "draft"
+    assert seen["publish"] is False
     assert seen["profile_id"] == "bp_test"
     assert seen["organization_id"] == "o_test"
+
+
+def test_public_publish_mode_is_durable_and_updates_destination(client, monkeypatch):
+    _connect()
+    seen = {}
+    monkeypatch.setattr(
+        browser_publish.runner,
+        "hashnode_browser_upload",
+        lambda **kwargs: seen.update(kwargs) or {
+            "success": True,
+            "method": "deterministic",
+            "status": "published",
+            "url": "https://example.hashnode.dev/test",
+            "draft_id": "public_test",
+        },
+    )
+
+    run = client.post(
+        "/api/articles/art_001/browser-publish/hashnode",
+        json={"mode": "publish"},
+    ).json()
+    assert run["mode"] == "publish"
+
+    client.post(f"/api/articles/art_001/browser-publish/{run['id']}/approve")
+
+    assert seen["publish"] is True
+    article = client.get("/api/articles/art_001").json()
+    assert article["destinations"]["hashnode"]["status"] == "published"
+    assert article["destinations"]["hashnode"]["url"] == (
+        "https://example.hashnode.dev/test"
+    )
 
 
 def test_browser_publish_cannot_be_approved_twice(client, monkeypatch):

--- a/tests/tests_backend/test_hashnode_browser.py
+++ b/tests/tests_backend/test_hashnode_browser.py
@@ -36,6 +36,7 @@ class FakeLocator:
             self.page.url = "https://hashnode.com/draft/current"
             self.page.visible.update({
                 "button:has-text('New')",
+                "button:has-text('Publish')",
                 "textarea[placeholder*='title' i]",
                 "button:has-text('Markdown')",
             })
@@ -44,6 +45,10 @@ class FakeLocator:
             self.page.filled.clear()
         elif self.selector == "button:has-text('Markdown')":
             self.page.visible.add("textarea[placeholder*='writing markdown' i]")
+        elif self.selector == "button:has-text('Publish')":
+            self.page.visible.add("[role='dialog'] button:has-text('Publish')")
+        elif self.selector == "[role='dialog'] button:has-text('Publish')":
+            self.page.url = "https://hashnode.com/edit/post_test"
 
     def input_value(self):
         return self.page.filled.get(self.selector, "")
@@ -59,6 +64,7 @@ class FakePage:
         self.filled = {}
         self.clicked = []
         self.cookies = []
+        self.request = FakeRequest(self)
 
     def goto(self, *_args, **_kwargs):
         return None
@@ -74,6 +80,37 @@ class FakePage:
 
     def reload(self, **_kwargs):
         return None
+
+
+class FakeResponse:
+    ok = True
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def json(self):
+        return self.payload
+
+
+class FakeRequest:
+    def __init__(self, page):
+        self.page = page
+
+    def get(self, _url):
+        return FakeResponse({
+            "success": True,
+            "post": {
+                "isActive": True,
+                "title": self.page.filled[
+                    "textarea[placeholder*='title' i]"
+                ],
+                "contentMarkdown": self.page.filled[
+                    "textarea[placeholder*='writing markdown' i]"
+                ],
+                "slug": "test-article",
+                "publication": {"username": "tensorworks"},
+            },
+        })
 
 
 class FakeContext:
@@ -146,6 +183,25 @@ def test_hashnode_markdown_normalization_accepts_editor_formatting():
         hashnode_browser._normalized_markdown(persisted)
         == hashnode_browser._normalized_markdown(original)
     )
+
+
+def test_public_publish_requires_final_confirmation(monkeypatch):
+    page = FakePage()
+    sync_api = SimpleNamespace(sync_playwright=lambda: PlaywrightManager(page))
+    monkeypatch.setitem(sys.modules, "patchright.sync_api", sync_api)
+
+    result = hashnode_browser.upload_hashnode_draft(
+        profile_dir="/tmp/profile",
+        title="A title",
+        article_md="# A title",
+        publish=True,
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "published"
+    assert result["url"] == "https://tensorworks.hashnode.dev/test-article"
+    assert result["post_id"] == "post_test"
+    assert "[role='dialog'] button:has-text('Publish')" in page.clicked
 
 
 def _write_cookie_snapshot(profile_dir, cookies):

--- a/tests/tests_backend/test_hashnode_browser.py
+++ b/tests/tests_backend/test_hashnode_browser.py
@@ -4,6 +4,7 @@ import importlib.util
 from pathlib import Path
 import sqlite3
 import sys
+from types import SimpleNamespace
 
 
 RUNNER = Path(__file__).resolve().parents[2] / "cli-runner"
@@ -12,6 +13,109 @@ spec = importlib.util.spec_from_file_location("hashnode_browser_under_test", RUN
 hashnode_browser = importlib.util.module_from_spec(spec)
 assert spec.loader
 spec.loader.exec_module(hashnode_browser)
+
+
+class FakeLocator:
+    def __init__(self, page, selector):
+        self.page = page
+        self.selector = selector
+
+    @property
+    def first(self):
+        return self
+
+    def is_visible(self, timeout=None):
+        return self.selector in self.page.visible
+
+    def fill(self, value):
+        self.page.filled[self.selector] = value
+
+    def click(self):
+        self.page.clicked.append(self.selector)
+
+    def evaluate_all(self, _script):
+        return [{"tag": "textarea", "placeholder": "Article title"}]
+
+
+class FakePage:
+    def __init__(self):
+        self.url = "https://hashnode.com/draft/new"
+        self.visible = {
+            "textarea[placeholder*='title' i]",
+            "[contenteditable='true'][role='textbox']",
+            "button:has-text('Save draft')",
+            "text=/draft saved|saved to drafts|saved successfully/i",
+        }
+        self.filled = {}
+        self.clicked = []
+        self.cookies = []
+
+    def goto(self, *_args, **_kwargs):
+        return None
+
+    def locator(self, selector):
+        return FakeLocator(self, selector)
+
+    def wait_for_timeout(self, _timeout):
+        return None
+
+
+class FakeContext:
+    def __init__(self, page):
+        self.pages = [page]
+
+    def close(self):
+        return None
+
+    def cookies(self, _urls=None):
+        return self.pages[0].cookies
+
+
+class FakePlaywright:
+    def __init__(self, page):
+        self.chromium = SimpleNamespace(
+            launch_persistent_context=lambda *_args, **_kwargs: FakeContext(page)
+        )
+
+
+class PlaywrightManager:
+    def __init__(self, page):
+        self.page = page
+
+    def __enter__(self):
+        return FakePlaywright(self.page)
+
+    def __exit__(self, *_args):
+        return None
+
+
+def test_deterministic_selectors_fill_and_save_draft(monkeypatch):
+    page = FakePage()
+    sync_api = SimpleNamespace(sync_playwright=lambda: PlaywrightManager(page))
+    monkeypatch.setitem(sys.modules, "patchright.sync_api", sync_api)
+    result = hashnode_browser.upload_hashnode_draft(
+        profile_dir="/tmp/profile", title="A title", article_md="# A title",
+    )
+
+    assert result["success"] is True
+    assert result["method"] == "deterministic"
+    assert page.filled["textarea[placeholder*='title' i]"] == "A title"
+    assert page.filled["[contenteditable='true'][role='textbox']"] == "# A title"
+
+
+def test_missing_deterministic_selector_fails(monkeypatch):
+    page = FakePage()
+    page.visible.remove("textarea[placeholder*='title' i]")
+    sync_api = SimpleNamespace(sync_playwright=lambda: PlaywrightManager(page))
+    monkeypatch.setitem(sys.modules, "patchright.sync_api", sync_api)
+    try:
+        hashnode_browser.upload_hashnode_draft(
+            profile_dir="/tmp/profile", title="A title", article_md="# A title",
+        )
+    except hashnode_browser.SelectorFailure as exc:
+        assert exc.action == "title"
+    else:
+        raise AssertionError("missing selector was accepted")
 
 
 def _write_cookie_snapshot(profile_dir, cookies):

--- a/tests/tests_backend/test_hashnode_browser.py
+++ b/tests/tests_backend/test_hashnode_browser.py
@@ -32,6 +32,21 @@ class FakeLocator:
 
     def click(self):
         self.page.clicked.append(self.selector)
+        if self.selector == "button:has-text('Write')":
+            self.page.url = "https://hashnode.com/draft/current"
+            self.page.visible.update({
+                "button:has-text('New')",
+                "textarea[placeholder*='title' i]",
+                "button:has-text('Markdown')",
+            })
+        elif self.selector == "button:has-text('New')":
+            self.page.url = "https://hashnode.com/draft/draft_test"
+            self.page.filled.clear()
+        elif self.selector == "button:has-text('Markdown')":
+            self.page.visible.add("textarea[placeholder*='writing markdown' i]")
+
+    def input_value(self):
+        return self.page.filled.get(self.selector, "")
 
     def evaluate_all(self, _script):
         return [{"tag": "textarea", "placeholder": "Article title"}]
@@ -39,13 +54,8 @@ class FakeLocator:
 
 class FakePage:
     def __init__(self):
-        self.url = "https://hashnode.com/draft/new"
-        self.visible = {
-            "textarea[placeholder*='title' i]",
-            "[contenteditable='true'][role='textbox']",
-            "button:has-text('Save draft')",
-            "text=/draft saved|saved to drafts|saved successfully/i",
-        }
+        self.url = "https://hashnode.com"
+        self.visible = {"button:has-text('Write')"}
         self.filled = {}
         self.clicked = []
         self.cookies = []
@@ -57,6 +67,12 @@ class FakePage:
         return FakeLocator(self, selector)
 
     def wait_for_timeout(self, _timeout):
+        return None
+
+    def wait_for_url(self, _url, timeout=None):
+        return None
+
+    def reload(self, **_kwargs):
         return None
 
 
@@ -89,7 +105,7 @@ class PlaywrightManager:
         return None
 
 
-def test_deterministic_selectors_fill_and_save_draft(monkeypatch):
+def test_deterministic_selectors_fill_and_verify_autosaved_draft(monkeypatch):
     page = FakePage()
     sync_api = SimpleNamespace(sync_playwright=lambda: PlaywrightManager(page))
     monkeypatch.setitem(sys.modules, "patchright.sync_api", sync_api)
@@ -99,13 +115,14 @@ def test_deterministic_selectors_fill_and_save_draft(monkeypatch):
 
     assert result["success"] is True
     assert result["method"] == "deterministic"
+    assert result["draft_id"] == "draft_test"
     assert page.filled["textarea[placeholder*='title' i]"] == "A title"
-    assert page.filled["[contenteditable='true'][role='textbox']"] == "# A title"
+    assert page.filled["textarea[placeholder*='writing markdown' i]"] == "# A title"
 
 
 def test_missing_deterministic_selector_fails(monkeypatch):
     page = FakePage()
-    page.visible.remove("textarea[placeholder*='title' i]")
+    page.visible.clear()
     sync_api = SimpleNamespace(sync_playwright=lambda: PlaywrightManager(page))
     monkeypatch.setitem(sys.modules, "patchright.sync_api", sync_api)
     try:
@@ -113,9 +130,22 @@ def test_missing_deterministic_selector_fails(monkeypatch):
             profile_dir="/tmp/profile", title="A title", article_md="# A title",
         )
     except hashnode_browser.SelectorFailure as exc:
-        assert exc.action == "title"
+        assert exc.action == "editor_entry"
     else:
         raise AssertionError("missing selector was accepted")
+
+
+def test_hashnode_markdown_normalization_accepts_editor_formatting():
+    original = "![Diagram](https://example.com/a.png)\n\n- first\n- second"
+    persisted = (
+        '![Diagram](https://example.com/a.png align="center")\n\n'
+        "*   first\n    \n*   second"
+    )
+
+    assert (
+        hashnode_browser._normalized_markdown(persisted)
+        == hashnode_browser._normalized_markdown(original)
+    )
 
 
 def _write_cookie_snapshot(profile_dir, cookies):

--- a/tests/tests_backend/test_store/test_schema.py
+++ b/tests/tests_backend/test_store/test_schema.py
@@ -42,6 +42,13 @@ def test_fresh_database_has_current_schema_and_seed_user(tmp_path):
         assert store._con.execute(
             "SELECT COUNT(*) FROM users WHERE id=?", (SEED_USER_ID,)
         ).fetchone()[0] == 1
+        publish_columns = {
+            row[1]
+            for row in store._con.execute(
+                "PRAGMA table_info(browser_publish_runs)"
+            )
+        }
+        assert "mode" in publish_columns
     finally:
         store.close()
 

--- a/tests/tests_backend/test_store/test_schema.py
+++ b/tests/tests_backend/test_store/test_schema.py
@@ -36,6 +36,7 @@ def test_fresh_database_has_current_schema_and_seed_user(tmp_path):
             "agent_approvals",
             "agent_checkpoints",
             "agent_session_outputs",
+            "browser_publish_runs",
             "browser_connections",
         } <= tables
         assert store._con.execute(


### PR DESCRIPTION
## Summary
- add deterministic Playwright publishing through the authenticated Hashnode browser profile
- expose article content, metadata, revisions, and publish status APIs
- support explicit draft and approved public-publish modes with durable run state
- verify saved and published Hashnode content, metadata, and image references

## Validation
- focused publishing and API suite passes
- Python compileall
- git diff --check

## Dependency
Stacked on PR #41 (feat/40) because publishing reuses the non-Pro Hashnode browser connection.