### PR TITLE
feat: add Medium browser publishing and retrieval

### DIFF
--- a/backend/routers/articles.py
+++ b/backend/routers/articles.py
@@ -474,7 +474,7 @@ def push_article(request: Request, article_id: str, body: dict = {}):
     return AsyncAccepted(jobId=job["job_id"], status=JobStatus.done)
 
 
-class HashnodeBrowserPublishRequest(BaseModel):
+class BrowserPublishRequest(BaseModel):
     mode: Literal["draft", "publish"] = "draft"
 
 
@@ -482,7 +482,7 @@ class HashnodeBrowserPublishRequest(BaseModel):
 def request_hashnode_browser_publish(
     request: Request,
     article_id: str,
-    body: HashnodeBrowserPublishRequest = HashnodeBrowserPublishRequest(),
+    body: BrowserPublishRequest = BrowserPublishRequest(),
 ):
     if store.get_article(request.state.user_id, article_id) is None:
         raise HTTPException(status_code=404, detail="Article not found")
@@ -500,6 +500,28 @@ def request_hashnode_browser_publish(
     )
 
 
+@router.post("/{article_id}/browser-publish/medium", status_code=201)
+def request_medium_browser_publish(
+    request: Request,
+    article_id: str,
+    body: BrowserPublishRequest = BrowserPublishRequest(),
+):
+    if store.get_article(request.state.user_id, article_id) is None:
+        raise HTTPException(status_code=404, detail="Article not found")
+    browser_connection = store.get_browser_connection(
+        request.state.user_id, "medium"
+    )
+    if not browser_connection or browser_connection["status"] != "connected":
+        raise HTTPException(
+            status_code=409,
+            detail="Connect Medium with browser login before browser publishing",
+        )
+    return store.create_browser_publish_run(
+        request.state.user_id, article_id,
+        platform="medium", mode=body.mode,
+    )
+
+
 @router.get("/{article_id}/browser-publish/{run_id}")
 def get_browser_publish(request: Request, article_id: str, run_id: str):
     run = store.get_browser_publish_run(request.state.user_id, run_id)
@@ -509,7 +531,7 @@ def get_browser_publish(request: Request, article_id: str, run_id: str):
 
 
 @router.post("/{article_id}/browser-publish/{run_id}/approve", status_code=202)
-def approve_hashnode_browser_publish(
+def approve_browser_publish(
     request: Request, article_id: str, run_id: str,
     background_tasks: BackgroundTasks,
 ):
@@ -520,9 +542,11 @@ def approve_hashnode_browser_publish(
         approved = store.approve_browser_publish_run(request.state.user_id, run_id)
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    executor = browser_publish.EXECUTORS.get(run["platform"])
+    if executor is None:
+        raise HTTPException(status_code=422, detail="Unsupported browser publish platform")
     background_tasks.add_task(
-        browser_publish.execute_hashnode_run,
-        user_id=request.state.user_id, run_id=run_id,
+        executor, user_id=request.state.user_id, run_id=run_id,
     )
     return approved
 

--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -854,14 +854,22 @@ def list_drafts(
 
     Hashnode: GraphQL me { drafts } + me { posts }
     Dev.to:   GET /articles/me/unpublished  +  GET /articles/me
-    Medium:   falls back to _MOCK_DRAFTS (Medium API does not expose drafts)
+    Medium:   browser retrieval when connected through Skyvern; legacy mock
+              fallback for API-token-only development connections
     """
     user_id: str = request.state.user_id
     if conn_id not in _BLOG_IDS:
         raise HTTPException(status_code=404, detail=f"Unknown platform: {conn_id}")
 
     token = store.get_connection_token(user_id, conn_id)
-    if not token:
+    browser_connection = (
+        store.get_browser_connection(user_id, "medium")
+        if conn_id == "medium" else None
+    )
+    has_medium_browser = bool(
+        browser_connection and browser_connection["status"] == "connected"
+    )
+    if not token and not has_medium_browser:
         raise HTTPException(
             status_code=404,
             detail={
@@ -876,8 +884,14 @@ def list_drafts(
         elif conn_id == "devto":
             all_drafts = _fetch_devto_drafts(token)
         else:
-            # Medium: API does not support draft listing; use mock data
-            all_drafts = _MOCK_DRAFTS.get(conn_id, [])
+            if has_medium_browser:
+                all_drafts = runner.list_medium_browser_articles(
+                    organization_id=browser_connection["skyvern_organization_id"],
+                    profile_id=browser_connection["skyvern_profile_id"],
+                )
+            else:
+                # Legacy API-token connections cannot retrieve Medium drafts.
+                all_drafts = _MOCK_DRAFTS.get(conn_id, [])
     except HTTPException:
         raise
     except httpx.HTTPStatusError as exc:
@@ -914,14 +928,22 @@ def list_drafts(
 def get_draft(request: Request, conn_id: str, draft_id: str):
     """
     Return the full markdown body of a single article from the platform.
-    Fetches from the live platform API for Hashnode and Dev.to.
+    Fetches from the live platform API for Hashnode and Dev.to, or from the
+    persisted browser profile for Medium.
     """
     user_id: str = request.state.user_id
     if conn_id not in _BLOG_IDS:
         raise HTTPException(status_code=404, detail=f"Unknown platform: {conn_id}")
 
     token = store.get_connection_token(user_id, conn_id)
-    if not token:
+    browser_connection = (
+        store.get_browser_connection(user_id, "medium")
+        if conn_id == "medium" else None
+    )
+    has_medium_browser = bool(
+        browser_connection and browser_connection["status"] == "connected"
+    )
+    if not token and not has_medium_browser:
         raise HTTPException(
             status_code=404,
             detail={
@@ -947,7 +969,13 @@ def get_draft(request: Request, conn_id: str, draft_id: str):
             return DraftContent(**draft)
 
         else:
-            # Medium: use mock data
+            if has_medium_browser:
+                article = runner.get_medium_browser_article(
+                    draft_id,
+                    organization_id=browser_connection["skyvern_organization_id"],
+                    profile_id=browser_connection["skyvern_profile_id"],
+                )
+                return DraftContent(**article)
             drafts = _MOCK_DRAFTS.get(conn_id, [])
             draft = next((d for d in drafts if d["id"] == draft_id), None)
             if draft is None:

--- a/backend/services/browser_publish.py
+++ b/backend/services/browser_publish.py
@@ -15,7 +15,7 @@ def _medium_article_fragment(rendered_html: str) -> str:
     )
     fragment = match.group(1) if match else rendered_html
     return re.sub(
-        r"^\s*<h1[^>]*>[\s\S]*?</h1>\s*", "", fragment,
+        r"<h1[^>]*>[\s\S]*?</h1>\s*", "", fragment,
         count=1, flags=re.IGNORECASE,
     )
 

--- a/backend/services/browser_publish.py
+++ b/backend/services/browser_publish.py
@@ -1,8 +1,23 @@
 """Orchestrate an approved browser publish without exposing browser credentials."""
 from __future__ import annotations
 
+import re
+
 import backend.services.cli_runner as runner
 import backend.store as store
+from blogs.medium.render import render_clipboard_html
+
+
+def _medium_article_fragment(rendered_html: str) -> str:
+    match = re.search(
+        r"<article[^>]*>([\s\S]*?)</article>", rendered_html,
+        flags=re.IGNORECASE,
+    )
+    fragment = match.group(1) if match else rendered_html
+    return re.sub(
+        r"^\s*<h1[^>]*>[\s\S]*?</h1>\s*", "", fragment,
+        count=1, flags=re.IGNORECASE,
+    )
 
 
 def execute_hashnode_run(*, user_id: str, run_id: str) -> None:
@@ -51,3 +66,59 @@ def execute_hashnode_run(*, user_id: str, run_id: str) -> None:
             error=str(exc)[:500], label="Browser upload failed",
         )
         store.complete_browser_publish_run(user_id, run_id, error=str(exc)[:500])
+
+
+def execute_medium_run(*, user_id: str, run_id: str) -> None:
+    run = store.get_browser_publish_run(user_id, run_id)
+    if run is None or run["status"] != "running":
+        return
+    revision = store.get_article_revision(
+        user_id, run["article_id"], run["article_revision_id"]
+    )
+    if revision is None:
+        store.complete_browser_publish_run(user_id, run_id, error="Article revision not found")
+        return
+    browser_connection = store.get_browser_connection(user_id, "medium")
+    if not browser_connection or browser_connection["status"] != "connected":
+        store.complete_browser_publish_run(
+            user_id, run_id, error="Medium browser login required"
+        )
+        return
+    try:
+        rendered = render_clipboard_html(revision["content"])
+        article_html = _medium_article_fragment(rendered.html)
+        result = runner.medium_browser_upload(
+            organization_id=browser_connection["skyvern_organization_id"],
+            profile_id=browser_connection["skyvern_profile_id"],
+            title=revision["title"], article_html=article_html,
+            publish=run["mode"] == "publish",
+        )
+        if not result.get("success"):
+            error = result.get("error") or "Medium upload failed"
+            store.apply_push_result(
+                user_id, run["article_id"], "medium", success=False,
+                error=error, label="Browser upload failed",
+            )
+            store.complete_browser_publish_run(
+                user_id, run_id, result=result, error=error
+            )
+            return
+        store.apply_push_result(
+            user_id, run["article_id"], "medium", success=True,
+            url=result.get("url"), draft_id=result.get("draft_id"),
+            label="Published" if run["mode"] == "publish" else "Draft",
+            status="published" if run["mode"] == "publish" else "draft",
+        )
+        store.complete_browser_publish_run(user_id, run_id, result=result)
+    except Exception as exc:
+        store.apply_push_result(
+            user_id, run["article_id"], "medium", success=False,
+            error=str(exc)[:500], label="Browser upload failed",
+        )
+        store.complete_browser_publish_run(user_id, run_id, error=str(exc)[:500])
+
+
+EXECUTORS = {
+    "hashnode": execute_hashnode_run,
+    "medium": execute_medium_run,
+}

--- a/backend/services/cli_runner.py
+++ b/backend/services/cli_runner.py
@@ -162,6 +162,56 @@ def hashnode_browser_upload(
         raise RunnerUnavailable(f"Browser runner unavailable: {exc}") from exc
 
 
+def medium_browser_upload(
+    *, organization_id: str, profile_id: str, title: str, article_html: str,
+    publish: bool = False,
+) -> dict:
+    payload = {
+        "organization_id": organization_id, "profile_id": profile_id,
+        "title": title, "article_html": article_html, "publish": publish,
+    }
+    try:
+        with _client() as client:
+            response = client.post(
+                "/browser/medium/upload", json=payload,
+                timeout=httpx.Timeout(connect=3, read=300, write=30, pool=5),
+            )
+            response.raise_for_status()
+            return response.json()
+    except (httpx.ConnectError, httpx.HTTPStatusError, httpx.ReadTimeout) as exc:
+        raise RunnerUnavailable(f"Browser runner unavailable: {exc}") from exc
+
+
+def list_medium_browser_articles(*, organization_id: str, profile_id: str) -> list[dict]:
+    try:
+        with _client() as client:
+            response = client.get(
+                "/browser/medium/articles",
+                params={"organization_id": organization_id, "profile_id": profile_id},
+                timeout=httpx.Timeout(connect=3, read=180, write=10, pool=5),
+            )
+            response.raise_for_status()
+            return response.json().get("articles", [])
+    except (httpx.ConnectError, httpx.HTTPStatusError, httpx.ReadTimeout) as exc:
+        raise RunnerUnavailable(f"Browser runner unavailable: {exc}") from exc
+
+
+def get_medium_browser_article(
+    article_id: str, *, organization_id: str, profile_id: str,
+) -> dict:
+    try:
+        with _client() as client:
+            response = client.get(
+                f"/browser/medium/articles/{article_id}",
+                params={"organization_id": organization_id, "profile_id": profile_id},
+                timeout=httpx.Timeout(connect=3, read=180, write=10, pool=5),
+            )
+            response.raise_for_status()
+            return response.json()
+    except (httpx.ConnectError, httpx.HTTPStatusError, httpx.ReadTimeout) as exc:
+        raise RunnerUnavailable(f"Browser runner unavailable: {exc}") from exc
+
+
 def start_browser_login(platform: str, profile_id: str | None = None) -> dict:
     if profile_id:
         return _post(f"/browser/{platform}/login", profile_id=profile_id)

--- a/cli-runner/main.py
+++ b/cli-runner/main.py
@@ -33,7 +33,12 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from hashnode_browser import check_hashnode_profile, upload_hashnode_draft
-from medium_browser import check_medium_profile
+from medium_browser import (
+    check_medium_profile,
+    get_medium_article,
+    list_medium_articles,
+    upload_medium_draft,
+)
 from skyvern_browser import (
     SkyvernUnavailable,
     close_hashnode_login,
@@ -235,6 +240,14 @@ class HashnodeBrowserUploadRequest(BaseModel):
     publish: bool = False
 
 
+class MediumBrowserUploadRequest(BaseModel):
+    organization_id: str
+    profile_id: str
+    title: str
+    article_html: str
+    publish: bool = False
+
+
 class HashnodeBrowserLoginCompleteRequest(BaseModel):
     profile_name: str
     profile_id: Optional[str] = None
@@ -293,6 +306,48 @@ def hashnode_browser_upload(req: HashnodeBrowserUploadRequest):
         )
     except Exception as exc:
         return {"success": False, "error": _safe_reason(str(exc))}
+
+
+def _browser_profile_dir(organization_id: str, profile_id: str, platform: str):
+    try:
+        profile_dir = profile_directory(organization_id, profile_id)
+    except ValueError as exc:
+        raise HTTPException(422, str(exc)) from exc
+    if not profile_dir.is_dir():
+        raise HTTPException(409, f"{platform.title()} browser profile is unavailable")
+    return profile_dir
+
+
+@app.post("/browser/medium/upload")
+def medium_browser_upload(req: MediumBrowserUploadRequest):
+    profile_dir = _browser_profile_dir(req.organization_id, req.profile_id, "medium")
+    try:
+        return upload_medium_draft(
+            profile_dir=str(profile_dir), title=req.title,
+            article_html=req.article_html, publish=req.publish,
+        )
+    except Exception as exc:
+        return {"success": False, "error": _safe_reason(str(exc))}
+
+
+@app.get("/browser/medium/articles")
+def medium_browser_articles(organization_id: str, profile_id: str):
+    profile_dir = _browser_profile_dir(organization_id, profile_id, "medium")
+    try:
+        return list_medium_articles(profile_dir=str(profile_dir))
+    except Exception as exc:
+        raise HTTPException(502, _safe_reason(str(exc))) from exc
+
+
+@app.get("/browser/medium/articles/{article_id}")
+def medium_browser_article(article_id: str, organization_id: str, profile_id: str):
+    profile_dir = _browser_profile_dir(organization_id, profile_id, "medium")
+    try:
+        return get_medium_article(profile_dir=str(profile_dir), article_id=article_id)
+    except ValueError as exc:
+        raise HTTPException(422, str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(502, _safe_reason(str(exc))) from exc
 
 
 @app.post("/browser/hashnode/login", status_code=201)

--- a/cli-runner/medium_browser.py
+++ b/cli-runner/medium_browser.py
@@ -1,13 +1,272 @@
-"""Medium browser-profile checks for persistent Skyvern sessions."""
+"""Deterministic Medium operations using a persisted Skyvern browser profile."""
 from __future__ import annotations
 
 import json
+from html import unescape
 from pathlib import Path
 import sqlite3
 import time
+import re
 
 
 _CHROMIUM_EPOCH_OFFSET_SECONDS = 11_644_473_600
+
+
+_EDITOR_URL = "https://medium.com/new-story"
+_DRAFTS_URL = "https://medium.com/me/stories/drafts"
+_PUBLISHED_URL = "https://medium.com/me/stories/public"
+
+
+class MediumBrowserError(RuntimeError):
+    pass
+
+
+def _launch_context(playwright, profile_dir: str):
+    return playwright.chromium.launch_persistent_context(
+        profile_dir,
+        headless=True,
+        viewport={"width": 1440, "height": 1000},
+        permissions=["clipboard-read", "clipboard-write"],
+    )
+
+
+def _is_login_url(url: str) -> bool:
+    lowered = url.lower()
+    return any(part in lowered for part in ("/signin", "/m/signin", "/login"))
+
+
+def _story_id(url: str) -> str | None:
+    match = re.search(r"/p/([a-f0-9]+)/edit", url)
+    return match.group(1) if match else None
+
+
+def upload_medium_draft(
+    *, profile_dir: str, title: str, article_html: str, publish: bool = False,
+) -> dict:
+    """Create a Medium draft by pasting rendered HTML into the rich editor."""
+    from patchright.sync_api import sync_playwright
+
+    with sync_playwright() as playwright:
+        context = _launch_context(playwright, profile_dir)
+        page = context.pages[0] if context.pages else context.new_page()
+        try:
+            page.goto(_EDITOR_URL, wait_until="domcontentloaded", timeout=60_000)
+            if _is_login_url(page.url):
+                return {"success": False, "error": "Medium browser session is not authenticated"}
+            page.wait_for_selector('[contenteditable="true"]', timeout=30_000)
+
+            title_control = None
+            for selector in (
+                'h1[data-testid="storyTitle"]', '[data-placeholder="Title"]',
+                '[placeholder*="Title"]', 'h1[contenteditable="true"]',
+                '[contenteditable="true"]',
+            ):
+                candidate = page.locator(selector).first
+                try:
+                    if candidate.is_visible(timeout=1500):
+                        title_control = candidate
+                        break
+                except Exception:
+                    continue
+            if title_control is None:
+                raise MediumBrowserError("Medium title editor was not found")
+
+            title_control.click()
+            page.keyboard.press("Control+A")
+            page.keyboard.insert_text(title)
+            page.keyboard.press("End")
+            page.keyboard.press("Enter")
+            page.keyboard.press("Enter")
+
+            staging = context.new_page()
+            staging.set_content(f"<!doctype html><html><body>{article_html}</body></html>")
+            staging.locator("body").click()
+            staging.keyboard.press("Control+A")
+            staging.keyboard.press("Control+C")
+            staging.close()
+            page.bring_to_front()
+            page.keyboard.press("Control+V")
+
+            deadline = time.monotonic() + 25
+            while _story_id(page.url) is None and time.monotonic() < deadline:
+                page.wait_for_timeout(500)
+            draft_url = page.url
+            draft_id = _story_id(draft_url)
+            if draft_id is None:
+                return {"success": False, "error": "Medium draft autosave did not return an article id"}
+
+            page.wait_for_timeout(4_000)
+            page.reload(wait_until="domcontentloaded", timeout=60_000)
+            page.wait_for_selector('[contenteditable="true"]', timeout=30_000)
+            visible_text = " ".join(page.locator("body").inner_text().split())
+            expected_body = " ".join(
+                unescape(re.sub(r"<[^>]+>", " ", article_html)).split()
+            )
+            body_probe = expected_body[:120].strip()
+            if title not in visible_text or (body_probe and body_probe not in visible_text):
+                return {
+                    "success": False,
+                    "error": "Medium draft autosave could not be verified",
+                    "url": draft_url,
+                    "draft_id": draft_id,
+                }
+
+            result_url = draft_url
+            status = "draft"
+            if publish:
+                publish_button = page.get_by_role("button", name=re.compile("^Publish$", re.I)).first
+                if not publish_button.is_visible(timeout=5_000):
+                    publish_button = page.locator('[data-action*="publish"]').first
+                publish_button.click()
+                page.wait_for_timeout(1_000)
+                confirm = page.get_by_role("button", name=re.compile("^Publish", re.I)).last
+                if not confirm.is_visible(timeout=10_000):
+                    raise MediumBrowserError("Medium publish confirmation was not found")
+                confirm.click()
+                deadline = time.monotonic() + 45
+                while "/edit" in page.url and time.monotonic() < deadline:
+                    page.wait_for_timeout(500)
+                result_url = page.url
+                status = "published"
+                if "/edit" in result_url:
+                    return {
+                        "success": False,
+                        "error": "Medium public publish could not be verified",
+                        "url": draft_url,
+                        "draft_id": draft_id,
+                    }
+
+            return {
+                "success": True,
+                "method": "deterministic",
+                "status": status,
+                "url": result_url,
+                "draft_id": draft_id,
+            }
+        finally:
+            context.close()
+
+
+def list_medium_articles(*, profile_dir: str) -> dict:
+    """List the signed-in user's Medium drafts and published stories."""
+    from patchright.sync_api import sync_playwright
+
+    with sync_playwright() as playwright:
+        context = _launch_context(playwright, profile_dir)
+        page = context.pages[0] if context.pages else context.new_page()
+        try:
+            articles: list[dict] = []
+            for status, url in (("draft", _DRAFTS_URL), ("published", _PUBLISHED_URL)):
+                page.goto(url, wait_until="domcontentloaded", timeout=60_000)
+                if _is_login_url(page.url):
+                    raise MediumBrowserError("Medium browser session is not authenticated")
+                page.wait_for_timeout(2_000)
+                for _ in range(8):
+                    previous = page.locator("h2").count()
+                    page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+                    page.wait_for_timeout(700)
+                    if page.locator("h2").count() == previous:
+                        break
+                rows = page.evaluate(
+                    r"""(status) => Array.from(document.querySelectorAll('h2')).map((heading) => {
+                      const container = heading.closest('article') || heading.parentElement?.parentElement?.parentElement;
+                      const links = Array.from((container || heading.parentElement).querySelectorAll('a[href]'));
+                      const edit = links.find((link) => /\/p\/[a-f0-9]+\/edit/.test(link.href));
+                      const storyLink = heading.closest('a[href]') || links.find((link) => link.innerText.trim() === heading.innerText.trim());
+                      const publicLink = storyLink || links.find((link) => link.href.includes('medium.com/') && !link.href.includes('/me/stories'));
+                      const href = (status === 'draft' ? edit : publicLink) || edit || publicLink;
+                      const text = (container?.innerText || '').replace(/\s+/g, ' ').trim();
+                      const words = text.match(/\((\d+)\s+words\)/i);
+                      const idMatch = edit?.href.match(/\/p\/([a-f0-9]+)\/edit/);
+                      const publicId = publicLink?.href.match(/-([a-f0-9]{12})(?:[/?#]|$)/)?.[1];
+                      const dataId = container?.getAttribute('data-post-id') || container?.querySelector('[data-post-id]')?.getAttribute('data-post-id');
+                      return {
+                        id: idMatch?.[1] || dataId || publicId || '', title: heading.innerText.trim(),
+                        url: href?.href?.split('?')[0] || '', status,
+                        word_count: words ? Number(words[1]) : 0,
+                        updated_at: '', snippet: text.slice(0, 280),
+                      };
+                    }).filter((item) => item.id && item.title)""",
+                    status,
+                )
+                articles.extend(rows)
+            deduped = {f"{item['status']}:{item['id']}": item for item in articles}
+            return {"articles": list(deduped.values())}
+        finally:
+            context.close()
+
+
+def get_medium_article(*, profile_dir: str, article_id: str) -> dict:
+    """Retrieve Medium article metadata and a Markdown representation of its body."""
+    from patchright.sync_api import sync_playwright
+
+    if not re.fullmatch(r"[A-Za-z0-9_-]+", article_id):
+        raise ValueError("Invalid Medium article id")
+    with sync_playwright() as playwright:
+        context = _launch_context(playwright, profile_dir)
+        page = context.pages[0] if context.pages else context.new_page()
+        try:
+            page.goto(
+                f"https://medium.com/p/{article_id}/edit",
+                wait_until="domcontentloaded", timeout=60_000,
+            )
+            if _is_login_url(page.url):
+                raise MediumBrowserError("Medium browser session is not authenticated")
+            page.wait_for_timeout(2_000)
+            article = page.evaluate(
+                r"""(articleId) => {
+                  const root = document.querySelector('.postArticle-content, article, [data-testid="richTextEditor"], .pw-editor');
+                  if (!root) return null;
+                  const clone = root.cloneNode(true);
+                  const titleNode = clone.querySelector('h1, h2.graf--title, [data-testid="storyTitle"]');
+                  const title = (titleNode?.innerText || document.title.replace(/^Editing /, '').replace(/ – Medium$/, '')).trim();
+                  if (titleNode) titleNode.remove();
+                  const render = (node) => {
+                    if (node.nodeType === Node.TEXT_NODE) return node.textContent;
+                    if (node.nodeType !== Node.ELEMENT_NODE) return '';
+                    const tag = node.tagName.toLowerCase();
+                    const inside = Array.from(node.childNodes).map(render).join('');
+                    if (tag === 'img') return `![${node.alt || ''}](${node.src || ''})`;
+                    if (tag === 'a') return `[${inside}](${node.href})`;
+                    if (tag === 'strong' || tag === 'b') return `**${inside}**`;
+                    if (tag === 'em' || tag === 'i') return `*${inside}*`;
+                    if (tag === 'code' && node.parentElement?.tagName.toLowerCase() !== 'pre') return `\`${inside}\``;
+                    if (tag === 'pre') return `\n\n\`\`\`\n${node.innerText}\n\`\`\`\n\n`;
+                    if (tag === 'h2') return `\n\n## ${inside.trim()}\n\n`;
+                    if (tag === 'h3') return `\n\n### ${inside.trim()}\n\n`;
+                    if (tag === 'blockquote') return `\n\n> ${node.innerText.replace(/\n/g, '\n> ')}\n\n`;
+                    if (tag === 'li') return `\n- ${inside.trim()}`;
+                    if (tag === 'p' || tag === 'figure') return `\n\n${inside.trim()}\n\n`;
+                    if (tag === 'br') return '\n';
+                    return inside;
+                  };
+                  const jsonLd = Array.from(document.querySelectorAll('script[type="application/ld+json"]'))
+                    .map((node) => { try { return JSON.parse(node.textContent); } catch (_) { return null; } })
+                    .find((value) => value?.articleId === articleId) || {};
+                  const stateText = Array.from(document.scripts).map((node) => node.textContent || '').find((text) => text.includes('canonicalUrl')) || '';
+                  const canonicalMatch = stateText.match(/"canonicalUrl":"([^"]*)"/);
+                  const mediumUrlMatch = stateText.match(/"mediumUrl":"([^"]*)"/);
+                  const publishedMatch = stateText.match(/"latestPublishedAt":(\d+)/);
+                  const canonicalUrl = canonicalMatch?.[1] || mediumUrlMatch?.[1] || '';
+                  return {
+                    id: articleId, title, body: render(clone).replace(/\n{3,}/g, '\n\n').trim(),
+                    word_count: Number(jsonLd.wordCount || 0),
+                    updated_at: jsonLd.dateModified || '',
+                    status: Number(publishedMatch?.[1] || 0) > 0 ? 'published' : 'draft',
+                    canonical_url: canonicalUrl || (jsonLd.url && !jsonLd.url.endsWith('/edit') ? jsonLd.url : null),
+                    cover_image: typeof jsonLd.image === 'string' ? jsonLd.image : jsonLd.image?.url || null,
+                  };
+                }""",
+                article_id,
+            )
+            if not article:
+                raise MediumBrowserError("Medium article content was not found")
+            if not article["word_count"]:
+                article["word_count"] = len(article["body"].split())
+            return article
+        finally:
+            context.close()
+
 def check_medium_profile(*, profile_dir: str) -> dict:
     profile = Path(profile_dir)
     authenticated = _chromium_cookie_db_has_medium_session(profile)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ cryptography>=42.0.0
 email-validator>=2.1.0
 fastapi>=0.111.0
 httpx>=0.27.0
+markdown-it-py>=3.0.0
 python-multipart>=0.0.9
 PyYAML>=6.0.0
 requests>=2.31.0

--- a/tests/tests_backend/test_browser_publish.py
+++ b/tests/tests_backend/test_browser_publish.py
@@ -14,6 +14,16 @@ def _connect() -> None:
     )
 
 
+def _connect_medium() -> None:
+    store.start_browser_connection(
+        "user_seed", "medium", session_id="pbs_medium",
+        organization_id="o_medium", app_url="http://localhost/login",
+    )
+    store.update_browser_connection(
+        "user_seed", "medium", "connected", profile_id="bp_medium"
+    )
+
+
 def test_browser_publish_requires_approval_and_completes(client, monkeypatch):
     _connect()
     seen = {}
@@ -75,6 +85,51 @@ def test_public_publish_mode_is_durable_and_updates_destination(client, monkeypa
     assert article["destinations"]["hashnode"]["url"] == (
         "https://example.hashnode.dev/test"
     )
+
+
+def test_medium_browser_publish_renders_html_and_dispatches_medium_worker(
+    client, monkeypatch,
+):
+    _connect_medium()
+    seen = {}
+    monkeypatch.setattr(
+        browser_publish.runner,
+        "medium_browser_upload",
+        lambda **kwargs: seen.update(kwargs) or {
+            "success": True,
+            "method": "deterministic",
+            "status": "draft",
+            "url": "https://medium.com/p/abc123/edit",
+            "draft_id": "abc123",
+        },
+    )
+
+    run = client.post(
+        "/api/articles/art_001/browser-publish/medium",
+    ).json()
+    approved = client.post(
+        f"/api/articles/art_001/browser-publish/{run['id']}/approve"
+    )
+
+    assert approved.status_code == 202
+    assert seen["profile_id"] == "bp_medium"
+    assert seen["organization_id"] == "o_medium"
+    assert "<!doctype" not in seen["article_html"].lower()
+    assert "<article" not in seen["article_html"].lower()
+    assert "<h1" not in seen["article_html"].lower()
+    assert len(seen["article_html"]) > 20
+    assert seen["publish"] is False
+    persisted = client.get(
+        f"/api/articles/art_001/browser-publish/{run['id']}"
+    ).json()
+    assert persisted["status"] == "completed"
+    article = client.get("/api/articles/art_001").json()
+    assert article["destinations"]["medium"]["status"] == "draft"
+
+
+def test_medium_browser_publish_requires_connected_profile(client):
+    response = client.post("/api/articles/art_001/browser-publish/medium")
+    assert response.status_code == 409
 
 
 def test_browser_publish_cannot_be_approved_twice(client, monkeypatch):

--- a/tests/tests_backend/test_browser_publish.py
+++ b/tests/tests_backend/test_browser_publish.py
@@ -127,6 +127,19 @@ def test_medium_browser_publish_renders_html_and_dispatches_medium_worker(
     assert article["destinations"]["medium"]["status"] == "draft"
 
 
+def test_medium_fragment_removes_title_after_leading_content():
+    rendered = (
+        "<article><blockquote>Context first</blockquote>"
+        "<h1>Article title</h1><p>Article body</p></article>"
+    )
+
+    fragment = browser_publish._medium_article_fragment(rendered)
+
+    assert "<h1>" not in fragment
+    assert "<blockquote>Context first</blockquote>" in fragment
+    assert "<p>Article body</p>" in fragment
+
+
 def test_medium_browser_publish_requires_connected_profile(client):
     response = client.post("/api/articles/art_001/browser-publish/medium")
     assert response.status_code == 409

--- a/tests/tests_backend/test_connections_drafts.py
+++ b/tests/tests_backend/test_connections_drafts.py
@@ -303,6 +303,32 @@ class TestListDraftsUnit:
         assert body["total"] == len(_MOCK_DRAFTS["medium"])
         assert len(body["drafts"]) > 0
 
+    def test_list_medium_uses_connected_browser_profile(self, client: TestClient):
+        store.start_browser_connection(
+            "user_seed", "medium", session_id="pbs_medium",
+            organization_id="o_medium", app_url="http://localhost/login",
+        )
+        store.update_browser_connection(
+            "user_seed", "medium", "connected", profile_id="bp_medium"
+        )
+        payload = [{
+            "id": "medium-1", "title": "A live Medium draft",
+            "snippet": "Retrieved in the browser", "word_count": 42,
+            "updated_at": "2026-08-20T00:00:00Z", "status": "draft",
+        }]
+
+        with patch(
+            "backend.routers.connections.runner.list_medium_browser_articles",
+            return_value=payload,
+        ) as fetch:
+            response = client.get("/api/connections/medium/drafts")
+
+        assert response.status_code == 200
+        assert response.json()["drafts"][0]["title"] == "A live Medium draft"
+        fetch.assert_called_once_with(
+            organization_id="o_medium", profile_id="bp_medium"
+        )
+
 
 class TestGetDraftUnit:
 
@@ -414,6 +440,33 @@ class TestGetDraftUnit:
         body = r.json()
         assert body["id"] == first_id
         assert len(body["body"]) > 0
+
+    def test_get_medium_article_uses_connected_browser_profile(self, client: TestClient):
+        store.start_browser_connection(
+            "user_seed", "medium", session_id="pbs_medium",
+            organization_id="o_medium", app_url="http://localhost/login",
+        )
+        store.update_browser_connection(
+            "user_seed", "medium", "connected", profile_id="bp_medium"
+        )
+        payload = {
+            "id": "medium-1", "title": "A live Medium draft",
+            "body": "# Retrieved\n\nReal browser content.", "word_count": 3,
+            "updated_at": "2026-08-20T00:00:00Z", "status": "draft",
+            "canonical_url": None, "cover_image": None,
+        }
+
+        with patch(
+            "backend.routers.connections.runner.get_medium_browser_article",
+            return_value=payload,
+        ) as fetch:
+            response = client.get("/api/connections/medium/drafts/medium-1")
+
+        assert response.status_code == 200
+        assert response.json()["body"].startswith("# Retrieved")
+        fetch.assert_called_once_with(
+            "medium-1", organization_id="o_medium", profile_id="bp_medium"
+        )
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- publish Medium drafts deterministically through the persisted browser profile
- expose Medium article lists, content, metadata, revisions, and publish status through the backend APIs
- retrieve editor content as Markdown, including image references and canonical metadata
- verify draft autosave and published URLs before reporting success
- remove the rendered title H1 even when source content appears before it

## Stack

- base: `feat/43-login` (PR #45)
- this PR contains only publishing and retrieval behavior

## Validation

- `43 passed, 2 deselected`: browser publishing, connections, drafts, Skyvern, and Medium tests
- includes a regression test for a title H1 after leading content
- `git diff --check`

Closes #43
