### PR TITLE
fix: paginate Hashnode article queries

### DIFF
--- a/blogs/hashnode/client.py
+++ b/blogs/hashnode/client.py
@@ -110,9 +110,9 @@ class HashnodeClient:
 
     def list_drafts(self, *, first: int = 20) -> list[HashnodeRemoteArticle]:
         query = """
-        query MeDrafts($first: Int!) {
+        query MeDrafts($first: Int!, $after: String) {
           me {
-            drafts(first: $first) {
+            drafts(first: $first, after: $after) {
               edges {
                 node {
                   id
@@ -131,15 +131,26 @@ class HashnodeClient:
                   }
                 }
               }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
             }
           }
         }
         """
-        payload = self._graphql(query, {"first": first})
-        return [
-            self._remote_article_payload(edge["node"], published=False)
-            for edge in payload["data"]["me"]["drafts"]["edges"]
-        ]
+        articles: list[HashnodeRemoteArticle] = []
+        cursor: str | None = None
+        while True:
+            payload = self._graphql(query, {"first": first, "after": cursor})
+            connection = (((payload.get("data") or {}).get("me") or {}).get("drafts") or {})
+            articles.extend(
+                self._remote_article_payload(edge["node"], published=False)
+                for edge in connection.get("edges") or []
+            )
+            cursor = _next_page_cursor(connection, cursor)
+            if cursor is None:
+                return articles
 
     def list_published_articles(
         self,
@@ -153,9 +164,9 @@ class HashnodeClient:
             if not host:
                 continue
             query = """
-            query PublicationPosts($host: String!, $first: Int!) {
+            query PublicationPosts($host: String!, $first: Int!, $after: String) {
               publication(host: $host) {
-                posts(first: $first) {
+                posts(first: $first, after: $after) {
                   edges {
                     node {
                       id
@@ -172,26 +183,38 @@ class HashnodeClient:
                       }
                     }
                   }
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
                 }
               }
             }
             """
-            payload = self._graphql(query, {"host": host, "first": post_first})
-            edges = (((payload.get("data") or {}).get("publication") or {}).get("posts") or {}).get(
-                "edges",
-                [],
-            )
-            articles.extend(
-                self._remote_article_payload(edge["node"], published=True)
-                for edge in edges
-            )
+            cursor: str | None = None
+            while True:
+                payload = self._graphql(
+                    query,
+                    {"host": host, "first": post_first, "after": cursor},
+                )
+                publication_payload = (payload.get("data") or {}).get("publication")
+                if not publication_payload:
+                    break
+                connection = publication_payload.get("posts") or {}
+                articles.extend(
+                    self._remote_article_payload(edge["node"], published=True)
+                    for edge in connection.get("edges") or []
+                )
+                cursor = _next_page_cursor(connection, cursor)
+                if cursor is None:
+                    break
         return articles
 
     def list_publications(self, *, first: int = 10) -> list[dict[str, str]]:
         query = """
-        query MePublications($first: Int!) {
+        query MePublications($first: Int!, $after: String) {
           me {
-            publications(first: $first) {
+            publications(first: $first, after: $after) {
               edges {
                 node {
                   id
@@ -199,12 +222,25 @@ class HashnodeClient:
                   url
                 }
               }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
             }
           }
         }
         """
-        payload = self._graphql(query, {"first": first})
-        return [edge["node"] for edge in payload["data"]["me"]["publications"]["edges"]]
+        publications: list[dict[str, str]] = []
+        cursor: str | None = None
+        while True:
+            payload = self._graphql(query, {"first": first, "after": cursor})
+            connection = (
+                ((payload.get("data") or {}).get("me") or {}).get("publications") or {}
+            )
+            publications.extend(edge["node"] for edge in connection.get("edges") or [])
+            cursor = _next_page_cursor(connection, cursor)
+            if cursor is None:
+                return publications
 
     def _graphql(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
         response = self._session.post(
@@ -294,6 +330,18 @@ def _optional_string(value: object) -> str | None:
         return None
     text = str(value).strip()
     return text or None
+
+
+def _next_page_cursor(connection: dict[str, Any], current: str | None) -> str | None:
+    page_info = connection.get("pageInfo") or {}
+    if not page_info.get("hasNextPage"):
+        return None
+    cursor = _optional_string(page_info.get("endCursor"))
+    if cursor is None:
+        raise HashnodeError("Hashnode pagination did not return an end cursor")
+    if cursor == current:
+        raise HashnodeError("Hashnode pagination returned the same cursor twice")
+    return cursor
 
 
 def _parse_datetime(raw_value: object) -> datetime | None:

--- a/tests/tests_hashnode/test_client.py
+++ b/tests/tests_hashnode/test_client.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from blogs.hashnode.client import HashnodeClient, HashnodeDraftInput
+import pytest
+
+from blogs.hashnode.client import HashnodeClient, HashnodeDraftInput, HashnodeError
 
 
 class _FakeResponse:
@@ -24,6 +26,38 @@ class _FakeSession:
     def post(self, url, **kwargs):
         self.calls.append({"url": url, **kwargs})
         return _FakeResponse(self.payload)
+
+
+class _QueuedSession:
+    def __init__(self, payloads):
+        self.calls: list[dict[str, object]] = []
+        self.payloads = iter(payloads)
+
+    def post(self, url, **kwargs):
+        self.calls.append({"url": url, **kwargs})
+        return _FakeResponse(next(self.payloads))
+
+
+def _page(nodes, *, has_next=False, end_cursor=None):
+    return {
+        "edges": [{"node": node} for node in nodes],
+        "pageInfo": {"hasNextPage": has_next, "endCursor": end_cursor},
+    }
+
+
+def _article(article_id, *, published=False):
+    return {
+        "id": article_id,
+        "title": f"Article {article_id}",
+        "subtitle": None,
+        "canonicalUrl": None,
+        "url": f"https://example.hashnode.dev/{article_id}" if published else None,
+        "publishedAt": "2026-01-01T00:00:00Z" if published else None,
+        "dateUpdated": "2026-01-01T00:00:00Z" if not published else None,
+        "coverImage": None,
+        "publication": {"url": "https://example.hashnode.dev"},
+        "content": {"markdown": f"Body {article_id}"},
+    }
 
 
 def test_create_draft_sends_cover_image_and_slugged_tags():
@@ -69,3 +103,114 @@ def test_create_draft_sends_cover_image_and_slugged_tags():
         "originalArticleURL": "https://example.com/source",
         "coverImageOptions": {"coverImageURL": "https://example.com/cover.png"},
     }
+
+
+def test_list_drafts_fetches_every_cursor_page():
+    session = _QueuedSession([
+        {"data": {"me": {"drafts": _page([_article("d1")], has_next=True, end_cursor="draft-1")}}},
+        {"data": {"me": {"drafts": _page([_article("d2")])}}},
+    ])
+
+    articles = HashnodeClient("token", session=session).list_drafts(first=1)
+
+    assert [article.article_id for article in articles] == ["d1", "d2"]
+    assert [call["json"]["variables"] for call in session.calls] == [
+        {"first": 1, "after": None},
+        {"first": 1, "after": "draft-1"},
+    ]
+
+
+def test_list_publications_fetches_every_cursor_page():
+    session = _QueuedSession([
+        {"data": {"me": {"publications": _page(
+            [{"id": "p1", "title": "One", "url": "https://one.example"}],
+            has_next=True,
+            end_cursor="publication-1",
+        )}}},
+        {"data": {"me": {"publications": _page(
+            [{"id": "p2", "title": "Two", "url": "https://two.example"}],
+        )}}},
+    ])
+
+    publications = HashnodeClient("token", session=session).list_publications(first=1)
+
+    assert [publication["id"] for publication in publications] == ["p1", "p2"]
+    assert [call["json"]["variables"] for call in session.calls] == [
+        {"first": 1, "after": None},
+        {"first": 1, "after": "publication-1"},
+    ]
+
+
+def test_list_published_articles_paginates_each_publication_independently():
+    session = _QueuedSession([
+        {"data": {"me": {"publications": _page([
+            {"id": "p1", "title": "One", "url": "https://one.example"},
+            {"id": "p2", "title": "Two", "url": "https://two.example"},
+        ])}}},
+        {"data": {"publication": {"posts": _page(
+            [_article("one-1", published=True)],
+            has_next=True,
+            end_cursor="one-page-1",
+        )}}},
+        {"data": {"publication": {"posts": _page([
+            _article("one-2", published=True),
+        ])}}},
+        {"data": {"publication": {"posts": _page([
+            _article("two-1", published=True),
+        ])}}},
+    ])
+
+    articles = HashnodeClient("token", session=session).list_published_articles(
+        publication_first=2,
+        post_first=1,
+    )
+
+    assert [article.article_id for article in articles] == ["one-1", "one-2", "two-1"]
+    assert [call["json"]["variables"] for call in session.calls] == [
+        {"first": 2, "after": None},
+        {"host": "one.example", "first": 1, "after": None},
+        {"host": "one.example", "first": 1, "after": "one-page-1"},
+        {"host": "two.example", "first": 1, "after": None},
+    ]
+
+
+def test_list_published_articles_treats_missing_publication_as_empty():
+    session = _QueuedSession([
+        {"data": {"me": {"publications": _page([
+            {"id": "p1", "title": "One", "url": "https://missing.example"},
+        ])}}},
+        {"data": {"publication": None}},
+    ])
+
+    articles = HashnodeClient("token", session=session).list_published_articles()
+
+    assert articles == []
+
+
+def test_pagination_propagates_graphql_error_from_later_page():
+    session = _QueuedSession([
+        {"data": {"me": {"drafts": _page(
+            [_article("d1")], has_next=True, end_cursor="draft-1",
+        )}}},
+        {"errors": [{"message": "Token expired"}]},
+    ])
+
+    with pytest.raises(HashnodeError, match="Token expired"):
+        HashnodeClient("token", session=session).list_drafts()
+
+
+@pytest.mark.parametrize("end_cursor", [None, "same-cursor"])
+def test_pagination_rejects_missing_or_repeated_cursor(end_cursor):
+    first_cursor = "same-cursor" if end_cursor == "same-cursor" else None
+    payloads = []
+    if first_cursor is not None:
+        payloads.append({"data": {"me": {"drafts": _page(
+            [], has_next=True, end_cursor=first_cursor,
+        )}}})
+    payloads.append({"data": {"me": {"drafts": _page(
+        [], has_next=True, end_cursor=end_cursor,
+    )}}})
+    session = _QueuedSession(payloads)
+
+    with pytest.raises(HashnodeError, match="cursor"):
+        HashnodeClient("token", session=session).list_drafts()


### PR DESCRIPTION
## Summary

- paginate Hashnode drafts with `pageInfo` and `after` cursors
- paginate the connected user's publications
- paginate posts independently within every publication
- stop safely for missing publication payloads and reject missing or repeated cursors
- preserve the existing normalized article and publication return values

## Why

The client previously returned only the first requested page, so larger Hashnode accounts were silently incomplete. This makes `first` the GraphQL page size and traverses all available pages.

## Validation

- `8 passed`: focused Hashnode client tests
- multi-page drafts, publications, and per-publication posts covered
- missing publications, later-page GraphQL errors, and malformed cursor metadata covered
- `git diff --check`

The broader non-live Hashnode suite currently reports `9 passed, 1 deselected, 2 errors`. Both errors are pre-existing in `tests/tests_hashnode/conftest.py`, which calls `store.list_articles()` without the required `user_id`; this PR does not touch that fixture or store API.

Closes #48
