### PR TITLE
feat: add GitHub CI baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
+      - "feat/**"
+      - "fix/**"
+      - "docs/**"
+      - "refactor/**"
+      - "test/**"
+      - "chore/**"
+      - "hotfix/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  python-tests:
+    name: Python tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      BLOGHUB_DB_PATH: ":memory:"
+      BLOGHUB_BLOBS_DIR: ${{ runner.temp }}/bloghub-blobs
+      BLOGHUB_CREDENTIAL_KEY_FILE: ${{ runner.temp }}/bloghub-credential-keys.json
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            backend/requirements.txt
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt -r backend/requirements.txt
+
+      - name: Run unit tests
+        run: python -m pytest
+
+  contract-checks:
+    name: Contract checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Validate generated contracts
+        run: npm run check:contracts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,10 @@ writes credentials into the mounted volume.
 ## Running Tests
 
 ```bash
-# Backend unit tests (no browser, no Docker needed)
-cd blog-hub && .venv/Scripts/python.exe -m pytest tests/backend -v
+# CI baseline: unit tests and API contract checks
+cd blog-hub
+python -m pytest
+npm run check:contracts
 
 # UI browser tests (requires backend on :8000 and cli-runner on :8001)
 .venv/Scripts/python.exe -m uvicorn backend.main:app --port 8000
@@ -84,3 +86,6 @@ cd blog-hub && .venv/Scripts/python.exe -m pytest tests/backend -v
 
 The Playwright UI test for Claude login (`test_claude_browser_login_full_loopback_flow`) captures
 the callback URL from failed network requests via `page.on("request", ...)` — no manual copy needed.
+
+GitHub CI is documented in `docs/ci.md`. Browser and live-provider tests remain
+opt-in until their dedicated Playwright workflow lands.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]>=0.29.0
 python-multipart>=0.0.9   # required for UploadFile / multipart form endpoints
 pydantic>=2.7.0
 httpx>=0.27.0   # for TestClient in pytest
+markdown-it-py>=3.0.0
 pytest>=8.2.0
 pytest-asyncio>=0.23.0
 aiofiles>=23.2.1

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,20 @@
+# Continuous Integration
+
+GitHub Actions runs the baseline CI workflow for pull requests into `develop`,
+pushes to numbered work branches, and manual dispatches.
+
+The default checks are intentionally deterministic:
+
+```bash
+python -m pytest
+npm run check:contracts
+```
+
+`pytest.ini` excludes tests marked `integration` or `browser` from the default
+Python run. Live provider credentials such as `HASHNODE_PAT`, `DEVTO_API_KEY`,
+and Medium browser sessions are not required by CI and should not be used by the
+baseline workflow.
+
+Playwright/browser coverage is tracked separately in issue #56. Those tests
+need browser setup, screenshots/traces on failure, and fixture-backed provider
+states before they become a required CI gate.

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ addopts    = -m "not integration and not browser"
 markers =
     integration: end-to-end tests that require live external services (Medium session)
     browser: Playwright browser tests that require a live server on port 8000
+    timeout: per-test timeout for optional live/browser suites

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ cryptography>=42.0.0
 email-validator>=2.1.0
 fastapi>=0.111.0
 httpx>=0.27.0
+markdown-it-py>=3.0.0
 python-multipart>=0.0.9
 PyYAML>=6.0.0
 requests>=2.31.0

--- a/scripts/generate-types.mjs
+++ b/scripts/generate-types.mjs
@@ -27,6 +27,11 @@ const cli = process.platform === "win32" && existsSync(binBase + ".cmd")
 
 mkdirSync(outDir, { recursive: true });
 
+if (!existsSync(specDir)) {
+  console.log("No .spec/backend directory found; using checked-in generated contracts.");
+  process.exit(0);
+}
+
 /**
  * Recursively find all swagger.yaml files under a directory.
  * Returns [{service, path}]
@@ -77,4 +82,3 @@ if (hadError) {
 } else {
   console.log("Done. Run `npm run check:types` to validate TS compatibility.");
 }
-

--- a/tests/tests_backend/test_connections_drafts.py
+++ b/tests/tests_backend/test_connections_drafts.py
@@ -421,6 +421,7 @@ class TestGetDraftUnit:
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+@pytest.mark.integration
 class TestDraftsIntegration:
 
     @pytest.fixture(autouse=True)

--- a/tests/tests_backend/test_credential_storage.py
+++ b/tests/tests_backend/test_credential_storage.py
@@ -49,7 +49,10 @@ def test_default_key_file_encrypts_without_plaintext(credential_environment):
     assert "sk-ant-secret" not in raw
     assert store.get_connection_token(store.SEED_USER_ID, "anthropic") == "sk-ant-secret"
     if os.name == "posix":
-        assert stat.S_IMODE(key_file.stat().st_mode) == 0o600
+        mode = stat.S_IMODE(key_file.stat().st_mode)
+        if mode != 0o600 and str(key_file).startswith("/mnt/"):
+            pytest.skip("WSL-mounted Windows filesystems do not preserve POSIX chmod")
+        assert mode == 0o600
 
 
 def test_startup_migrates_plaintext_and_disconnect_erases_it(credential_environment):

--- a/tests/tests_devto/conftest.py
+++ b/tests/tests_devto/conftest.py
@@ -16,6 +16,7 @@ from fastapi.testclient import TestClient
 
 from backend.main import app
 import backend.store as store
+from backend.store.schema import SEED_USER_ID
 
 
 @pytest.fixture(autouse=True)
@@ -32,5 +33,5 @@ def client():
 
 @pytest.fixture
 def all_articles():
-    items, _ = store.list_articles()
+    items, _ = store.list_articles(SEED_USER_ID)
     return items

--- a/tests/tests_hashnode/conftest.py
+++ b/tests/tests_hashnode/conftest.py
@@ -16,6 +16,7 @@ from fastapi.testclient import TestClient
 
 from backend.main import app
 import backend.store as store
+from backend.store.schema import SEED_USER_ID
 
 
 @pytest.fixture(autouse=True)
@@ -32,5 +33,5 @@ def client():
 
 @pytest.fixture
 def all_articles():
-    items, _ = store.list_articles()
+    items, _ = store.list_articles(SEED_USER_ID)
     return items

--- a/tests/tests_medium/conftest.py
+++ b/tests/tests_medium/conftest.py
@@ -25,6 +25,7 @@ import pytest
 from fastapi.testclient import TestClient
 from backend.main import app
 import backend.store as store
+from backend.store.schema import SEED_USER_ID
 
 
 @pytest.fixture(autouse=True)
@@ -43,5 +44,5 @@ def client():
 @pytest.fixture
 def all_articles():
     """Return all seed articles (list of dicts)."""
-    items, _ = store.list_articles()
+    items, _ = store.list_articles(SEED_USER_ID)
     return items


### PR DESCRIPTION
## Summary
- Add a GitHub Actions CI workflow for PRs into develop, numbered work branches, and manual dispatches.
- Run the default Python unit suite and generated-contract TypeScript checks.
- Document the CI baseline and keep browser/live-provider tests explicitly out of this first required gate.

## Test and dependency fixes
- Add the missing markdown-it-py dependency used by Medium rendering tests.
- Make generated contract checks tolerate branches where .spec/backend is absent and checked-in generated contracts are used.
- Fix platform service fixtures to use the seed user id with the user-scoped article store.
- Mark live draft listing tests as integration so default CI does not call real providers.
- Avoid false failures on WSL-mounted filesystems that do not preserve POSIX chmod.

## Validation
- npm run check:contracts
- uv run --with-requirements requirements.txt --with-requirements backend/requirements.txt python -m pytest -s

Closes #54