### PR TITLE
feat: add Medium browser login

### DIFF
--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -52,6 +52,7 @@ _VALID_IDS = {"medium", "hashnode", "devto", "anthropic", "openai"}
 _BLOG_IDS = {"medium", "hashnode", "devto"}
 _CLI_IDS = {"anthropic", "openai"}
 _PROVIDER_MAP = {"anthropic": "anthropic", "openai": "openai"}
+_BROWSER_LOGIN_IDS = {"medium", "hashnode"}
 
 # ── Mock draft data ───────────────────────────────────────────────────────────
 # Real implementation would call each platform's API with the stored token.
@@ -487,9 +488,9 @@ class SubmitCodeRequest(BaseModel):
     code: str
 
 
-def _browser_connection_response(connection: dict | None) -> dict:
+def _browser_connection_response(platform: str, connection: dict | None) -> dict:
     if connection is None:
-        return {"platform": "hashnode", "status": "disconnected"}
+        return {"platform": platform, "status": "disconnected"}
     return {
         "platform": connection["platform"],
         "status": connection["status"],
@@ -505,92 +506,122 @@ def _browser_connection_response(connection: dict | None) -> dict:
 
 @router.get("/hashnode/browser-connection")
 def get_hashnode_browser_connection(request: Request):
+    return get_browser_connection(request, "hashnode")
+
+
+@router.get("/{conn_id}/browser-connection")
+def get_browser_connection(request: Request, conn_id: str):
+    if conn_id not in _BROWSER_LOGIN_IDS:
+        raise HTTPException(status_code=400, detail=f"{conn_id} does not support browser login")
     return _browser_connection_response(
-        store.get_browser_connection(request.state.user_id, "hashnode")
+        conn_id,
+        store.get_browser_connection(request.state.user_id, conn_id)
     )
 
 
 @router.post("/hashnode/browser-connection", status_code=201)
 def start_hashnode_browser_connection(request: Request):
-    previous = store.get_browser_connection(request.state.user_id, "hashnode")
+    return start_browser_connection(request, "hashnode")
+
+
+@router.post("/{conn_id}/browser-connection", status_code=201)
+def start_browser_connection(request: Request, conn_id: str):
+    if conn_id not in _BROWSER_LOGIN_IDS:
+        raise HTTPException(status_code=400, detail=f"{conn_id} does not support browser login")
+    previous = store.get_browser_connection(request.state.user_id, conn_id)
     if previous and previous.get("skyvern_session_id") and previous["status"] == "waiting_for_login":
         try:
-            runner.cancel_hashnode_browser_login(previous["skyvern_session_id"])
+            runner.cancel_browser_login(conn_id, previous["skyvern_session_id"])
         except runner.RunnerUnavailable:
             pass
     reusable_profile_id = previous.get("skyvern_profile_id") if previous else None
     try:
-        session = runner.start_hashnode_browser_login(reusable_profile_id)
+        session = runner.start_browser_login(conn_id, reusable_profile_id)
     except runner.RunnerUnavailable as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
     connection = store.start_browser_connection(
         request.state.user_id,
-        "hashnode",
+        conn_id,
         session_id=session["session_id"],
         organization_id=session["organization_id"],
         app_url=session["app_url"],
         profile_id=reusable_profile_id,
     )
-    return _browser_connection_response(connection)
+    return _browser_connection_response(conn_id, connection)
 
 
 @router.post("/hashnode/browser-connection/complete")
 def complete_hashnode_browser_connection(request: Request):
+    return complete_browser_connection(request, "hashnode")
+
+
+@router.post("/{conn_id}/browser-connection/complete")
+def complete_browser_connection(request: Request, conn_id: str):
+    if conn_id not in _BROWSER_LOGIN_IDS:
+        raise HTTPException(status_code=400, detail=f"{conn_id} does not support browser login")
     user_id = request.state.user_id
-    connection = store.get_browser_connection(user_id, "hashnode")
+    connection = store.get_browser_connection(user_id, conn_id)
     if not connection or connection["status"] != "waiting_for_login":
-        raise HTTPException(status_code=409, detail="No Hashnode browser login is active")
-    store.update_browser_connection(user_id, "hashnode", "verifying")
-    profile_name = "bloghub-" + hashlib.sha256(user_id.encode()).hexdigest()[:16]
+        raise HTTPException(status_code=409, detail=f"No {conn_id.title()} browser login is active")
+    store.update_browser_connection(user_id, conn_id, "verifying")
+    profile_name = f"bloghub-{conn_id}-" + hashlib.sha256(user_id.encode()).hexdigest()[:16]
     try:
-        result = runner.complete_hashnode_browser_login(
+        result = runner.complete_browser_login(
+            conn_id,
             connection["skyvern_session_id"],
             profile_name,
             profile_id=connection.get("skyvern_profile_id"),
             organization_id=connection.get("skyvern_organization_id"),
         )
     except runner.RunnerUnavailable as exc:
-        store.update_browser_connection(user_id, "hashnode", "failed", error=str(exc))
+        store.update_browser_connection(user_id, conn_id, "failed", error=str(exc))
         raise HTTPException(status_code=503, detail=str(exc)) from exc
     if not result.get("authenticated"):
         failed = store.update_browser_connection(
-            user_id, "hashnode", "failed",
+            user_id, conn_id, "failed",
             profile_id=result.get("profile_id"),
-            error="Hashnode sign-in was not completed in the browser",
+            error=f"{conn_id.title()} sign-in was not completed in the browser",
         )
-        return _browser_connection_response(failed)
+        return _browser_connection_response(conn_id, failed)
     if result.get("organization_id") != connection["skyvern_organization_id"]:
         if result.get("profile_id"):
             try:
-                runner.delete_hashnode_browser_profile(result["profile_id"])
+                runner.delete_browser_profile(conn_id, result["profile_id"])
             except runner.RunnerUnavailable:
                 pass
         failed = store.update_browser_connection(
-            user_id, "hashnode", "failed",
+            user_id, conn_id, "failed",
             error="Browser profile ownership could not be verified",
         )
-        return _browser_connection_response(failed)
+        return _browser_connection_response(conn_id, failed)
     connected = store.update_browser_connection(
-        user_id, "hashnode", "connected", profile_id=result["profile_id"]
+        user_id, conn_id, "connected", profile_id=result["profile_id"]
     )
-    return _browser_connection_response(connected)
+    return _browser_connection_response(conn_id, connected)
 
 
 @router.delete("/hashnode/browser-connection")
 def disconnect_hashnode_browser_connection(request: Request):
-    connection = store.get_browser_connection(request.state.user_id, "hashnode")
+    return disconnect_browser_connection(request, "hashnode")
+
+
+@router.delete("/{conn_id}/browser-connection")
+def disconnect_browser_connection(request: Request, conn_id: str):
+    if conn_id not in _BROWSER_LOGIN_IDS:
+        raise HTTPException(status_code=400, detail=f"{conn_id} does not support browser login")
+    connection = store.get_browser_connection(request.state.user_id, conn_id)
     if connection and connection.get("skyvern_session_id") and connection["status"] == "waiting_for_login":
         try:
-            runner.cancel_hashnode_browser_login(connection["skyvern_session_id"])
+            runner.cancel_browser_login(conn_id, connection["skyvern_session_id"])
         except runner.RunnerUnavailable as exc:
             raise HTTPException(status_code=503, detail=str(exc)) from exc
     if connection and connection.get("skyvern_profile_id"):
         try:
-            runner.delete_hashnode_browser_profile(connection["skyvern_profile_id"])
+            runner.delete_browser_profile(conn_id, connection["skyvern_profile_id"])
         except runner.RunnerUnavailable as exc:
             raise HTTPException(status_code=503, detail=str(exc)) from exc
-    store.delete_browser_connection(request.state.user_id, "hashnode")
-    return {"platform": "hashnode", "status": "disconnected"}
+    store.delete_browser_connection(request.state.user_id, conn_id)
+    return {"platform": conn_id, "status": "disconnected"}
 
 
 @router.post("/{conn_id}/submit-code")

--- a/backend/services/cli_runner.py
+++ b/backend/services/cli_runner.py
@@ -162,26 +162,51 @@ def hashnode_browser_upload(
         raise RunnerUnavailable(f"Browser runner unavailable: {exc}") from exc
 
 
-def start_hashnode_browser_login(profile_id: str | None = None) -> dict:
+def start_browser_login(platform: str, profile_id: str | None = None) -> dict:
     if profile_id:
-        return _post("/browser/hashnode/login", profile_id=profile_id)
-    return _post("/browser/hashnode/login")
+        return _post(f"/browser/{platform}/login", profile_id=profile_id)
+    return _post(f"/browser/{platform}/login")
+
+
+def start_hashnode_browser_login(profile_id: str | None = None) -> dict:
+    return start_browser_login("hashnode", profile_id)
+
+
+def start_medium_browser_login(profile_id: str | None = None) -> dict:
+    return start_browser_login("medium", profile_id)
+
+
+def get_browser_login(platform: str, session_id: str) -> dict:
+    return _get(f"/browser/{platform}/login/{session_id}")
 
 
 def get_hashnode_browser_login(session_id: str) -> dict:
-    return _get(f"/browser/hashnode/login/{session_id}")
+    return get_browser_login("hashnode", session_id)
 
 
-def cancel_hashnode_browser_login(session_id: str) -> None:
+def get_medium_browser_login(session_id: str) -> dict:
+    return get_browser_login("medium", session_id)
+
+
+def cancel_browser_login(platform: str, session_id: str) -> None:
     try:
         with _client() as client:
-            response = client.delete(f"/browser/hashnode/login/{session_id}")
+            response = client.delete(f"/browser/{platform}/login/{session_id}")
             response.raise_for_status()
     except (httpx.ConnectError, httpx.HTTPStatusError, httpx.ReadTimeout) as exc:
         raise RunnerUnavailable(f"Browser login runner unavailable: {exc}") from exc
 
 
-def complete_hashnode_browser_login(
+def cancel_hashnode_browser_login(session_id: str) -> None:
+    cancel_browser_login("hashnode", session_id)
+
+
+def cancel_medium_browser_login(session_id: str) -> None:
+    cancel_browser_login("medium", session_id)
+
+
+def complete_browser_login(
+    platform: str,
     session_id: str,
     profile_name: str,
     *,
@@ -191,7 +216,7 @@ def complete_hashnode_browser_login(
     try:
         with _client() as client:
             response = client.post(
-                f"/browser/hashnode/login/{session_id}/complete",
+                f"/browser/{platform}/login/{session_id}/complete",
                 json={
                     "profile_name": profile_name,
                     "profile_id": profile_id,
@@ -205,13 +230,53 @@ def complete_hashnode_browser_login(
         raise RunnerUnavailable(f"Browser login runner unavailable: {exc}") from exc
 
 
-def delete_hashnode_browser_profile(profile_id: str) -> None:
+def complete_hashnode_browser_login(
+    session_id: str,
+    profile_name: str,
+    *,
+    profile_id: str | None = None,
+    organization_id: str | None = None,
+) -> dict:
+    return complete_browser_login(
+        "hashnode",
+        session_id,
+        profile_name,
+        profile_id=profile_id,
+        organization_id=organization_id,
+    )
+
+
+def complete_medium_browser_login(
+    session_id: str,
+    profile_name: str,
+    *,
+    profile_id: str | None = None,
+    organization_id: str | None = None,
+) -> dict:
+    return complete_browser_login(
+        "medium",
+        session_id,
+        profile_name,
+        profile_id=profile_id,
+        organization_id=organization_id,
+    )
+
+
+def delete_browser_profile(platform: str, profile_id: str) -> None:
     try:
         with _client() as client:
-            response = client.delete(f"/browser/hashnode/profiles/{profile_id}")
+            response = client.delete(f"/browser/{platform}/profiles/{profile_id}")
             response.raise_for_status()
     except (httpx.ConnectError, httpx.HTTPStatusError, httpx.ReadTimeout) as exc:
         raise RunnerUnavailable(f"Browser login runner unavailable: {exc}") from exc
+
+
+def delete_hashnode_browser_profile(profile_id: str) -> None:
+    delete_browser_profile("hashnode", profile_id)
+
+
+def delete_medium_browser_profile(profile_id: str) -> None:
+    delete_browser_profile("medium", profile_id)
 
 
 def run_task(

--- a/cli-runner/Dockerfile
+++ b/cli-runner/Dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 RUN patchright install --with-deps chromium
-COPY main.py hashnode_browser.py skyvern_browser.py browser_selectors.json ./
+COPY main.py hashnode_browser.py medium_browser.py skyvern_browser.py browser_selectors.json ./
 
 # Credential directories (will be overridden by named volumes in docker-compose)
 RUN mkdir -p /root/.claude /root/.config/openai /data/skyvern-browser-sessions

--- a/cli-runner/main.py
+++ b/cli-runner/main.py
@@ -33,14 +33,20 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from hashnode_browser import check_hashnode_profile, upload_hashnode_draft
+from medium_browser import check_medium_profile
 from skyvern_browser import (
     SkyvernUnavailable,
     close_hashnode_login,
+    close_medium_login,
     delete_hashnode_profile,
+    delete_medium_profile,
     finish_hashnode_login,
+    finish_medium_login,
     get_hashnode_login,
+    get_medium_login,
     profile_directory,
     start_hashnode_login,
+    start_medium_login,
 )
 
 app = FastAPI(title="BlogHub CLI Runner", version="0.1.0")
@@ -245,6 +251,32 @@ class HashnodeBrowserProfileRequest(BaseModel):
 
 _chat_processes: dict[str, subprocess.Popen] = {}
 
+_BROWSER_LOGIN = {
+    "hashnode": {
+        "start": start_hashnode_login,
+        "get": get_hashnode_login,
+        "close": close_hashnode_login,
+        "finish": finish_hashnode_login,
+        "delete": delete_hashnode_profile,
+        "check": check_hashnode_profile,
+    },
+    "medium": {
+        "start": start_medium_login,
+        "get": get_medium_login,
+        "close": close_medium_login,
+        "finish": finish_medium_login,
+        "delete": delete_medium_profile,
+        "check": check_medium_profile,
+    },
+}
+
+
+def _browser_provider(platform: str) -> dict:
+    provider = _BROWSER_LOGIN.get(platform)
+    if provider is None:
+        raise HTTPException(404, f"{platform} does not support browser login")
+    return provider
+
 
 @app.post("/browser/hashnode/upload")
 def hashnode_browser_upload(req: HashnodeBrowserUploadRequest):
@@ -265,8 +297,13 @@ def hashnode_browser_upload(req: HashnodeBrowserUploadRequest):
 
 @app.post("/browser/hashnode/login", status_code=201)
 def hashnode_browser_login(req: Optional[HashnodeBrowserLoginRequest] = None):
+    return browser_login("hashnode", req)
+
+
+@app.post("/browser/{platform}/login", status_code=201)
+def browser_login(platform: str, req: Optional[HashnodeBrowserLoginRequest] = None):
     try:
-        return start_hashnode_login(req.profile_id if req else None)
+        return _browser_provider(platform)["start"](req.profile_id if req else None)
     except ValueError as exc:
         raise HTTPException(422, str(exc)) from exc
     except SkyvernUnavailable as exc:
@@ -275,8 +312,13 @@ def hashnode_browser_login(req: Optional[HashnodeBrowserLoginRequest] = None):
 
 @app.get("/browser/hashnode/login/{session_id}")
 def hashnode_browser_login_status(session_id: str):
+    return browser_login_status("hashnode", session_id)
+
+
+@app.get("/browser/{platform}/login/{session_id}")
+def browser_login_status(platform: str, session_id: str):
     try:
-        return get_hashnode_login(session_id)
+        return _browser_provider(platform)["get"](session_id)
     except ValueError as exc:
         raise HTTPException(422, str(exc)) from exc
     except SkyvernUnavailable as exc:
@@ -285,8 +327,13 @@ def hashnode_browser_login_status(session_id: str):
 
 @app.delete("/browser/hashnode/login/{session_id}")
 def hashnode_browser_login_cancel(session_id: str):
+    return browser_login_cancel("hashnode", session_id)
+
+
+@app.delete("/browser/{platform}/login/{session_id}")
+def browser_login_cancel(platform: str, session_id: str):
     try:
-        close_hashnode_login(session_id)
+        _browser_provider(platform)["close"](session_id)
         return {"status": "canceled"}
     except ValueError as exc:
         raise HTTPException(422, str(exc)) from exc
@@ -298,14 +345,22 @@ def hashnode_browser_login_cancel(session_id: str):
 def hashnode_browser_login_complete(
     session_id: str, req: HashnodeBrowserLoginCompleteRequest,
 ):
+    return browser_login_complete("hashnode", session_id, req)
+
+
+@app.post("/browser/{platform}/login/{session_id}/complete")
+def browser_login_complete(
+    platform: str, session_id: str, req: HashnodeBrowserLoginCompleteRequest,
+):
     try:
-        profile = finish_hashnode_login(
+        provider = _browser_provider(platform)
+        profile = provider["finish"](
             session_id,
             req.profile_name,
             profile_id=req.profile_id,
             organization_id=req.organization_id,
         )
-        verification = check_hashnode_profile(profile_dir=profile["profile_dir"])
+        verification = provider["check"](profile_dir=profile["profile_dir"])
         return {**verification, **profile}
     except ValueError as exc:
         raise HTTPException(422, str(exc)) from exc
@@ -317,8 +372,13 @@ def hashnode_browser_login_complete(
 
 @app.delete("/browser/hashnode/profiles/{profile_id}")
 def hashnode_browser_profile_delete(profile_id: str):
+    return browser_profile_delete("hashnode", profile_id)
+
+
+@app.delete("/browser/{platform}/profiles/{profile_id}")
+def browser_profile_delete(platform: str, profile_id: str):
     try:
-        delete_hashnode_profile(profile_id)
+        _browser_provider(platform)["delete"](profile_id)
         return {"status": "disconnected"}
     except ValueError as exc:
         raise HTTPException(422, str(exc)) from exc

--- a/cli-runner/medium_browser.py
+++ b/cli-runner/medium_browser.py
@@ -1,0 +1,87 @@
+"""Medium browser-profile checks for persistent Skyvern sessions."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sqlite3
+import time
+def check_medium_profile(*, profile_dir: str) -> dict:
+    profile = Path(profile_dir)
+    authenticated = _chromium_cookie_db_has_medium_session(profile)
+    if not authenticated:
+        authenticated = _cookie_snapshot_has_medium_session(profile)
+    return {
+        "authenticated": authenticated,
+        "status": "connected" if authenticated else "login_required",
+    }
+
+
+def _is_medium_session_cookie(domain: object, name: object) -> bool:
+    normalized_domain = str(domain or "").lstrip(".")
+    return (
+        normalized_domain == "medium.com"
+        and str(name or "") in {"sid", "uid", "lightstep_guid"}
+    )
+
+
+def _cookie_is_not_expired(expires: object) -> bool:
+    try:
+        value = float(expires)
+    except (TypeError, ValueError):
+        return True
+    return value < 0 or value > time.time()
+
+
+def _chromium_cookie_db_has_medium_session(profile: Path) -> bool:
+    candidates = [
+        profile / "Default" / "Cookies",
+        profile / "Cookies",
+    ]
+    for db_path in candidates:
+        if not db_path.exists():
+            continue
+        try:
+            connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+            rows = connection.execute(
+                "SELECT host_key, name, expires_utc, value, encrypted_value FROM cookies"
+            ).fetchall()
+        except sqlite3.Error:
+            continue
+        finally:
+            try:
+                connection.close()
+            except Exception:
+                pass
+        has_uid = False
+        has_sid = False
+        for domain, name, expires_utc, value, encrypted_value in rows:
+            if not _is_medium_session_cookie(domain, name):
+                continue
+            if expires_utc and int(expires_utc) < 10_000_000_000_000_000:
+                continue
+            if not (value or encrypted_value):
+                continue
+            has_uid = has_uid or name == "uid"
+            has_sid = has_sid or name == "sid"
+        if has_uid and has_sid:
+            return True
+    return False
+
+
+def _cookie_snapshot_has_medium_session(profile: Path) -> bool:
+    snapshot = profile / ".skyvern_session_cookies.json"
+    try:
+        cookies = json.loads(snapshot.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(cookies, list):
+        return False
+    names = {
+        str(cookie.get("name") or "")
+        for cookie in cookies
+        if isinstance(cookie, dict)
+        and _is_medium_session_cookie(cookie.get("domain"), cookie.get("name"))
+        and _cookie_is_not_expired(cookie.get("expires"))
+        and cookie.get("value")
+    }
+    return {"sid", "uid"}.issubset(names)

--- a/cli-runner/medium_browser.py
+++ b/cli-runner/medium_browser.py
@@ -5,6 +5,9 @@ import json
 from pathlib import Path
 import sqlite3
 import time
+
+
+_CHROMIUM_EPOCH_OFFSET_SECONDS = 11_644_473_600
 def check_medium_profile(*, profile_dir: str) -> dict:
     profile = Path(profile_dir)
     authenticated = _chromium_cookie_db_has_medium_session(profile)
@@ -32,6 +35,17 @@ def _cookie_is_not_expired(expires: object) -> bool:
     return value < 0 or value > time.time()
 
 
+def _chromium_cookie_is_not_expired(expires_utc: object) -> bool:
+    try:
+        value = int(expires_utc)
+    except (TypeError, ValueError):
+        return False
+    if value == 0:
+        return True
+    expires_unix = value / 1_000_000 - _CHROMIUM_EPOCH_OFFSET_SECONDS
+    return expires_unix > time.time()
+
+
 def _chromium_cookie_db_has_medium_session(profile: Path) -> bool:
     candidates = [
         profile / "Default" / "Cookies",
@@ -57,7 +71,7 @@ def _chromium_cookie_db_has_medium_session(profile: Path) -> bool:
         for domain, name, expires_utc, value, encrypted_value in rows:
             if not _is_medium_session_cookie(domain, name):
                 continue
-            if expires_utc and int(expires_utc) < 10_000_000_000_000_000:
+            if not _chromium_cookie_is_not_expired(expires_utc):
                 continue
             if not (value or encrypted_value):
                 continue

--- a/cli-runner/skyvern_browser.py
+++ b/cli-runner/skyvern_browser.py
@@ -61,7 +61,7 @@ def _request(method: str, path: str, payload: dict | None = None) -> dict:
         raise SkyvernUnavailable(f"Skyvern request failed: {type(exc).__name__}") from exc
 
 
-def _public_app_url(app_url: str | None, session_id: str) -> str:
+def _public_app_url(app_url: str | None, session_id: str, purpose: str) -> str:
     path = f"/browser-session/{session_id}/stream"
     if app_url:
         upstream_path = urlsplit(app_url).path.rstrip("/")
@@ -75,17 +75,26 @@ def _public_app_url(app_url: str | None, session_id: str) -> str:
             public.scheme,
             public.netloc,
             path,
-            "embed=true&purpose=hashnode-login",
+            f"embed=true&purpose={purpose}",
             "",
         )
     )
 
 
-def start_hashnode_login(profile_id: str | None = None) -> dict:
+_LOGIN_URLS = {
+    "hashnode": "https://hashnode.com/login",
+    "medium": "https://medium.com/m/signin",
+}
+
+
+def start_browser_login(platform: str, profile_id: str | None = None) -> dict:
+    login_url = _LOGIN_URLS.get(platform)
+    if login_url is None:
+        raise ValueError(f"{platform} does not support browser login")
     if profile_id is not None and not _PROFILE_ID.fullmatch(profile_id):
         raise ValueError("Invalid Skyvern profile id")
     payload = {
-        "url": "https://hashnode.com/login",
+        "url": login_url,
         "timeout": None,
         # New sessions need an export that can become a profile. Sessions
         # loaded from a profile persist back to that profile automatically.
@@ -102,38 +111,63 @@ def start_hashnode_login(profile_id: str | None = None) -> dict:
     return {
         "session_id": session_id,
         "organization_id": organization_id,
-        "app_url": _public_app_url(session.get("app_url"), session_id),
+        "app_url": _public_app_url(session.get("app_url"), session_id, f"{platform}-login"),
         "status": session.get("status") or "created",
     }
 
 
-def get_hashnode_login(session_id: str) -> dict:
+def start_hashnode_login(profile_id: str | None = None) -> dict:
+    return start_browser_login("hashnode", profile_id)
+
+
+def start_medium_login(profile_id: str | None = None) -> dict:
+    return start_browser_login("medium", profile_id)
+
+
+def get_browser_login(session_id: str, platform: str = "hashnode") -> dict:
     if not _SESSION_ID.fullmatch(session_id):
         raise ValueError("Invalid Skyvern session id")
     session = _request("GET", f"/v1/browser_sessions/{session_id}")
     return {
         "session_id": session_id,
         "status": session.get("status"),
-        "app_url": _public_app_url(session.get("app_url"), session_id),
+        "app_url": _public_app_url(session.get("app_url"), session_id, f"{platform}-login"),
         "completed_at": session.get("completed_at"),
     }
 
 
-def close_hashnode_login(session_id: str) -> None:
+def get_hashnode_login(session_id: str) -> dict:
+    return get_browser_login(session_id, "hashnode")
+
+
+def get_medium_login(session_id: str) -> dict:
+    return get_browser_login(session_id, "medium")
+
+
+def close_browser_login(session_id: str) -> None:
     if not _SESSION_ID.fullmatch(session_id):
         raise ValueError("Invalid Skyvern session id")
     _request("POST", f"/v1/browser_sessions/{session_id}/close")
 
 
-def finish_hashnode_login(
+def close_hashnode_login(session_id: str) -> None:
+    close_browser_login(session_id)
+
+
+def close_medium_login(session_id: str) -> None:
+    close_browser_login(session_id)
+
+
+def finish_browser_login(
     session_id: str,
     profile_name: str,
+    platform: str,
     profile_id: str | None = None,
     organization_id: str | None = None,
 ) -> dict:
     if not _SESSION_ID.fullmatch(session_id):
         raise ValueError("Invalid Skyvern session id")
-    close_hashnode_login(session_id)
+    close_browser_login(session_id)
     if profile_id is not None:
         if organization_id is None:
             raise ValueError("Skyvern organization id is required for a reused profile")
@@ -147,7 +181,7 @@ def finish_hashnode_login(
         "/v1/browser_profiles",
         {
             "name": profile_name[:120],
-            "description": "BlogHub Hashnode browser login profile",
+            "description": f"BlogHub {platform.title()} browser login profile",
             "browser_session_id": session_id,
         },
     )
@@ -162,10 +196,48 @@ def finish_hashnode_login(
     }
 
 
-def delete_hashnode_profile(profile_id: str) -> None:
+def finish_hashnode_login(
+    session_id: str,
+    profile_name: str,
+    profile_id: str | None = None,
+    organization_id: str | None = None,
+) -> dict:
+    return finish_browser_login(
+        session_id,
+        profile_name,
+        "hashnode",
+        profile_id=profile_id,
+        organization_id=organization_id,
+    )
+
+
+def finish_medium_login(
+    session_id: str,
+    profile_name: str,
+    profile_id: str | None = None,
+    organization_id: str | None = None,
+) -> dict:
+    return finish_browser_login(
+        session_id,
+        profile_name,
+        "medium",
+        profile_id=profile_id,
+        organization_id=organization_id,
+    )
+
+
+def delete_browser_profile(profile_id: str) -> None:
     if not _PROFILE_ID.fullmatch(profile_id):
         raise ValueError("Invalid Skyvern profile id")
     _request("DELETE", f"/v1/browser_profiles/{profile_id}")
+
+
+def delete_hashnode_profile(profile_id: str) -> None:
+    delete_browser_profile(profile_id)
+
+
+def delete_medium_profile(profile_id: str) -> None:
+    delete_browser_profile(profile_id)
 
 
 def profile_directory(organization_id: str, profile_id: str) -> Path:

--- a/contracts/settings.ts
+++ b/contracts/settings.ts
@@ -33,8 +33,8 @@ export type ConnectionType = 'platform' | 'ai';
  *               OpenAI internally; user visits the URL and enters the code
  *               shown in the UI. No paste-back step needed.
  *
- * oauth_popup   Standard Authorization Code popup (Medium). Backend exchanges
- *               the code server-side; callback page sends postMessage.
+ * oauth_popup   Legacy Authorization Code popup. Backend exchanges the code
+ *               server-side; callback page sends postMessage.
  */
 export type OAuthFlow = 'cli_browser' | 'device_code' | 'oauth_popup';
 
@@ -130,7 +130,9 @@ export interface SubmitCodeRequest {
  * GET  /api/connections/{id}/oauth-start         → OAuthStartResponse
  * POST /api/connections/{id}/submit-code         → { status: "submitted" }
  * GET  /api/connections/{id}/cli-login-status    → CliLoginStatus
- * GET  /api/connections/{id}/oauth-callback      (Medium only — server-side callback)
+ * GET  /api/connections/{id}/browser-connection  → browser profile status
+ * POST /api/connections/{id}/browser-connection  → start Skyvern browser login
+ * POST /api/connections/{id}/browser-connection/complete → verify closed login tab
  *
  * CLI runner (port 8001, not called directly by the UI):
  * POST /auth/{provider}/login                    → LoginResponse (includes device_code)

--- a/screens/settings/v2.html
+++ b/screens/settings/v2.html
@@ -54,19 +54,19 @@
       display: flex; align-items: center; justify-content: space-between;
       gap: 16px; padding: 16px 20px;
     }
-    .hashnode-methods {
+    .browser-methods {
       position: absolute; right: 0; top: calc(100% + 6px); z-index: 30;
       width: 272px; padding: 6px; display: grid; gap: 4px;
       background: #151925; border: 1px solid #30364a; border-radius: 6px;
       box-shadow: 0 8px 24px rgba(0,0,0,.5);
     }
-    .hashnode-method {
+    .browser-method {
       width: 100%; display: flex; align-items: center; gap: 10px;
       padding: 10px 12px; border: 0; border-radius: 5px;
       background: transparent; color: #c9cfe0; cursor: pointer;
       font: inherit; text-align: left;
     }
-    .hashnode-method:hover { background: #1e2332; }
+    .browser-method:hover { background: #1e2332; }
 
     /* ── CliProviderCard C ──────────────────────────────────── */
     .ai-card {
@@ -189,10 +189,9 @@
 <script>
 // ─── Static metadata ───────────────────────────────────────────────────────────
 const CONN_META = {
-  // oauth:true   → supports Authorization Code flow via popup + postMessage
-  //                 (server exchanges code for token; browser never sees the secret)
-  // oauth:false  → API key / PAT only; no browser login available
-  medium:    { label: 'Medium',    tokenLabel: 'Integration token',     helpUrl: 'https://medium.com/me/settings/security',     oauth: true  },
+  // oauth controls the legacy provider OAuth path. Medium and Hashnode expose
+  // their persistent browser-login path through BROWSER_LOGIN_PLATFORMS below.
+  medium:    { label: 'Medium',    tokenLabel: 'Integration token',     helpUrl: 'https://medium.com/me/settings/security',     oauth: false },
   hashnode:  { label: 'Hashnode',  tokenLabel: 'Personal Access Token', helpUrl: 'https://hashnode.com/settings/developer',     oauth: false },
   devto:     { label: 'Dev.to',    tokenLabel: 'API Key',               helpUrl: 'https://dev.to/settings/extensions',          oauth: false },
   // Anthropic uses loopback OAuth via claude CLI.
@@ -211,10 +210,14 @@ const ICON_STYLE = {
 };
 
 let _connections = [];
-let _hashnodeBrowserConnection = { platform: 'hashnode', status: 'disconnected' };
-let _hashnodeMethodMenuOpen = false;
-let _hashnodeLoginTab = null;
-let _hashnodeLoginTabTimer = null;
+const BROWSER_LOGIN_PLATFORMS = new Set(['medium', 'hashnode']);
+let _browserConnections = {
+  medium: { platform: 'medium', status: 'disconnected' },
+  hashnode: { platform: 'hashnode', status: 'disconnected' },
+};
+let _browserMethodMenus = { medium: false, hashnode: false };
+let _browserLoginTabs = {};
+let _browserLoginTabTimers = {};
 const _authTimers = new Map();
 
 const AUTH_STATES = {
@@ -254,10 +257,12 @@ async function loadConnections() {
     console.warn('API unavailable, using static fallback:', e.message);
     _connections = buildStaticConns();
   }
-  try {
-    const browserRes = await fetch('/api/connections/hashnode/browser-connection');
-    if (browserRes.ok) _hashnodeBrowserConnection = await browserRes.json();
-  } catch { /* The PAT path remains usable while browser automation is offline. */ }
+  await Promise.all([...BROWSER_LOGIN_PLATFORMS].map(async (id) => {
+    try {
+      const browserRes = await fetch(`/api/connections/${id}/browser-connection`);
+      if (browserRes.ok) _browserConnections[id] = await browserRes.json();
+    } catch { /* The token path remains usable while browser automation is offline. */ }
+  }));
   renderPlatforms(_connections.filter(c => c.type === 'blog'));
   renderAI(_connections.filter(c => c.type === 'ai'));
   updateCount(_connections);
@@ -275,9 +280,10 @@ function buildStaticConns() {
 }
 
 function updateCount(conns) {
-  const n = conns.filter(c => c.id !== 'hashnode' && c.status === 'connected').length +
-    (conns.some(c => c.id === 'hashnode' && c.status === 'connected') ||
-      _hashnodeBrowserConnection.status === 'connected' ? 1 : 0);
+  const n = conns.filter(c => {
+    if (!BROWSER_LOGIN_PLATFORMS.has(c.id)) return c.status === 'connected';
+    return c.status === 'connected' || _browserConnections[c.id]?.status === 'connected';
+  }).length;
   document.getElementById('count-dot').style.background = n > 0 ? '#4ade80' : '#5a6080';
   document.getElementById('count-label').textContent    = `${n} connection${n !== 1 ? 's' : ''} active`;
 }
@@ -288,7 +294,7 @@ function renderPlatforms(conns) {
 }
 
 function platCard(conn) {
-  if (conn.id === 'hashnode') return hashnodeCard(conn);
+  if (BROWSER_LOGIN_PLATFORMS.has(conn.id)) return browserPlatformCard(conn);
 
   const ic   = ICON_STYLE[conn.id] || { bg: '#25293840', color: '#5a6080', letter: '?' };
   const meta = CONN_META[conn.id] || {};
@@ -391,9 +397,13 @@ function platCard(conn) {
     </div>`;
 }
 
-function hashnodeCard(conn) {
+function browserPlatformCard(conn) {
+  const id = conn.id;
+  const meta = CONN_META[id] || {};
+  const ic = ICON_STYLE[id] || { color: '#5a6080', letter: '?' };
   const apiConnected = conn.status === 'connected';
-  const browserStatus = _hashnodeBrowserConnection.status || 'disconnected';
+  const browserConnection = _browserConnections[id] || { platform: id, status: 'disconnected' };
+  const browserStatus = browserConnection.status || 'disconnected';
   const browserConnected = browserStatus === 'connected';
   const connected = apiConnected || browserConnected;
   const waiting = ['waiting_for_login', 'verifying'].includes(browserStatus) && !apiConnected;
@@ -402,52 +412,59 @@ function hashnodeCard(conn) {
   const statusLabel = connected ? 'Connected' : waiting
     ? (browserStatus === 'verifying' ? 'Verifying login' : 'Finish signing in')
     : failed ? 'Login failed' : 'Not connected';
-  const method = apiConnected && browserConnected ? 'API token + browser login' : apiConnected
-    ? 'API token · Hashnode Plus' : browserConnected
+  const tokenMethod = id === 'hashnode' ? 'API token · Hashnode Plus' : 'Integration token';
+  const method = apiConnected && browserConnected ? 'Token + browser login' : apiConnected
+    ? tokenMethod : browserConnected
     ? 'Browser login · Persistent profile' : '';
   const helper = connected ? (browserConnected ? 'Browser session verified' : 'Token stored securely')
-    : waiting ? 'Close the login tab after Hashnode confirms sign-in.'
-    : failed ? esc(_hashnodeBrowserConnection.error || 'Hashnode sign-in was not completed.')
+    : waiting ? `Close the login tab after ${conn.label} confirms sign-in.`
+    : failed ? esc(browserConnection.error || `${conn.label} sign-in was not completed.`)
     : 'Choose API token or browser login.';
 
   let actions = '';
   if (connected) {
     const connectedMethod = apiConnected && browserConnected ? 'both' : apiConnected ? 'api' : 'browser';
-    actions = `<button onclick="disconnectHashnodeConnection('${connectedMethod}')"
+    actions = `<button onclick="disconnectBrowserPlatformConnection('${id}', '${connectedMethod}')"
       style="font-size:11px;color:#f87171;background:transparent;border:none;cursor:pointer;font-family:inherit;">Disconnect</button>`;
   } else if (waiting) {
-    actions = `<button onclick="openHashnodeBrowserLogin()"
+    actions = `<button onclick="openBrowserLogin('${id}')"
       style="font-size:11px;padding:4px 10px;border-radius:4px;border:1px solid #252a38;background:transparent;color:#c9cfe0;cursor:pointer;font-family:inherit;">Open login</button>
-      <button onclick="disconnectHashnodeBrowser()"
+      <button onclick="disconnectBrowserPlatform('${id}')"
       style="font-size:11px;color:#f87171;background:transparent;border:none;cursor:pointer;font-family:inherit;">Cancel</button>`;
   } else {
-    actions = `<button id="hashnode-connect" onclick="toggleHashnodeMethods()" aria-label="Connect" aria-haspopup="menu" aria-expanded="${_hashnodeMethodMenuOpen}"
+    actions = `<button id="${id}-connect" onclick="toggleBrowserPlatformMethods('${id}')" aria-label="Connect" aria-haspopup="menu" aria-expanded="${_browserMethodMenus[id]}"
       style="font-size:12px;font-weight:500;padding:5px 12px 5px 14px;border-radius:5px;background:#6366f1;color:#fff;border:none;cursor:pointer;font-family:inherit;">Connect <span aria-hidden="true" style="margin-left:3px;">▾</span></button>`;
   }
 
-  const methodMenu = !connected && !waiting && _hashnodeMethodMenuOpen ? `
-    <div class="hashnode-methods" id="hashnode-method-menu">
-      <button class="hashnode-method" onclick="chooseHashnodeApiToken()">
+  const tokenCaption = id === 'hashnode'
+    ? 'Deterministic publishing for Hashnode Plus'
+    : 'Use an existing Medium integration token';
+  const tokenBadge = id === 'hashnode'
+    ? '<span style="font-size:9px;font-weight:600;color:#a5b4fc;border:1px solid #3b4670;border-radius:3px;padding:2px 5px;">PLUS</span>'
+    : '';
+  const methodMenu = !connected && !waiting && _browserMethodMenus[id] ? `
+    <div class="browser-methods" id="${id}-method-menu">
+      <button class="browser-method" onclick="chooseBrowserPlatformApiToken('${id}')">
         <span style="width:30px;height:30px;border-radius:5px;background:#1d2945;color:#7fa4ff;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;">API</span>
-        <span style="flex:1;"><span style="display:block;font-size:12px;font-weight:600;color:#e8eaf2;">API token</span><span style="display:block;font-size:10px;color:#69708a;margin-top:2px;">Deterministic publishing for Hashnode Plus</span></span>
-        <span style="font-size:9px;font-weight:600;color:#a5b4fc;border:1px solid #3b4670;border-radius:3px;padding:2px 5px;">PLUS</span>
+        <span style="flex:1;"><span style="display:block;font-size:12px;font-weight:600;color:#e8eaf2;">API token</span><span style="display:block;font-size:10px;color:#69708a;margin-top:2px;">${tokenCaption}</span></span>
+        ${tokenBadge}
       </button>
-      <button class="hashnode-method" onclick="chooseHashnodeBrowserLogin()">
+      <button class="browser-method" onclick="chooseBrowserPlatformLogin('${id}')">
         <span style="width:30px;height:30px;border-radius:5px;background:#173127;color:#71d892;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;">WEB</span>
         <span style="flex:1;"><span style="display:block;font-size:12px;font-weight:600;color:#e8eaf2;">Browser login</span><span style="display:block;font-size:10px;color:#69708a;margin-top:2px;">Isolated persistent browser for free accounts</span></span>
         <span style="font-size:9px;font-weight:600;color:#71d892;border:1px solid #285b43;border-radius:3px;padding:2px 5px;">FREE</span>
       </button>
     </div>` : '';
 
-  return `<div id="plat-card-hashnode" style="position:relative;">
+  return `<div id="plat-card-${id}" style="position:relative;">
     <div class="plat-card" style="position:relative;">
       ${connected ? '<div style="position:absolute;left:0;top:0;bottom:0;width:3px;background:#4ade80;"></div>' : ''}
       <div class="plat-row">
         <div style="display:flex;align-items:center;gap:10px;flex:1;min-width:0;">
-          <div style="width:28px;height:28px;border-radius:6px;background:#1e2438;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;color:${connected ? '#4f6cae' : '#5a6080'};flex-shrink:0;">H</div>
+          <div style="width:28px;height:28px;border-radius:6px;background:#1e2438;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;color:${connected ? ic.color : '#5a6080'};flex-shrink:0;">${ic.letter}</div>
           <div style="min-width:0;">
             <div style="display:flex;align-items:center;gap:6px;">
-              <span style="font-size:14px;font-weight:600;color:#e8eaf2;">Hashnode</span>
+              <span style="font-size:14px;font-weight:600;color:#e8eaf2;">${conn.label}</span>
               <span style="width:6px;height:6px;border-radius:50%;background:${statusColor};"></span>
               <span style="font-size:11px;color:${statusColor};">${statusLabel}</span>
             </div>
@@ -457,68 +474,68 @@ function hashnodeCard(conn) {
         </div>
         <div style="display:flex;align-items:center;gap:8px;flex-shrink:0;">${actions}</div>
       </div>
-      <div class="expand-row" id="expand-hashnode">
+      <div class="expand-row" id="expand-${id}">
         <div style="display:flex;gap:6px;align-items:center;">
-          <input id="key-input-hashnode" type="password" autocomplete="off" placeholder="Paste personal access token…"
+          <input id="key-input-${id}" type="password" autocomplete="off" placeholder="Paste ${meta.tokenLabel || 'API key'}…"
             style="flex:1;background:#0f1117;border:1px solid #252a38;border-radius:5px;padding:7px 10px;font-size:12px;color:#c9cfe0;font-family:inherit;"
-            onkeydown="if(event.key==='Enter')saveKey('hashnode')" />
-          <button onclick="saveKey('hashnode')" style="font-size:12px;font-weight:500;padding:7px 14px;border-radius:5px;background:#6366f1;color:#fff;border:none;cursor:pointer;font-family:inherit;">Save</button>
-          <button onclick="collapseKey('hashnode')" style="font-size:12px;padding:7px 10px;border-radius:5px;border:1px solid #252a38;background:transparent;color:#5a6080;cursor:pointer;font-family:inherit;">Cancel</button>
+            onkeydown="if(event.key==='Enter')saveKey('${id}')" />
+          <button onclick="saveKey('${id}')" style="font-size:12px;font-weight:500;padding:7px 14px;border-radius:5px;background:#6366f1;color:#fff;border:none;cursor:pointer;font-family:inherit;">Save</button>
+          <button onclick="collapseKey('${id}')" style="font-size:12px;padding:7px 10px;border-radius:5px;border:1px solid #252a38;background:transparent;color:#5a6080;cursor:pointer;font-family:inherit;">Cancel</button>
         </div>
-        <a href="${CONN_META.hashnode.helpUrl}" target="_blank" rel="noopener noreferrer" style="font-size:11px;color:#5a6080;text-decoration:none;display:block;margin-top:6px;">Get your personal access token →</a>
+        <a href="${meta.helpUrl}" target="_blank" rel="noopener noreferrer" style="font-size:11px;color:#5a6080;text-decoration:none;display:block;margin-top:6px;">Get your ${(meta.tokenLabel || 'token').toLowerCase()} →</a>
       </div>
     </div>
     ${methodMenu}
   </div>`;
 }
 
-function toggleHashnodeMethods() {
-  _hashnodeMethodMenuOpen = !_hashnodeMethodMenuOpen;
+function toggleBrowserPlatformMethods(id) {
+  _browserMethodMenus[id] = !_browserMethodMenus[id];
   renderPlatforms(_connections.filter(c => c.type === 'blog'));
 }
 
-function chooseHashnodeApiToken() {
-  _hashnodeMethodMenuOpen = false;
+function chooseBrowserPlatformApiToken(id) {
+  _browserMethodMenus[id] = false;
   renderPlatforms(_connections.filter(c => c.type === 'blog'));
-  expandKey('hashnode');
+  expandKey(id);
 }
 
-function chooseHashnodeBrowserLogin() {
-  _hashnodeMethodMenuOpen = false;
-  startHashnodeBrowserLogin();
+function chooseBrowserPlatformLogin(id) {
+  _browserMethodMenus[id] = false;
+  startBrowserLogin(id);
 }
 
-function createHashnodeLoginTab(url='about:blank') {
+function createBrowserLoginTab(url='about:blank') {
   // Omitting window features lets the browser open a normal tab. Open the
   // blank tab synchronously so the later API response is not popup-blocked.
   return window.open(url, '_blank');
 }
 
-function hashnodeLoginUrl(url) {
+function browserLoginUrl(id, url) {
   const target = new URL(url, window.location.href);
-  target.searchParams.set('purpose', 'hashnode-login');
+  target.searchParams.set('purpose', `${id}-login`);
   return target.href;
 }
 
-function watchHashnodeLoginTab(tab) {
-  if (_hashnodeLoginTabTimer) clearInterval(_hashnodeLoginTabTimer);
-  _hashnodeLoginTab = tab;
+function watchBrowserLoginTab(id, tab) {
+  if (_browserLoginTabTimers[id]) clearInterval(_browserLoginTabTimers[id]);
+  _browserLoginTabs[id] = tab;
   if (!tab) return;
-  _hashnodeLoginTabTimer = setInterval(() => {
+  _browserLoginTabTimers[id] = setInterval(() => {
     if (!tab.closed) return;
-    clearInterval(_hashnodeLoginTabTimer);
-    _hashnodeLoginTabTimer = null;
-    _hashnodeLoginTab = null;
-    if (_hashnodeBrowserConnection.status === 'waiting_for_login') {
-      completeHashnodeBrowserLogin();
+    clearInterval(_browserLoginTabTimers[id]);
+    _browserLoginTabTimers[id] = null;
+    _browserLoginTabs[id] = null;
+    if (_browserConnections[id]?.status === 'waiting_for_login') {
+      completeBrowserLogin(id);
     }
   }, 500);
 }
 
-async function startHashnodeBrowserLogin() {
-  const loginTab = createHashnodeLoginTab();
+async function startBrowserLogin(id) {
+  const loginTab = createBrowserLoginTab();
   try {
-    const res = await fetch('/api/connections/hashnode/browser-connection', { method: 'POST' });
+    const res = await fetch(`/api/connections/${id}/browser-connection`, { method: 'POST' });
     if (res.status === 401) {
       loginTab?.close();
       redirectToLogin();
@@ -526,15 +543,15 @@ async function startHashnodeBrowserLogin() {
     }
     const data = await res.json();
     if (!res.ok) throw new Error(data.detail || `HTTP ${res.status}`);
-    _hashnodeBrowserConnection = data;
+    _browserConnections[id] = data;
     renderPlatforms(_connections.filter(c => c.type === 'blog'));
     if (data.authorizationUrl && loginTab) {
-      loginTab.location.href = hashnodeLoginUrl(data.authorizationUrl);
+      loginTab.location.href = browserLoginUrl(id, data.authorizationUrl);
       loginTab.focus();
-      watchHashnodeLoginTab(loginTab);
+      watchBrowserLoginTab(id, loginTab);
     } else if (data.authorizationUrl) {
-      const fallback = window.open(hashnodeLoginUrl(data.authorizationUrl), '_blank', 'noopener');
-      watchHashnodeLoginTab(fallback);
+      const fallback = window.open(browserLoginUrl(id, data.authorizationUrl), '_blank', 'noopener');
+      watchBrowserLoginTab(id, fallback);
     }
     else loginTab?.close();
   } catch (error) {
@@ -543,50 +560,50 @@ async function startHashnodeBrowserLogin() {
   }
 }
 
-function openHashnodeBrowserLogin() {
-  if (_hashnodeBrowserConnection.authorizationUrl) {
-    const tab = createHashnodeLoginTab(hashnodeLoginUrl(_hashnodeBrowserConnection.authorizationUrl));
+function openBrowserLogin(id) {
+  if (_browserConnections[id]?.authorizationUrl) {
+    const tab = createBrowserLoginTab(browserLoginUrl(id, _browserConnections[id].authorizationUrl));
     tab?.focus();
-    watchHashnodeLoginTab(tab);
+    watchBrowserLoginTab(id, tab);
   }
 }
 
-async function completeHashnodeBrowserLogin() {
-  _hashnodeBrowserConnection = { ..._hashnodeBrowserConnection, status: 'verifying' };
-  if (_hashnodeLoginTabTimer) clearInterval(_hashnodeLoginTabTimer);
-  _hashnodeLoginTabTimer = null;
-  _hashnodeLoginTab?.close();
-  _hashnodeLoginTab = null;
+async function completeBrowserLogin(id) {
+  _browserConnections[id] = { ..._browserConnections[id], status: 'verifying' };
+  if (_browserLoginTabTimers[id]) clearInterval(_browserLoginTabTimers[id]);
+  _browserLoginTabTimers[id] = null;
+  _browserLoginTabs[id]?.close();
+  _browserLoginTabs[id] = null;
   renderPlatforms(_connections.filter(c => c.type === 'blog'));
   try {
-    const res = await fetch('/api/connections/hashnode/browser-connection/complete', { method: 'POST' });
+    const res = await fetch(`/api/connections/${id}/browser-connection/complete`, { method: 'POST' });
     if (res.status === 401) {
       redirectToLogin();
       return;
     }
     const data = await res.json();
     if (!res.ok) throw new Error(data.detail || `HTTP ${res.status}`);
-    _hashnodeBrowserConnection = data;
+    _browserConnections[id] = data;
   } catch (error) {
-    _hashnodeBrowserConnection = { platform: 'hashnode', status: 'failed', error: error.message };
+    _browserConnections[id] = { platform: id, status: 'failed', error: error.message };
   }
   renderPlatforms(_connections.filter(c => c.type === 'blog'));
 }
 
-async function disconnectHashnodeBrowser() {
-  if (_hashnodeLoginTabTimer) clearInterval(_hashnodeLoginTabTimer);
-  _hashnodeLoginTabTimer = null;
-  _hashnodeLoginTab?.close();
-  _hashnodeLoginTab = null;
+async function disconnectBrowserPlatform(id) {
+  if (_browserLoginTabTimers[id]) clearInterval(_browserLoginTabTimers[id]);
+  _browserLoginTabTimers[id] = null;
+  _browserLoginTabs[id]?.close();
+  _browserLoginTabs[id] = null;
   try {
-    const res = await fetch('/api/connections/hashnode/browser-connection', { method: 'DELETE' });
+    const res = await fetch(`/api/connections/${id}/browser-connection`, { method: 'DELETE' });
     if (res.status === 401) {
       redirectToLogin();
       return;
     }
     const data = await res.json();
     if (!res.ok) throw new Error(data.detail || `HTTP ${res.status}`);
-    _hashnodeBrowserConnection = { platform: 'hashnode', status: 'disconnected' };
+    _browserConnections[id] = { platform: id, status: 'disconnected' };
     renderPlatforms(_connections.filter(c => c.type === 'blog'));
     updateCount(_connections);
   } catch (error) {
@@ -594,9 +611,9 @@ async function disconnectHashnodeBrowser() {
   }
 }
 
-async function disconnectHashnodeConnection(method) {
-  if (method === 'browser' || method === 'both') await disconnectHashnodeBrowser();
-  if (method === 'api' || method === 'both') await doDisconnect('hashnode');
+async function disconnectBrowserPlatformConnection(id, method) {
+  if (method === 'browser' || method === 'both') await disconnectBrowserPlatform(id);
+  if (method === 'api' || method === 'both') await doDisconnect(id);
 }
 
 // ─── CliProviderCard C ─────────────────────────────────────────────────────────
@@ -1015,9 +1032,12 @@ function _doOAuthPopup(id, url) {
 // ─── Close popovers on outside click ──────────────────────────────────────────
 document.addEventListener('click', (e) => {
   if (!e.target.closest('.confirm-anchor')) closeAllConfirm();
-  if (_hashnodeMethodMenuOpen && !e.target.closest('#plat-card-hashnode')) {
-    _hashnodeMethodMenuOpen = false;
-    renderPlatforms(_connections.filter(c => c.type === 'blog'));
+  for (const id of BROWSER_LOGIN_PLATFORMS) {
+    if (_browserMethodMenus[id] && !e.target.closest(`#plat-card-${id}`)) {
+      _browserMethodMenus[id] = false;
+      renderPlatforms(_connections.filter(c => c.type === 'blog'));
+      break;
+    }
   }
 });
 

--- a/tests/tests_backend/test_browser_connections.py
+++ b/tests/tests_backend/test_browser_connections.py
@@ -8,8 +8,8 @@ import backend.store as store
 def test_hashnode_browser_login_persists_only_profile_references(client, monkeypatch):
     monkeypatch.setattr(
         connections_router.runner,
-        "start_hashnode_browser_login",
-        lambda *_args: {
+        "start_browser_login",
+        lambda *_args, **_kwargs: {
             "session_id": "pbs_session",
             "organization_id": "o_org",
             "app_url": "http://localhost:8083/browser-session/pbs_session",
@@ -17,7 +17,7 @@ def test_hashnode_browser_login_persists_only_profile_references(client, monkeyp
     )
     monkeypatch.setattr(
         connections_router.runner,
-        "complete_hashnode_browser_login",
+        "complete_browser_login",
         lambda *args, **kwargs: {
             "authenticated": True,
             "profile_id": "bp_profile",
@@ -49,8 +49,8 @@ def test_hashnode_browser_login_persists_only_profile_references(client, monkeyp
 def test_hashnode_browser_login_rejects_unverified_profile(client, monkeypatch):
     monkeypatch.setattr(
         connections_router.runner,
-        "start_hashnode_browser_login",
-        lambda *_args: {
+        "start_browser_login",
+        lambda *_args, **_kwargs: {
             "session_id": "pbs_session",
             "organization_id": "o_org",
             "app_url": "http://localhost:8083/browser-session/pbs_session",
@@ -58,7 +58,7 @@ def test_hashnode_browser_login_rejects_unverified_profile(client, monkeypatch):
     )
     monkeypatch.setattr(
         connections_router.runner,
-        "complete_hashnode_browser_login",
+        "complete_browser_login",
         lambda *args, **kwargs: {
             "authenticated": False,
             "profile_id": "bp_failed",
@@ -85,8 +85,8 @@ def test_hashnode_browser_retry_reuses_provider_session_profile(client, monkeypa
     reused = []
     monkeypatch.setattr(
         connections_router.runner,
-        "start_hashnode_browser_login",
-        lambda profile_id: reused.append(profile_id) or {
+        "start_browser_login",
+        lambda platform, profile_id: reused.append((platform, profile_id)) or {
             "session_id": "pbs_retry",
             "organization_id": "o_org",
             "app_url": "http://localhost:8083/browser-session/pbs_retry",
@@ -96,7 +96,7 @@ def test_hashnode_browser_retry_reuses_provider_session_profile(client, monkeypa
     started = client.post("/api/connections/hashnode/browser-connection")
 
     assert started.status_code == 201
-    assert reused == ["bp_identity"]
+    assert reused == [("hashnode", "bp_identity")]
     persisted = store.get_browser_connection("user_seed", "hashnode")
     assert persisted["skyvern_profile_id"] == "bp_identity"
 
@@ -112,15 +112,13 @@ def test_hashnode_browser_disconnect_deletes_remote_profile(client, monkeypatch)
     deleted = []
     monkeypatch.setattr(
         connections_router.runner,
-        "delete_hashnode_browser_profile",
-        lambda profile_id: deleted.append(profile_id),
+        "delete_browser_profile",
+        lambda platform, profile_id: deleted.append((platform, profile_id)),
     )
     response = client.delete("/api/connections/hashnode/browser-connection")
     assert response.status_code == 200
-    assert deleted == ["bp_profile"]
+    assert deleted == [("hashnode", "bp_profile")]
     assert store.get_browser_connection("user_seed", "hashnode") is None
-
-
 def test_hashnode_browser_disconnect_retains_profile_when_remote_cleanup_fails(
     client, monkeypatch,
 ):
@@ -132,11 +130,11 @@ def test_hashnode_browser_disconnect_retains_profile_when_remote_cleanup_fails(
         "user_seed", "hashnode", "connected", profile_id="bp_profile"
     )
 
-    def unavailable(_profile_id):
+    def unavailable(_platform, _profile_id):
         raise runner.RunnerUnavailable("Skyvern unavailable")
 
     monkeypatch.setattr(
-        connections_router.runner, "delete_hashnode_browser_profile", unavailable,
+        connections_router.runner, "delete_browser_profile", unavailable,
     )
 
     response = client.delete("/api/connections/hashnode/browser-connection")
@@ -145,3 +143,39 @@ def test_hashnode_browser_disconnect_retains_profile_when_remote_cleanup_fails(
     assert response.json()["detail"] == "Skyvern unavailable"
     persisted = store.get_browser_connection("user_seed", "hashnode")
     assert persisted["skyvern_profile_id"] == "bp_profile"
+
+
+def test_medium_browser_login_uses_same_profile_reference_flow(client, monkeypatch):
+    started_platforms = []
+    completed_platforms = []
+    monkeypatch.setattr(
+        connections_router.runner,
+        "start_browser_login",
+        lambda platform, profile_id=None: started_platforms.append((platform, profile_id)) or {
+            "session_id": "pbs_medium",
+            "organization_id": "o_org",
+            "app_url": "http://localhost:8083/browser-session/pbs_medium",
+        },
+    )
+    monkeypatch.setattr(
+        connections_router.runner,
+        "complete_browser_login",
+        lambda platform, *args, **kwargs: completed_platforms.append(platform) or {
+            "authenticated": True,
+            "profile_id": "bp_medium",
+            "organization_id": "o_org",
+        },
+    )
+
+    started = client.post("/api/connections/medium/browser-connection")
+    assert started.status_code == 201
+    assert started.json()["platform"] == "medium"
+    assert started.json()["authorizationUrl"].endswith("pbs_medium")
+
+    completed = client.post("/api/connections/medium/browser-connection/complete")
+    assert completed.status_code == 200
+    assert completed.json()["status"] == "connected"
+    assert started_platforms == [("medium", None)]
+    assert completed_platforms == ["medium"]
+    persisted = store.get_browser_connection("user_seed", "medium")
+    assert persisted["skyvern_profile_id"] == "bp_medium"

--- a/tests/tests_backend/test_medium_browser.py
+++ b/tests/tests_backend/test_medium_browser.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sqlite3
+
+
+RUNNER = Path(__file__).resolve().parents[2] / "cli-runner"
+spec = importlib.util.spec_from_file_location(
+    "medium_browser_under_test", RUNNER / "medium_browser.py"
+)
+medium_browser = importlib.util.module_from_spec(spec)
+assert spec.loader
+spec.loader.exec_module(medium_browser)
+
+
+def _write_cookie_snapshot(profile_dir, cookies):
+    (profile_dir / ".skyvern_session_cookies.json").write_text(
+        __import__("json").dumps(cookies), encoding="utf-8"
+    )
+
+
+def test_profile_check_rejects_profile_without_medium_session(tmp_path):
+    _write_cookie_snapshot(tmp_path, [
+        {"domain": ".medium.com", "name": "xsrf", "value": "opaque"},
+    ])
+
+    result = medium_browser.check_medium_profile(profile_dir=str(tmp_path))
+
+    assert result == {"authenticated": False, "status": "login_required"}
+
+
+def test_profile_check_accepts_medium_session_snapshot(tmp_path):
+    _write_cookie_snapshot(tmp_path, [
+        {"domain": ".medium.com", "name": "uid", "value": "user"},
+        {"domain": ".medium.com", "name": "sid", "value": "session"},
+    ])
+
+    result = medium_browser.check_medium_profile(profile_dir=str(tmp_path))
+
+    assert result == {"authenticated": True, "status": "connected"}
+
+
+def test_profile_check_accepts_encrypted_chromium_medium_session(tmp_path):
+    cookie_db = tmp_path / "Default" / "Cookies"
+    cookie_db.parent.mkdir()
+    connection = sqlite3.connect(cookie_db)
+    connection.execute(
+        "CREATE TABLE cookies (host_key TEXT, name TEXT, expires_utc INTEGER, "
+        "value TEXT, encrypted_value BLOB)"
+    )
+    connection.executemany(
+        "INSERT INTO cookies VALUES (?, ?, ?, ?, ?)",
+        [
+            (".medium.com", "uid", 99_999_999_999_999_999, "", b"encrypted"),
+            (".medium.com", "sid", 99_999_999_999_999_999, "", b"encrypted"),
+        ],
+    )
+    connection.commit()
+    connection.close()
+
+    result = medium_browser.check_medium_profile(profile_dir=str(tmp_path))
+
+    assert result == {"authenticated": True, "status": "connected"}

--- a/tests/tests_backend/test_medium_browser.py
+++ b/tests/tests_backend/test_medium_browser.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 import sqlite3
+import time
 
 
 RUNNER = Path(__file__).resolve().parents[2] / "cli-runner"
@@ -62,3 +63,27 @@ def test_profile_check_accepts_encrypted_chromium_medium_session(tmp_path):
     result = medium_browser.check_medium_profile(profile_dir=str(tmp_path))
 
     assert result == {"authenticated": True, "status": "connected"}
+
+
+def test_profile_check_rejects_expired_chromium_medium_session(tmp_path):
+    cookie_db = tmp_path / "Default" / "Cookies"
+    cookie_db.parent.mkdir()
+    connection = sqlite3.connect(cookie_db)
+    connection.execute(
+        "CREATE TABLE cookies (host_key TEXT, name TEXT, expires_utc INTEGER, "
+        "value TEXT, encrypted_value BLOB)"
+    )
+    expired_utc = int((time.time() + 11_644_473_600 - 60) * 1_000_000)
+    connection.executemany(
+        "INSERT INTO cookies VALUES (?, ?, ?, ?, ?)",
+        [
+            (".medium.com", "uid", expired_utc, "", b"encrypted"),
+            (".medium.com", "sid", expired_utc, "", b"encrypted"),
+        ],
+    )
+    connection.commit()
+    connection.close()
+
+    result = medium_browser.check_medium_profile(profile_dir=str(tmp_path))
+
+    assert result == {"authenticated": False, "status": "login_required"}

--- a/tests/tests_backend/test_skyvern_browser.py
+++ b/tests/tests_backend/test_skyvern_browser.py
@@ -50,6 +50,28 @@ def test_start_login_uses_non_expiring_live_profile_session(monkeypatch):
     assert seen["payload"]["timeout"] is None
 
 
+def test_start_medium_login_uses_medium_signin_url(monkeypatch):
+    seen = {}
+
+    def request(method, url, **kwargs):
+        seen.update(method=method, url=url, payload=kwargs["json"])
+        return FakeResponse({
+            "browser_session_id": "pbs_session123",
+            "organization_id": "o_org123",
+            "app_url": "http://skyvern-ui:8080/browser-session/pbs_session123",
+            "status": "created",
+        })
+
+    monkeypatch.setenv("SKYVERN_API_KEY", "local-key")
+    monkeypatch.setattr(skyvern_browser.httpx, "request", request)
+    result = skyvern_browser.start_medium_login()
+    assert result["app_url"] == (
+        "http://localhost:8083/browser-session/pbs_session123/stream"
+        "?embed=true&purpose=medium-login"
+    )
+    assert seen["payload"]["url"] == "https://medium.com/m/signin"
+
+
 def test_start_login_reuses_identity_provider_profile(monkeypatch):
     seen = {}
 

--- a/tests/tests_ui/screens/test_settings.py
+++ b/tests/tests_ui/screens/test_settings.py
@@ -34,6 +34,16 @@ def _hashnode_browser_payload(status="disconnected", authorization_url=None):
     }
 
 
+def _browser_payload(platform, status="disconnected", authorization_url=None):
+    return {
+        "platform": platform,
+        "status": status,
+        "authorizationUrl": authorization_url,
+        "verifiedAt": None,
+        "error": None,
+    }
+
+
 def _show_disconnected_hashnode(page):
     page.route(
         f"{BASE_URL}/api/connections/hashnode/browser-connection",
@@ -80,6 +90,21 @@ def test_hashnode_api_token_choice_opens_credential_input(settings_page):
     card.get_by_role("button", name=re.compile(r"API token")).click()
 
     assert card.locator("#key-input-hashnode").is_visible()
+
+
+def test_medium_connect_opens_browser_login_choice(settings_page):
+    settings_page.route(
+        f"{BASE_URL}/api/connections/medium/browser-connection",
+        lambda route: route.fulfill(json=_browser_payload("medium")),
+    )
+    settings_page.reload()
+    card = settings_page.locator("#plat-card-medium")
+
+    card.get_by_role("button", name="Connect").click()
+
+    menu = card.locator("#medium-method-menu")
+    assert menu.get_by_role("button", name=re.compile(r"API token")).is_visible()
+    assert menu.get_by_role("button", name=re.compile(r"Browser login")).is_visible()
 
 
 def test_hashnode_browser_login_opens_normal_tab(settings_page, context):


### PR DESCRIPTION
## Summary

- add Medium as a browser-login platform backed by a persistent Skyvern profile
- expose the generic browser-login lifecycle through the CLI runner and backend
- add Medium login, completion, disconnect, and connected states to Settings
- verify completed sessions from persisted Medium authentication cookies
- reject expired Chromium cookies using the correct 1601-to-Unix epoch conversion

## Validation

- `16 passed`: browser connection, Skyvern browser, and Medium profile tests
- includes a regression test for expired encrypted Chromium cookies
- `git diff --check`

Part 1 of #43. The publishing and retrieval implementation is stacked in PR #44.
