### PR TITLE
feat: add durable remote article identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository Agent Instructions
+
+## GitHub Identity
+
+- Use the `amadou-6e` GitHub account for repository operations.
+- Author and commit changes as `amadou-6e <106311251+amadou-6e@users.noreply.github.com>`.
+- Before committing, verify both the active `gh` account and the repository-local
+  Git author. Do not use the `cisseam` identity in this repository.

--- a/backend/schemas/remote_articles.py
+++ b/backend/schemas/remote_articles.py
@@ -1,0 +1,42 @@
+"""API-facing models for durable remote article identity metadata."""
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RemoteSyncStatus(str, Enum):
+    succeeded = "succeeded"
+    partial = "partial"
+    failed = "failed"
+
+
+class RemoteArticleIdentity(BaseModel):
+    article_id: str = Field(alias="articleId")
+    platform: str
+    remote_id: str = Field(alias="remoteId")
+    remote_content_fingerprint: str | None = Field(
+        default=None, alias="remoteContentFingerprint",
+    )
+    subtitle: str | None = None
+    cover_asset_id: int | None = Field(default=None, alias="coverAssetId")
+    last_sync_status: RemoteSyncStatus | None = Field(
+        default=None, alias="lastSyncStatus",
+    )
+    last_sync_result: dict[str, Any] | None = Field(
+        default=None, alias="lastSyncResult",
+    )
+    last_sync_error: str | None = Field(default=None, alias="lastSyncError")
+    remote_created_at: datetime | None = Field(default=None, alias="remoteCreatedAt")
+    remote_updated_at: datetime | None = Field(default=None, alias="remoteUpdatedAt")
+    last_sync_started_at: datetime | None = Field(
+        default=None, alias="lastSyncStartedAt",
+    )
+    last_synced_at: datetime | None = Field(default=None, alias="lastSyncedAt")
+    created_at: datetime = Field(alias="createdAt")
+    updated_at: datetime = Field(alias="updatedAt")
+
+    model_config = ConfigDict(populate_by_name=True)

--- a/backend/store/__init__.py
+++ b/backend/store/__init__.py
@@ -97,6 +97,21 @@ def set_destinations_pending(user_id: str, *a, **kw):
     return _backend.set_destinations_pending(user_id, *a, **kw)
 
 
+# ── Remote article identity ─────────────────────────────────────────────────
+
+
+def get_remote_article_identity(user_id: str, *a, **kw):
+    return _backend.get_remote_article_identity(user_id, *a, **kw)
+
+
+def list_article_remote_identities(user_id: str, *a, **kw):
+    return _backend.list_article_remote_identities(user_id, *a, **kw)
+
+
+def upsert_remote_article_identity(user_id: str, *a, **kw):
+    return _backend.upsert_remote_article_identity(user_id, *a, **kw)
+
+
 # ── Connections ───────────────────────────────────────────────────────────────
 
 

--- a/backend/store/backends/sqlite.py
+++ b/backend/store/backends/sqlite.py
@@ -34,6 +34,7 @@ from backend.store.article_revisions import ArticleRevisionStoreMixin
 from backend.store.connection_auth import ConnectionAuthStoreMixin
 from backend.store.browser_publish import BrowserPublishStoreMixin
 from backend.store.browser_connections import BrowserConnectionStoreMixin
+from backend.store.remote_articles import RemoteArticleStoreMixin
 from backend.store.schema import (
     SEED_USER_EMAIL as DEFAULT_SEED_USER_EMAIL,
     SEED_USER_HASH as DEFAULT_SEED_USER_HASH,
@@ -221,6 +222,7 @@ def _seed_articles() -> list[dict]:
 
 
 class SQLiteStore(
+    RemoteArticleStoreMixin,
     BrowserConnectionStoreMixin,
     BrowserPublishStoreMixin,
     ConnectionAuthStoreMixin,
@@ -994,6 +996,7 @@ class SQLiteStore(
                 DELETE FROM article_timeline;
                 DELETE FROM article_revisions;
                 DELETE FROM article_destinations;
+                DELETE FROM remote_article_identities;
                 DELETE FROM article_assets;
                 DELETE FROM articles;
                 DELETE FROM jobs;

--- a/backend/store/backups.py
+++ b/backend/store/backups.py
@@ -90,6 +90,7 @@ def _database_summary(database_path: Path, blobs_path: Path) -> dict:
             "users",
             "articles",
             "article_assets",
+            "remote_article_identities",
             "article_revisions",
             "connections",
             "jobs",

--- a/backend/store/base.py
+++ b/backend/store/base.py
@@ -121,6 +121,24 @@ class ArticleStore(Protocol):
     def set_destinations_pending(self, article_id: str, platforms: list[str]) -> None:
         ...
 
+    # ── Remote article identity ──────────────────────────────────────────────
+
+    def get_remote_article_identity(
+        self, user_id: str, platform: str, remote_id: str,
+    ) -> dict | None:
+        ...
+
+    def list_article_remote_identities(
+        self, user_id: str, article_id: str,
+    ) -> list[dict]:
+        ...
+
+    def upsert_remote_article_identity(
+        self, user_id: str, article_id: str, platform: str, remote_id: str,
+        **kwargs: Any,
+    ) -> dict:
+        ...
+
     # ── Connections ──────────────────────────────────────────────────────────
 
     def list_connections(self, user_id: str) -> list[dict]:

--- a/backend/store/remote_articles.py
+++ b/backend/store/remote_articles.py
@@ -1,0 +1,143 @@
+"""Durable identity and synchronization metadata for remote articles."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+
+REMOTE_SYNC_STATUSES = {"succeeded", "partial", "failed"}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _remote_article_row(row) -> dict:
+    result = dict(row)
+    result["last_sync_result"] = (
+        json.loads(result.pop("last_sync_result_json"))
+        if result.get("last_sync_result_json")
+        else None
+    )
+    return result
+
+
+class RemoteArticleStoreMixin:
+    """Mixin requiring the SQLite connection and workspace lock from SQLiteStore."""
+
+    def get_remote_article_identity(
+        self, user_id: str, platform: str, remote_id: str,
+    ) -> dict | None:
+        platform = platform.strip().lower()
+        remote_id = remote_id.strip()
+        row = self._con.execute(
+            """SELECT * FROM remote_article_identities
+               WHERE user_id=? AND platform=? AND remote_id=?""",
+            (user_id, platform, remote_id),
+        ).fetchone()
+        return _remote_article_row(row) if row else None
+
+    def list_article_remote_identities(
+        self, user_id: str, article_id: str,
+    ) -> list[dict]:
+        rows = self._con.execute(
+            """SELECT * FROM remote_article_identities
+               WHERE user_id=? AND article_id=?
+               ORDER BY platform, remote_id""",
+            (user_id, article_id),
+        ).fetchall()
+        return [_remote_article_row(row) for row in rows]
+
+    def upsert_remote_article_identity(
+        self,
+        user_id: str,
+        article_id: str,
+        platform: str,
+        remote_id: str,
+        *,
+        remote_content_fingerprint: str | None = None,
+        subtitle: str | None = None,
+        cover_asset_id: int | None = None,
+        last_sync_status: str | None = None,
+        last_sync_result: dict | None = None,
+        last_sync_error: str | None = None,
+        remote_created_at: str | None = None,
+        remote_updated_at: str | None = None,
+        last_sync_started_at: str | None = None,
+        last_synced_at: str | None = None,
+    ) -> dict:
+        platform = platform.strip().lower()
+        remote_id = remote_id.strip()
+        if not platform or not remote_id:
+            raise ValueError("platform and remote_id are required")
+        if last_sync_status is not None and last_sync_status not in REMOTE_SYNC_STATUSES:
+            raise ValueError(f"Unsupported remote sync status: {last_sync_status}")
+
+        now = _now()
+        with self._workspace_lock.acquire():
+            article = self._con.execute(
+                "SELECT id FROM articles WHERE id=? AND user_id=?",
+                (article_id, user_id),
+            ).fetchone()
+            if article is None:
+                raise KeyError(f"Article {article_id} not found for user")
+            if cover_asset_id is not None:
+                cover = self._con.execute(
+                    "SELECT id FROM article_assets WHERE id=? AND article_id=?",
+                    (cover_asset_id, article_id),
+                ).fetchone()
+                if cover is None:
+                    raise ValueError("cover asset must belong to the mapped article")
+
+            existing = self._con.execute(
+                """SELECT article_id FROM remote_article_identities
+                   WHERE user_id=? AND platform=? AND remote_id=?""",
+                (user_id, platform, remote_id),
+            ).fetchone()
+            if existing is not None and existing["article_id"] != article_id:
+                raise ValueError("remote article identity is already mapped to another article")
+
+            with self._con:
+                self._con.execute(
+                    """INSERT INTO remote_article_identities
+                       (user_id, platform, remote_id, article_id,
+                        remote_content_fingerprint, subtitle, cover_asset_id,
+                        last_sync_status, last_sync_result_json, last_sync_error,
+                        remote_created_at, remote_updated_at,
+                        last_sync_started_at, last_synced_at, created_at, updated_at)
+                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                       ON CONFLICT(user_id, platform, remote_id) DO UPDATE SET
+                         remote_content_fingerprint=excluded.remote_content_fingerprint,
+                         subtitle=excluded.subtitle,
+                         cover_asset_id=excluded.cover_asset_id,
+                         last_sync_status=excluded.last_sync_status,
+                         last_sync_result_json=excluded.last_sync_result_json,
+                         last_sync_error=excluded.last_sync_error,
+                         remote_created_at=excluded.remote_created_at,
+                         remote_updated_at=excluded.remote_updated_at,
+                         last_sync_started_at=excluded.last_sync_started_at,
+                         last_synced_at=excluded.last_synced_at,
+                         updated_at=excluded.updated_at""",
+                    (
+                        user_id,
+                        platform,
+                        remote_id,
+                        article_id,
+                        remote_content_fingerprint,
+                        subtitle,
+                        cover_asset_id,
+                        last_sync_status,
+                        json.dumps(last_sync_result, sort_keys=True)
+                        if last_sync_result is not None else None,
+                        last_sync_error,
+                        remote_created_at,
+                        remote_updated_at,
+                        last_sync_started_at,
+                        last_synced_at,
+                        now,
+                        now,
+                    ),
+                )
+        return self.get_remote_article_identity(
+            user_id, platform, remote_id,
+        )  # type: ignore[return-value]

--- a/backend/store/schema.py
+++ b/backend/store/schema.py
@@ -1,9 +1,4 @@
-"""Applies BlogHub's SQLite schema, defined in sql/schema.sql.
-
-BlogHub does not migrate schemas in place. When the schema changes, delete
-the runtime database and let it be recreated fresh from sql/schema.sql
-instead of writing an upgrade path for the old shape.
-"""
+"""Apply BlogHub's current SQLite schema and additive migrations."""
 from __future__ import annotations
 
 import sqlite3
@@ -13,10 +8,9 @@ SEED_USER_ID = "user_seed"
 SEED_USER_EMAIL = "seed@example.com"
 SEED_USER_HASH = "$2b$12$BJsbJlf3SZUMUISLA8oASeFn.Q3U.Ar6TqoIFtu0F9OlYyev.DZLC"
 
-# Bump when sql/schema.sql changes in a way that isn't safe to layer onto an
-# existing database (e.g. a dropped/renamed column). Operators reset by
-# deleting the database file; there is no in-place upgrade path.
-SCHEMA_VERSION = 7
+# Bump for every released schema shape. Idempotent additions migrate in place;
+# destructive changes require an explicit migration and recovery plan.
+SCHEMA_VERSION = 8
 
 _SCHEMA_SQL_PATH = Path(__file__).resolve().parent / "sql" / "schema.sql"
 

--- a/backend/store/sql/schema.sql
+++ b/backend/store/sql/schema.sql
@@ -1,10 +1,8 @@
 -- BlogHub SQLite schema.
 --
--- This is the single source of truth for the database shape. BlogHub does
--- not migrate schemas in place: when this file changes, delete the runtime
--- database (data/bloghub.db) and let it be recreated fresh. All statements
--- are idempotent so re-running this file against an already-current
--- database is a no-op.
+-- This is the single source of truth for the database shape. Additive changes
+-- are idempotent and migrate in place when BlogHub opens an older database.
+-- Destructive changes require an explicit migration and recovery plan.
 
 CREATE TABLE IF NOT EXISTS users (
     id            TEXT PRIMARY KEY,
@@ -36,6 +34,9 @@ CREATE TABLE IF NOT EXISTS articles (
     updated_at      TEXT NOT NULL,
     user_id         TEXT REFERENCES users(id) ON DELETE CASCADE
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_articles_id_user
+    ON articles(id, user_id);
 
 CREATE TABLE IF NOT EXISTS article_destinations (
     article_id  TEXT NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
@@ -118,6 +119,31 @@ CREATE TABLE IF NOT EXISTS article_assets (
     mime_type   TEXT,
     created_at  TEXT NOT NULL,
     UNIQUE(article_id, filename)
+);
+
+CREATE TABLE IF NOT EXISTS remote_article_identities (
+    user_id                   TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    platform                  TEXT NOT NULL,
+    remote_id                 TEXT NOT NULL,
+    article_id                TEXT NOT NULL,
+    remote_content_fingerprint TEXT,
+    subtitle                  TEXT,
+    cover_asset_id            INTEGER REFERENCES article_assets(id) ON DELETE SET NULL,
+    last_sync_status          TEXT CHECK (
+        last_sync_status IS NULL OR
+        last_sync_status IN ('succeeded', 'partial', 'failed')
+    ),
+    last_sync_result_json     TEXT,
+    last_sync_error           TEXT,
+    remote_created_at         TEXT,
+    remote_updated_at         TEXT,
+    last_sync_started_at      TEXT,
+    last_synced_at            TEXT,
+    created_at                TEXT NOT NULL,
+    updated_at                TEXT NOT NULL,
+    PRIMARY KEY (user_id, platform, remote_id),
+    FOREIGN KEY (article_id, user_id)
+        REFERENCES articles(id, user_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS article_comments (
@@ -292,6 +318,9 @@ CREATE INDEX IF NOT EXISTS idx_article_timeline_article
 
 CREATE INDEX IF NOT EXISTS idx_article_revisions_article
     ON article_revisions(article_id, revision_number DESC);
+
+CREATE INDEX IF NOT EXISTS idx_remote_articles_local_article
+    ON remote_article_identities(user_id, article_id);
 
 CREATE INDEX IF NOT EXISTS idx_article_comments_article
     ON article_comments(article_id);

--- a/contracts/remote-articles.ts
+++ b/contracts/remote-articles.ts
@@ -1,0 +1,19 @@
+export type RemoteSyncStatus = "succeeded" | "partial" | "failed";
+
+export interface RemoteArticleIdentity {
+  articleId: string;
+  platform: string;
+  remoteId: string;
+  remoteContentFingerprint: string | null;
+  subtitle: string | null;
+  coverAssetId: number | null;
+  lastSyncStatus: RemoteSyncStatus | null;
+  lastSyncResult: Record<string, unknown> | null;
+  lastSyncError: string | null;
+  remoteCreatedAt: string | null;
+  remoteUpdatedAt: string | null;
+  lastSyncStartedAt: string | null;
+  lastSyncedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/docs/database-recovery.md
+++ b/docs/database-recovery.md
@@ -23,11 +23,14 @@ Python so it can be read and reviewed on its own. BlogHub applies it automatical
 when it opens the database; every statement is idempotent, so re-applying it
 against an already-current database is a no-op.
 
-BlogHub does not migrate schemas in place. When `schema.sql` changes, delete the
-runtime database (`data/bloghub.db`) and let it be recreated fresh, instead of
-writing an upgrade path for the old shape. Bump `SCHEMA_VERSION` in
-`backend/store/schema.py` alongside a breaking schema change so `status` reports
-it.
+BlogHub applies additive migrations in place by re-running the idempotent schema
+and advancing `SCHEMA_VERSION` in `backend/store/schema.py`. Version 8 adds the
+`remote_article_identities` table and supporting indexes; opening a version 7
+database creates those structures without rewriting existing article rows.
+
+Breaking changes still require an explicit migration before release. Do not
+drop or rename columns in `schema.sql` and rely on `CREATE TABLE IF NOT EXISTS`.
+Take a verified database-and-blob backup before deploying a schema upgrade.
 
 Check the current schema version and database integrity with:
 
@@ -96,6 +99,16 @@ python scripts/bloghub_db.py status
 
 Restore stages the database and blobs before replacing the active paths. If the
 replacement fails, it puts the previous database and blob directory back.
+
+## Version 8 rollback
+
+The version 8 migration is additive. Rolling the application binary back leaves
+the remote identity table unused, but downgrade compatibility is not guaranteed
+by older BlogHub versions. The supported rollback is to stop all writers and
+restore the verified version 7 backup taken before deployment. A later retry can
+open that backup and apply version 8 again. Restoring only the SQLite file is not
+supported because cover references and article assets belong to the same backup
+generation.
 
 ## Recovery policy
 

--- a/tests/tests_backend/test_store/test_backups.py
+++ b/tests/tests_backend/test_store/test_backups.py
@@ -27,12 +27,23 @@ def test_online_backup_contains_database_and_referenced_blobs(tmp_path):
             b"png-content",
             "image/png",
         )
+        store.upsert_remote_article_identity(
+            store.SEED_USER_ID,
+            "art_001",
+            "hashnode",
+            "remote-backup-test",
+            remote_content_fingerprint="sha256:backup",
+            last_sync_status="succeeded",
+            last_sync_result={"articlesUpdated": 1},
+            last_synced_at="2026-08-20T08:00:00+00:00",
+        )
         bundle = store.create_backup(str(tmp_path / "backups"))
         manifest = verify_backup(bundle)
 
         assert manifest["summary"]["schema_version"] == SCHEMA_VERSION
         assert manifest["summary"]["counts"]["articles"] == 6
         assert manifest["summary"]["counts"]["article_assets"] == 1
+        assert manifest["summary"]["counts"]["remote_article_identities"] == 1
         assert manifest["summary"]["counts"]["article_revisions"] == 6
         assert manifest["summary"]["referenced_blob_count"] == 7
         assert (

--- a/tests/tests_backend/test_store/test_remote_articles.py
+++ b/tests/tests_backend/test_store/test_remote_articles.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from backend.schemas.remote_articles import RemoteArticleIdentity
+from backend.store.backends.sqlite import SQLiteStore
+from backend.store.schema import SCHEMA_VERSION
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _store(tmp_path) -> SQLiteStore:
+    return SQLiteStore(str(tmp_path / "bloghub.db"), str(tmp_path / "blobs"))
+
+
+def _cover_asset_id(store: SQLiteStore, article_id: str) -> int:
+    store.store_asset(
+        store.SEED_USER_ID, article_id, "cover.png", b"cover", "image/png",
+    )
+    return store._con.execute(
+        "SELECT id FROM article_assets WHERE article_id=? AND filename='cover.png'",
+        (article_id,),
+    ).fetchone()[0]
+
+
+def test_remote_identity_and_sync_metadata_round_trip(tmp_path):
+    store = _store(tmp_path)
+    try:
+        article = store.create_article(store.SEED_USER_ID, "Remote article")
+        cover_asset_id = _cover_asset_id(store, article["id"])
+        identity = store.upsert_remote_article_identity(
+            store.SEED_USER_ID,
+            article["id"],
+            "Hashnode",
+            "remote-123",
+            remote_content_fingerprint="sha256:content-v1",
+            subtitle="A durable subtitle",
+            cover_asset_id=cover_asset_id,
+            last_sync_status="partial",
+            last_sync_result={"articlesUpdated": 1, "imagesFailed": 1},
+            last_sync_error="one image was unavailable",
+            remote_created_at="2026-08-01T10:00:00+00:00",
+            remote_updated_at="2026-08-19T12:00:00+00:00",
+            last_sync_started_at="2026-08-20T07:59:00+00:00",
+            last_synced_at="2026-08-20T08:00:00+00:00",
+        )
+
+        assert identity["platform"] == "hashnode"
+        assert identity["remote_content_fingerprint"] == "sha256:content-v1"
+        assert identity["subtitle"] == "A durable subtitle"
+        assert identity["cover_asset_id"] == cover_asset_id
+        assert identity["last_sync_status"] == "partial"
+        assert identity["last_sync_result"] == {
+            "articlesUpdated": 1,
+            "imagesFailed": 1,
+        }
+        assert identity["last_sync_error"] == "one image was unavailable"
+        assert identity["remote_created_at"] == "2026-08-01T10:00:00+00:00"
+        assert identity["remote_updated_at"] == "2026-08-19T12:00:00+00:00"
+        assert identity["last_sync_started_at"] == "2026-08-20T07:59:00+00:00"
+        assert identity["last_synced_at"] == "2026-08-20T08:00:00+00:00"
+
+        api_model = RemoteArticleIdentity.model_validate(identity)
+        payload = api_model.model_dump(by_alias=True, mode="json")
+        assert payload["articleId"] == article["id"]
+        assert payload["remoteId"] == "remote-123"
+        assert payload["lastSyncStatus"] == "partial"
+        assert payload["lastSyncResult"]["imagesFailed"] == 1
+    finally:
+        store.close()
+
+
+def test_remote_identity_is_stable_and_unique_per_user_platform_remote_id(tmp_path):
+    store = _store(tmp_path)
+    try:
+        first = store.create_article(store.SEED_USER_ID, "First")
+        second = store.create_article(store.SEED_USER_ID, "Second")
+        store.upsert_remote_article_identity(
+            store.SEED_USER_ID, first["id"], "hashnode", "same-id",
+            subtitle="Before",
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            with store._con:
+                store._con.execute(
+                    """INSERT INTO remote_article_identities
+                       (user_id, platform, remote_id, article_id, created_at, updated_at)
+                       VALUES (?,?,?,?,?,?)""",
+                    (
+                        store.SEED_USER_ID,
+                        "hashnode",
+                        "same-id",
+                        second["id"],
+                        "2026-08-20T08:00:00+00:00",
+                        "2026-08-20T08:00:00+00:00",
+                    ),
+                )
+        updated = store.upsert_remote_article_identity(
+            store.SEED_USER_ID, first["id"], "hashnode", "same-id",
+            subtitle="After",
+        )
+        assert updated["article_id"] == first["id"]
+        assert updated["subtitle"] == "After"
+
+        with pytest.raises(ValueError, match="already mapped"):
+            store.upsert_remote_article_identity(
+                store.SEED_USER_ID, second["id"], "hashnode", "same-id",
+            )
+
+        other_user = store.create_user("remote-owner@example.com", "hash")
+        other_article = store.create_article(other_user["id"], "Other user's copy")
+        other = store.upsert_remote_article_identity(
+            other_user["id"], other_article["id"], "hashnode", "same-id",
+        )
+        assert other["article_id"] == other_article["id"]
+        assert store._con.execute(
+            """SELECT COUNT(*) FROM remote_article_identities
+               WHERE platform='hashnode' AND remote_id='same-id'"""
+        ).fetchone()[0] == 2
+    finally:
+        store.close()
+
+
+def test_remote_identity_enforces_article_and_cover_ownership(tmp_path):
+    store = _store(tmp_path)
+    try:
+        seed_article = store.create_article(store.SEED_USER_ID, "Seed article")
+        other_user = store.create_user("other-owner@example.com", "hash")
+        other_article = store.create_article(other_user["id"], "Other article")
+        other_cover = store.store_asset(
+            other_user["id"], other_article["id"], "cover.png", b"other", "image/png",
+        )
+        assert other_cover
+        other_cover_id = store._con.execute(
+            "SELECT id FROM article_assets WHERE article_id=?",
+            (other_article["id"],),
+        ).fetchone()[0]
+
+        with pytest.raises(KeyError, match="not found for user"):
+            store.upsert_remote_article_identity(
+                store.SEED_USER_ID, other_article["id"], "hashnode", "foreign-article",
+            )
+        with pytest.raises(ValueError, match="must belong"):
+            store.upsert_remote_article_identity(
+                store.SEED_USER_ID,
+                seed_article["id"],
+                "hashnode",
+                "foreign-cover",
+                cover_asset_id=other_cover_id,
+            )
+
+        with pytest.raises(sqlite3.IntegrityError):
+            with store._con:
+                store._con.execute(
+                    """INSERT INTO remote_article_identities
+                       (user_id, platform, remote_id, article_id, created_at, updated_at)
+                       VALUES (?,?,?,?,?,?)""",
+                    (
+                        store.SEED_USER_ID,
+                        "hashnode",
+                        "foreign-direct",
+                        other_article["id"],
+                        "2026-08-20T08:00:00+00:00",
+                        "2026-08-20T08:00:00+00:00",
+                    ),
+                )
+    finally:
+        store.close()
+
+
+def test_remote_identity_foreign_key_deletion_behavior(tmp_path):
+    store = _store(tmp_path)
+    try:
+        article = store.create_article(store.SEED_USER_ID, "Delete behavior")
+        cover_asset_id = _cover_asset_id(store, article["id"])
+        store.upsert_remote_article_identity(
+            store.SEED_USER_ID,
+            article["id"],
+            "hashnode",
+            "delete-test",
+            cover_asset_id=cover_asset_id,
+        )
+
+        with store._con:
+            store._con.execute("DELETE FROM article_assets WHERE id=?", (cover_asset_id,))
+        without_cover = store.get_remote_article_identity(
+            store.SEED_USER_ID, "hashnode", "delete-test",
+        )
+        assert without_cover["cover_asset_id"] is None
+
+        assert store.delete_articles(store.SEED_USER_ID, [article["id"]]) == []
+        assert store.get_remote_article_identity(
+            store.SEED_USER_ID, "hashnode", "delete-test",
+        ) is None
+
+        other_user = store.create_user("deleted-owner@example.com", "hash")
+        other_article = store.create_article(other_user["id"], "User cascade")
+        store.upsert_remote_article_identity(
+            other_user["id"], other_article["id"], "hashnode", "user-delete",
+        )
+        with store._con:
+            store._con.execute("DELETE FROM users WHERE id=?", (other_user["id"],))
+        assert store._con.execute(
+            "SELECT COUNT(*) FROM remote_article_identities WHERE remote_id='user-delete'"
+        ).fetchone()[0] == 0
+    finally:
+        store.close()
+
+
+def test_v7_database_migrates_without_changing_native_articles(tmp_path):
+    database = tmp_path / "bloghub.db"
+    blobs = tmp_path / "blobs"
+    store = SQLiteStore(str(database), str(blobs))
+    store.update_article_title(store.SEED_USER_ID, "art_001", "Preserved native article")
+    with store._con:
+        store._con.execute("DROP TABLE remote_article_identities")
+        store._con.execute("PRAGMA user_version = 7")
+    store.close()
+
+    migrated = SQLiteStore(str(database), str(blobs))
+    try:
+        assert migrated.schema_version == SCHEMA_VERSION == 8
+        assert migrated.get_article(migrated.SEED_USER_ID, "art_001")["title"] == (
+            "Preserved native article"
+        )
+        assert migrated._con.execute(
+            """SELECT 1 FROM sqlite_master
+               WHERE type='table' AND name='remote_article_identities'"""
+        ).fetchone()
+        assert migrated.list_article_remote_identities(
+            migrated.SEED_USER_ID, "art_001",
+        ) == []
+    finally:
+        migrated.close()
+
+
+def test_remote_article_typescript_contract_matches_api_model():
+    source = (ROOT / "contracts" / "remote-articles.ts").read_text(encoding="utf-8")
+    body = re.search(
+        r"export interface RemoteArticleIdentity\s*\{(?P<body>.*?)\}",
+        source,
+        re.DOTALL,
+    ).group("body")
+    typescript_fields = {
+        line.strip().split(":", 1)[0].rstrip("?")
+        for line in body.splitlines()
+        if ":" in line
+    }
+    model_fields = {
+        field.alias or name
+        for name, field in RemoteArticleIdentity.model_fields.items()
+    }
+    assert typescript_fields == model_fields

--- a/tests/tests_backend/test_store/test_schema.py
+++ b/tests/tests_backend/test_store/test_schema.py
@@ -38,6 +38,7 @@ def test_fresh_database_has_current_schema_and_seed_user(tmp_path):
             "agent_session_outputs",
             "browser_publish_runs",
             "browser_connections",
+            "remote_article_identities",
         } <= tables
         assert store._con.execute(
             "SELECT COUNT(*) FROM users WHERE id=?", (SEED_USER_ID,)
@@ -49,6 +50,27 @@ def test_fresh_database_has_current_schema_and_seed_user(tmp_path):
             )
         }
         assert "mode" in publish_columns
+        remote_identity_columns = {
+            row[1]
+            for row in store._con.execute(
+                "PRAGMA table_info(remote_article_identities)"
+            )
+        }
+        assert {
+            "user_id",
+            "platform",
+            "remote_id",
+            "article_id",
+            "remote_content_fingerprint",
+            "subtitle",
+            "cover_asset_id",
+            "last_sync_status",
+            "last_sync_result_json",
+            "remote_created_at",
+            "remote_updated_at",
+            "last_sync_started_at",
+            "last_synced_at",
+        } <= remote_identity_columns
     finally:
         store.close()
 


### PR DESCRIPTION
## Summary
- add a user-scoped remote article identity table keyed by platform and remote ID
- persist content fingerprints, subtitles, cover asset references, structured sync results, and remote/sync timestamps
- expose deterministic storage protocol and facade methods with ownership validation
- add mirrored Pydantic and TypeScript models
- migrate schema version 7 databases additively to version 8 and include mappings in backups

## Foreign key behavior
- deleting an article or user cascades its remote mappings
- deleting a referenced cover asset sets the mapping cover reference to null
- composite article/user ownership is enforced by SQLite

## Scope
Storage and models only. This PR does not fetch, synchronize, download, or render remote content.

## Validation
- focused schema, persistence, migration, and backup suite: 15 passed
- backend suite: 290 passed, 13 environment-dependent tests deselected
- Python compileall
- git diff --check

Closes #47