### PR TITLE
feat: add safe remote image ingestion

### DIFF
--- a/backend/services/image_ingest.py
+++ b/backend/services/image_ingest.py
@@ -113,12 +113,14 @@ def _is_safe_ip(ip: IPv4Address | IPv6Address) -> bool:
     if isinstance(ip, IPv6Address) and ip.ipv4_mapped is not None:
         ip = ip.ipv4_mapped
     return not (
-        ip.is_loopback
+        not ip.is_global
+        or ip.is_loopback
         or ip.is_link_local
         or ip.is_private
         or ip.is_multicast
         or ip.is_reserved
         or ip.is_unspecified
+        or (isinstance(ip, IPv6Address) and ip.is_site_local)
     )
 
 

--- a/backend/services/image_ingest.py
+++ b/backend/services/image_ingest.py
@@ -1,0 +1,401 @@
+"""
+Bounded, SSRF-hardened remote image ingestion.
+
+This module downloads a single remote image over HTTP(S), validates it end
+to end (network destination, declared MIME type, decoded format, dimensions,
+pixel count), and returns orientation-corrected image bytes plus a bounded
+thumbnail. It performs no storage: callers own persistence.
+
+Scope (see issue #46/#49): standalone ingestion + validation utility. It is
+NOT wired into Hashnode sync, routers, or the article/asset store.
+
+Security model
+---------------
+Untrusted URLs can point at internal infrastructure (SSRF) directly, via a
+redirect chain, or via DNS rebinding (a hostname that resolves safely at
+validation time and unsafely at connect time). To close all three paths:
+
+- Only http/https schemes are accepted.
+- Every hop (the original URL and each redirect target) has its hostname
+  resolved to a concrete IP address, and that IP is checked against the
+  loopback / link-local / private / multicast / reserved / unspecified
+  ranges *before* any connection is made.
+- The connection is pinned to the exact IP address that was validated (via
+  a transport wrapper), so a hostname cannot resolve to a different,
+  unsafe address between validation and connection (DNS rebinding).
+- Redirects are followed manually, one hop at a time, up to a bounded
+  count, with the same validation applied to each target.
+"""
+from __future__ import annotations
+
+import io
+import socket
+from dataclasses import dataclass
+from enum import Enum
+from ipaddress import IPv4Address, IPv6Address, ip_address
+from urllib.parse import urlsplit
+
+import httpx
+from PIL import Image, ImageOps, UnidentifiedImageError
+
+# ── Policy ───────────────────────────────────────────────────────────────
+
+ALLOWED_SCHEMES = {"http", "https"}
+
+# Declared Content-Type -> expected Pillow format name. Both must agree.
+ALLOWED_CONTENT_TYPES: dict[str, str] = {
+    "image/jpeg": "JPEG",
+    "image/png": "PNG",
+    "image/gif": "GIF",
+    "image/webp": "WEBP",
+}
+ALLOWED_IMAGE_FORMATS = set(ALLOWED_CONTENT_TYPES.values())
+
+DEFAULT_MAX_BYTES = 8 * 1024 * 1024          # 8 MiB response cap
+DEFAULT_MAX_REDIRECTS = 5
+DEFAULT_MAX_DIMENSION = 8000                 # px, per side
+DEFAULT_MAX_PIXELS = 40_000_000              # ~40 MP decompression-bomb guard
+DEFAULT_THUMBNAIL_SIZE = (400, 400)          # bounded card thumbnail (w, h)
+DEFAULT_TIMEOUT = httpx.Timeout(connect=3.0, read=10.0, write=5.0, pool=5.0)
+
+
+class ImageIngestReason(str, Enum):
+    """Stable, non-secret failure categories safe to surface in sync reports."""
+
+    UNSUPPORTED_SCHEME = "unsupported_scheme"
+    INVALID_URL = "invalid_url"
+    UNSAFE_DESTINATION = "unsafe_destination"
+    DNS_RESOLUTION_FAILED = "dns_resolution_failed"
+    TOO_MANY_REDIRECTS = "too_many_redirects"
+    TIMEOUT = "timeout"
+    HTTP_ERROR = "http_error"
+    MIME_NOT_ALLOWED = "mime_not_allowed"
+    MIME_MISMATCH = "mime_mismatch"
+    RESPONSE_TOO_LARGE = "response_too_large"
+    DECODE_FAILED = "decode_failed"
+    DIMENSIONS_TOO_LARGE = "dimensions_too_large"
+    PIXEL_COUNT_TOO_LARGE = "pixel_count_too_large"
+    NETWORK_ERROR = "network_error"
+
+
+class ImageIngestError(Exception):
+    """Internal control-flow exception. Never escapes fetch_and_validate_image."""
+
+    def __init__(self, reason: ImageIngestReason):
+        self.reason = reason
+        super().__init__(reason.value)
+
+
+@dataclass
+class IngestedImage:
+    """Result of an ingestion attempt. Bytes are held in memory only; nothing
+    is written to disk or a database by this module."""
+
+    ok: bool
+    reason: ImageIngestReason | None = None
+    source_url: str | None = None
+    final_url: str | None = None
+    content_type: str | None = None
+    image_format: str | None = None
+    width: int | None = None
+    height: int | None = None
+    size_bytes: int | None = None
+    image_bytes: bytes | None = None
+    thumbnail_bytes: bytes | None = None
+    thumbnail_format: str | None = None
+    thumbnail_width: int | None = None
+    thumbnail_height: int | None = None
+
+
+# ── Network safety ──────────────────────────────────────────────────────
+
+def _is_safe_ip(ip: IPv4Address | IPv6Address) -> bool:
+    if isinstance(ip, IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return not (
+        ip.is_loopback
+        or ip.is_link_local
+        or ip.is_private
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _resolve_safe_ip(hostname: str) -> str:
+    """Resolve hostname to an IP and reject it if unsafe. Raises ImageIngestError."""
+    try:
+        literal = ip_address(hostname.strip("[]"))
+    except ValueError:
+        literal = None
+
+    if literal is not None:
+        if not _is_safe_ip(literal):
+            raise ImageIngestError(ImageIngestReason.UNSAFE_DESTINATION)
+        return str(literal)
+
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as exc:
+        raise ImageIngestError(ImageIngestReason.DNS_RESOLUTION_FAILED) from exc
+
+    resolved: list[IPv4Address | IPv6Address] = []
+    for info in infos:
+        addr = info[4][0]
+        try:
+            resolved.append(ip_address(addr.split("%")[0]))
+        except ValueError:
+            continue
+
+    if not resolved:
+        raise ImageIngestError(ImageIngestReason.DNS_RESOLUTION_FAILED)
+
+    # Reject the whole hostname if *any* resolved address is unsafe. A host
+    # that answers with a mix of public and private addresses is exactly
+    # the DNS-rebinding shape we're defending against.
+    for candidate in resolved:
+        if not _is_safe_ip(candidate):
+            raise ImageIngestError(ImageIngestReason.UNSAFE_DESTINATION)
+
+    return str(resolved[0])
+
+
+def _validate_scheme(url: str) -> str:
+    parts = urlsplit(url)
+    if parts.scheme not in ALLOWED_SCHEMES:
+        raise ImageIngestError(ImageIngestReason.UNSUPPORTED_SCHEME)
+    if not parts.hostname:
+        raise ImageIngestError(ImageIngestReason.INVALID_URL)
+    return url
+
+
+class _PinnedTransport(httpx.BaseTransport):
+    """Wraps a transport so every request (including redirect hops handled by
+    the caller) is DNS-resolved and safety-checked immediately before the
+    connection is made, and the connection is pinned to that exact address.
+
+    This closes the DNS-rebinding gap: resolving a hostname once during
+    validation and connecting to it separately later would let an attacker
+    change the answer in between.
+    """
+
+    def __init__(self, wrapped: httpx.BaseTransport):
+        self._wrapped = wrapped
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        hostname = request.url.host
+        ip = _resolve_safe_ip(hostname)
+        pinned_url = request.url.copy_with(host=ip)
+        pinned_request = httpx.Request(
+            method=request.method,
+            url=pinned_url,
+            headers=request.headers,
+            stream=request.stream,
+            extensions={**request.extensions, "sni_hostname": hostname},
+        )
+        response = self._wrapped.handle_request(pinned_request)
+        response.request = request
+        return response
+
+    def close(self) -> None:
+        self._wrapped.close()
+
+
+def _normalize_content_type(header_value: str | None) -> str | None:
+    if not header_value:
+        return None
+    return header_value.split(";")[0].strip().lower()
+
+
+# ── Download ─────────────────────────────────────────────────────────────
+
+def _download(
+    url: str,
+    *,
+    max_bytes: int,
+    max_redirects: int,
+    timeout: httpx.Timeout,
+    transport: httpx.BaseTransport,
+) -> tuple[bytes, str, str]:
+    """Stream a single image, following bounded, revalidated redirects.
+
+    Returns (bytes, normalized_content_type, final_url).
+    """
+    current_url = _validate_scheme(url)
+    pinned = _PinnedTransport(transport)
+
+    with httpx.Client(transport=pinned, timeout=timeout, follow_redirects=False) as client:
+        redirects = 0
+        while True:
+            try:
+                with client.stream("GET", current_url) as response:
+                    if response.is_redirect:
+                        redirects += 1
+                        if redirects > max_redirects:
+                            raise ImageIngestError(ImageIngestReason.TOO_MANY_REDIRECTS)
+                        location = response.headers.get("location")
+                        if not location:
+                            raise ImageIngestError(ImageIngestReason.HTTP_ERROR)
+                        next_url = str(httpx.URL(current_url).join(location))
+                        current_url = _validate_scheme(next_url)
+                        continue
+
+                    if response.status_code != 200:
+                        raise ImageIngestError(ImageIngestReason.HTTP_ERROR)
+
+                    content_type = _normalize_content_type(response.headers.get("content-type"))
+                    if content_type not in ALLOWED_CONTENT_TYPES:
+                        raise ImageIngestError(ImageIngestReason.MIME_NOT_ALLOWED)
+
+                    declared_length = response.headers.get("content-length")
+                    if declared_length is not None and declared_length.isdigit():
+                        if int(declared_length) > max_bytes:
+                            raise ImageIngestError(ImageIngestReason.RESPONSE_TOO_LARGE)
+
+                    chunks = bytearray()
+                    for chunk in response.iter_bytes():
+                        chunks.extend(chunk)
+                        if len(chunks) > max_bytes:
+                            raise ImageIngestError(ImageIngestReason.RESPONSE_TOO_LARGE)
+
+                    return bytes(chunks), content_type, current_url
+            except ImageIngestError:
+                raise
+            except httpx.TimeoutException as exc:
+                raise ImageIngestError(ImageIngestReason.TIMEOUT) from exc
+            except httpx.HTTPError as exc:
+                raise ImageIngestError(ImageIngestReason.NETWORK_ERROR) from exc
+
+
+# ── Decode & thumbnail ──────────────────────────────────────────────────
+
+def _decode_and_build(
+    image_bytes: bytes,
+    *,
+    content_type: str,
+    max_dimension: int,
+    max_pixels: int,
+    thumbnail_size: tuple[int, int],
+) -> tuple[Image.Image, Image.Image, str]:
+    """Validate, orientation-correct, and thumbnail decoded image bytes.
+
+    Returns (corrected_full_image, thumbnail_image, pillow_format).
+    Raises ImageIngestError on any validation failure.
+    """
+    try:
+        img = Image.open(io.BytesIO(image_bytes))
+        img_format = img.format
+        width, height = img.size
+    except Image.DecompressionBombError as exc:
+        raise ImageIngestError(ImageIngestReason.PIXEL_COUNT_TOO_LARGE) from exc
+    except (UnidentifiedImageError, OSError, ValueError) as exc:
+        raise ImageIngestError(ImageIngestReason.DECODE_FAILED) from exc
+
+    if img_format not in ALLOWED_IMAGE_FORMATS:
+        raise ImageIngestError(ImageIngestReason.MIME_MISMATCH)
+
+    expected_format = ALLOWED_CONTENT_TYPES[content_type]
+    if img_format != expected_format:
+        raise ImageIngestError(ImageIngestReason.MIME_MISMATCH)
+
+    # Dimension / pixel-count checks happen before the full pixel decode
+    # (Image.open only parses headers) to guard against decompression bombs.
+    if width > max_dimension or height > max_dimension:
+        raise ImageIngestError(ImageIngestReason.DIMENSIONS_TOO_LARGE)
+    if width * height > max_pixels:
+        raise ImageIngestError(ImageIngestReason.PIXEL_COUNT_TOO_LARGE)
+
+    try:
+        img.load()
+    except Image.DecompressionBombError as exc:
+        raise ImageIngestError(ImageIngestReason.PIXEL_COUNT_TOO_LARGE) from exc
+    except (OSError, ValueError) as exc:
+        raise ImageIngestError(ImageIngestReason.DECODE_FAILED) from exc
+
+    corrected = ImageOps.exif_transpose(img) or img
+
+    thumb = corrected.copy()
+    thumb.thumbnail(thumbnail_size, Image.LANCZOS)
+
+    return corrected, thumb, img_format
+
+
+def _encode(img: Image.Image, fmt: str) -> bytes:
+    if fmt == "JPEG" and img.mode not in ("RGB", "L"):
+        img = img.convert("RGB")
+    buffer = io.BytesIO()
+    img.save(buffer, format=fmt)
+    return buffer.getvalue()
+
+
+def _encode_thumbnail(img: Image.Image) -> bytes:
+    if img.mode not in ("RGB", "RGBA", "L", "LA", "P"):
+        img = img.convert("RGBA")
+    buffer = io.BytesIO()
+    img.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+# ── Public API ───────────────────────────────────────────────────────────
+
+def fetch_and_validate_image(
+    url: str,
+    *,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+    max_redirects: int = DEFAULT_MAX_REDIRECTS,
+    max_dimension: int = DEFAULT_MAX_DIMENSION,
+    max_pixels: int = DEFAULT_MAX_PIXELS,
+    thumbnail_size: tuple[int, int] = DEFAULT_THUMBNAIL_SIZE,
+    timeout: httpx.Timeout = DEFAULT_TIMEOUT,
+    transport: httpx.BaseTransport | None = None,
+) -> IngestedImage:
+    """Download and validate a single remote image.
+
+    This function performs no storage: it returns bytes and metadata only.
+    `transport` overrides the underlying HTTP transport (used by tests to
+    avoid real network calls); production callers should leave it unset.
+
+    On any failure, returns IngestedImage(ok=False, reason=<stable enum>)
+    with no exception raised and no internal detail exposed.
+    """
+    base_transport = transport if transport is not None else httpx.HTTPTransport()
+
+    try:
+        image_bytes, content_type, final_url = _download(
+            url,
+            max_bytes=max_bytes,
+            max_redirects=max_redirects,
+            timeout=timeout,
+            transport=base_transport,
+        )
+        corrected, thumb, img_format = _decode_and_build(
+            image_bytes,
+            content_type=content_type,
+            max_dimension=max_dimension,
+            max_pixels=max_pixels,
+            thumbnail_size=thumbnail_size,
+        )
+        normalized_bytes = _encode(corrected, img_format)
+        thumbnail_bytes = _encode_thumbnail(thumb)
+    except ImageIngestError as exc:
+        return IngestedImage(ok=False, reason=exc.reason, source_url=url)
+    except Exception:
+        # Anything unanticipated is reported generically; no raw exception
+        # text or stack trace crosses this boundary.
+        return IngestedImage(ok=False, reason=ImageIngestReason.DECODE_FAILED, source_url=url)
+
+    return IngestedImage(
+        ok=True,
+        source_url=url,
+        final_url=final_url,
+        content_type=content_type,
+        image_format=img_format,
+        width=corrected.width,
+        height=corrected.height,
+        size_bytes=len(normalized_bytes),
+        image_bytes=normalized_bytes,
+        thumbnail_bytes=thumbnail_bytes,
+        thumbnail_format="PNG",
+        thumbnail_width=thumb.width,
+        thumbnail_height=thumb.height,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ cryptography>=42.0.0
 email-validator>=2.1.0
 fastapi>=0.111.0
 httpx>=0.27.0
+Pillow>=10.4.0
 python-multipart>=0.0.9
 PyYAML>=6.0.0
 requests>=2.31.0

--- a/tests/tests_backend/test_image_ingest.py
+++ b/tests/tests_backend/test_image_ingest.py
@@ -139,11 +139,13 @@ class TestUnsafeDestinations:
         "10.0.0.5",           # private
         "172.16.0.1",         # private
         "192.168.1.1",        # private
+        "100.64.0.1",         # shared carrier-grade NAT space
         "0.0.0.0",             # unspecified
         "224.0.0.1",           # multicast
         "[::1]",                # IPv6 loopback
         "[fe80::1]",             # IPv6 link-local
         "[fc00::1]",              # IPv6 unique local (private)
+        "[fec0::1]",              # deprecated IPv6 site-local
     ])
     def test_malicious_destinations_are_rejected(self, host, monkeypatch):
         # "localhost" resolves via DNS in this implementation; everything

--- a/tests/tests_backend/test_image_ingest.py
+++ b/tests/tests_backend/test_image_ingest.py
@@ -1,0 +1,440 @@
+"""
+Unit tests for backend.services.image_ingest.
+
+No test makes a real network call. Safe-destination happy-path tests target
+literal public IP addresses (which skip DNS) with an httpx.MockTransport
+standing in for the network. DNS-based tests monkeypatch socket.getaddrinfo.
+"""
+from __future__ import annotations
+
+import io
+import socket
+
+import httpx
+import pytest
+from PIL import Image
+
+from backend.services.image_ingest import (
+    ImageIngestReason,
+    fetch_and_validate_image,
+)
+
+# A public, non-reserved IPv4 address used only as a URL host in tests. No
+# request is ever sent over a real socket: transport is always mocked.
+PUBLIC_IP = "93.184.216.34"
+
+
+def _make_png_bytes(size=(100, 80), color=(255, 0, 0)) -> bytes:
+    img = Image.new("RGB", size, color)
+    buffer = io.BytesIO()
+    img.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _make_jpeg_bytes(size=(100, 80), color=(0, 255, 0)) -> bytes:
+    img = Image.new("RGB", size, color)
+    buffer = io.BytesIO()
+    img.save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+def _mock_transport(handler) -> httpx.MockTransport:
+    return httpx.MockTransport(handler)
+
+
+def _ok_png_handler(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(
+        200,
+        headers={"content-type": "image/png"},
+        content=_make_png_bytes(),
+    )
+
+
+# ── Happy path ───────────────────────────────────────────────────────────
+
+class TestHappyPath:
+    def test_valid_png_is_ingested_with_thumbnail(self):
+        result = fetch_and_validate_image(
+            f"http://{PUBLIC_IP}/image.png",
+            transport=_mock_transport(_ok_png_handler),
+        )
+        assert result.ok is True
+        assert result.reason is None
+        assert result.image_format == "PNG"
+        assert result.content_type == "image/png"
+        assert result.width == 100
+        assert result.height == 80
+        assert result.image_bytes
+        assert result.thumbnail_bytes
+        # Thumbnail is bounded and preserves aspect ratio (100x80 -> 400x320 max, capped at 400x400).
+        thumb = Image.open(io.BytesIO(result.thumbnail_bytes))
+        assert thumb.width <= 400 and thumb.height <= 400
+        assert round(thumb.width / thumb.height, 2) == round(100 / 80, 2)
+
+    def test_valid_jpeg_is_ingested(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "image/jpeg; charset=binary"},
+                content=_make_jpeg_bytes(),
+            )
+
+        result = fetch_and_validate_image(
+            f"https://{PUBLIC_IP}/photo.jpg",
+            transport=_mock_transport(handler),
+        )
+        assert result.ok is True
+        assert result.image_format == "JPEG"
+
+    def test_exif_orientation_is_corrected(self):
+        img = Image.new("RGB", (60, 30), (10, 20, 30))
+        exif = img.getexif()
+        exif[0x0112] = 6  # Orientation: rotate 270
+        buffer = io.BytesIO()
+        img.save(buffer, format="JPEG", exif=exif)
+        raw = buffer.getvalue()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, headers={"content-type": "image/jpeg"}, content=raw)
+
+        result = fetch_and_validate_image(
+            f"http://{PUBLIC_IP}/rotated.jpg",
+            transport=_mock_transport(handler),
+        )
+        assert result.ok is True
+        # Orientation 6 swaps width/height for a 60x30 source.
+        assert result.width == 30
+        assert result.height == 60
+
+
+# ── Scheme / URL validation ─────────────────────────────────────────────
+
+class TestSchemeValidation:
+    @pytest.mark.parametrize("url", [
+        "ftp://example.com/image.png",
+        "file:///etc/passwd",
+        "data:image/png;base64,abcd",
+        "javascript:alert(1)",
+        "gopher://example.com/1",
+    ])
+    def test_unsupported_schemes_are_rejected(self, url):
+        result = fetch_and_validate_image(url, transport=_mock_transport(_ok_png_handler))
+        assert result.ok is False
+        assert result.reason == ImageIngestReason.UNSUPPORTED_SCHEME
+
+    def test_url_without_host_is_rejected(self):
+        result = fetch_and_validate_image("http:///image.png", transport=_mock_transport(_ok_png_handler))
+        assert result.ok is False
+        assert result.reason == ImageIngestReason.INVALID_URL
+
+
+# ── SSRF: unsafe network destinations ───────────────────────────────────
+
+class TestUnsafeDestinations:
+    @pytest.mark.parametrize("host", [
+        "127.0.0.1",
+        "127.0.0.53",
+        "localhost",
+        "169.254.169.254",   # cloud metadata endpoint (link-local)
+        "10.0.0.5",           # private
+        "172.16.0.1",         # private
+        "192.168.1.1",        # private
+        "0.0.0.0",             # unspecified
+        "224.0.0.1",           # multicast
+        "[::1]",                # IPv6 loopback
+        "[fe80::1]",             # IPv6 link-local
+        "[fc00::1]",              # IPv6 unique local (private)
+    ])
+    def test_malicious_destinations_are_rejected(self, host, monkeypatch):
+        # "localhost" resolves via DNS in this implementation; everything
+        # else is a literal IP and bypasses DNS entirely.
+        if host == "localhost":
+            monkeypatch.setattr(
+                socket, "getaddrinfo",
+                lambda *a, **k: [(socket.AF_INET, None, None, "", ("127.0.0.1", 0))],
+            )
+        url = f"http://{host}/image.png"
+        result = fetch_and_validate_image(url, transport=_mock_transport(_ok_png_handler))
+        assert result.ok is False
+        assert result.reason in (
+            ImageIngestReason.UNSAFE_DESTINATION,
+            ImageIngestReason.INVALID_URL,
+        )
+
+    def test_dns_resolution_failure_is_reported(self, monkeypatch):
+        def fail(*a, **k):
+            raise socket.gaierror("name resolution failed")
+
+        monkeypatch.setattr(socket, "getaddrinfo", fail)
+        result = fetch_and_validate_image(
+            "http://nonexistent.invalid/image.png",
+            transport=_mock_transport(_ok_png_handler),
+        )
+        assert result.ok is False
+        assert result.reason == ImageIngestReason.DNS_RESOLUTION_FAILED
+
+    def test_dns_rebinding_hostname_with_mixed_answers_is_rejected(self, monkeypatch):
+        # One public-looking answer and one internal answer: reject the
+        # whole hostname rather than racing which one gets used.
+        monkeypatch.setattr(
+            socket, "getaddrinfo",
+            lambda *a, **k: [
+                (socket.AF_INET, None, None, "", (PUBLIC_IP, 0)),
+                (socket.AF_INET, None, None, "", ("10.0.0.9", 0)),
+            ],
+        )
+        result = fetch_and_validate_image(
+            "http://rebinder.example/image.png",
+            transport=_mock_transport(_ok_png_handler),
+        )
+        assert result.ok is False
+        assert result.reason == ImageIngestReason.UNSAFE_DESTINATION
+
+
+# ── Redirects ────────────────────────────────────────────────────────────
+
+class TestRedirects:
+    def test_safe_redirect_is_followed_and_revalidated(self):
+        calls = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(str(request.url))
+            if len(calls) == 1:
+                return httpx.Response(302, headers={"location": f"http://{PUBLIC_IP}/final.png"})
+            return httpx.Response(200, headers={"content-type": "image/png"}, content=_make_png_bytes())
+
+        result = fetch_and_validate_image(
+            f"http://{PUBLIC_IP}/start.png",
+            transport=_mock_transport(handler),
+        )
+        assert result.ok is True
+        assert len(calls) == 2
+
+    def test_redirect_to_unsafe_destination_is_rejected(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.host == PUBLIC_IP:
+                return httpx.Response(302, headers={"location": "http://127.0.0.1/evil.png"})
+            # Should never be reached: the pinned transport must reject
+            # the redirect target before issuing this request.
+            return httpx.Response(200, headers={"content-type": "image/png"}, content=_make_png_bytes())
+
+        result = fetch_and_validate_image(
+            f"http://{PUBLIC_IP}/start.png",
+            transport=_mock_transport(handler),
+        )
+        assert result.ok is False
+        assert result.reason == ImageIngestReason.UNSAFE_DESTINATION
+
+    def test_redirect_depth_is_bounded(self):
+        counter = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            counter["n"] += 1
+            return httpx.Response(
+                302, headers={"location": f"http://{PUBLIC_IP}/hop{counter['n']}.png"}
+            )
+
+        result = fetch_and_validate_image(
+            f"http://{PUBLIC_IP}/start.png",
+            transport=_mock_transport(handler),
+            max_redirects=3,
+        )
+        assert result.ok is False
+        assert result.reason == ImageIngestReason.TOO_MANY_REDIRECTS
+        assert counter["n"] <= 5
+
+    def test_redirect_to_unsupported_scheme_is_rejected(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(302, headers={"location": "file:///etc/passwd"})
+
+        result = fetch_and_validate_image(
+            f"http://{PUBLIC_IP}/start.png",
+            transport=_mock_transport(handler),
+        )
+        assert result.ok is False
+        assert result.reason == ImageIngestReason.UNSUPPORTED_SCHEME
+
+
+# ── Size limits ──────────────────────────────────────────────────────────
+
+class TestSizeLimits:
+    def test_oversized_content_length_is_rejected_without_reading_body(self):
+        read_calls = {"n": 0}
+
+        class TrackingStream:
+            def __iter__(self):
+                read_calls["n"] += 1
+                yield b"x" * 1000
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "image/png", "content-length": "999999999"},
+                content=_make_png_bytes(),
+            )
+
+        result = fetch_and_validate_image(
+            f"http://{PUBLIC_IP}/huge.png",
+            transport=_mock_transport(handler),
+            max_bytes=1000,
+        )
+        assert result.ok is False
+        assert result.reason == ImageIngestReason.RESPONSE_TOO_LARGE
+
+    def test_stream_exceeding_max_bytes_is_rejected(self):
+        big_payload = b"\x89PNG\r\n" + b"0" * 5000  # not a valid PNG, but size check runs first
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, headers={"content-type": "image/png"}, content=big_payload)
+
+        result = fetch_and_validate_image(
+            f"http://{PUBLIC_IP}/big.png",
+            transport=_mock_transport(handler),
+            max_bytes=1000,
+        )
+        assert result.ok is False
+        assert result.reason == ImageIngestReason.RESPONSE_TOO_LARGE
+
+
+# ── MIME validation ──────────────────────────────────────────────────────
+
+class TestMimeValidation:
+    def test_disallowed_content_type_is_rejected(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "application/pdf"},
+                content=b"%PDF-1.4",
+            )
+
+        result = fetch_and_validate_image(
+            f"http://{PUBLIC_IP}/doc.pdf",
+            transport=_mock_transport(handler),
+        )
+        assert result.ok is False
+        assert result.reason == ImageIngestReason.MIME_NOT_ALLOWED
+
+    def test_declared_mime_and_decoded_format_mismatch_is_rejected(self):
+        # Declares PNG but the bytes are actually a JPEG.
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "image/png"},
+                content=_make_jpeg_bytes(),
+            )
+
+        result = fetch_and_validate_image(
+            f"http://{PUBLIC_IP}/mismatch.png",
+            transport=_mock_transport(handler),
+        )
+        assert result.ok is False
+        assert result.reason == ImageIngestReason.MIME_MISMATCH
+
+
+# ── Corrupt / malicious image payloads ──────────────────────────────────
+
+class TestImageDecoding:
+    def test_corrupt_image_bytes_are_rejected(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "image/png"},
+                content=b"\x89PNG\r\n\x1a\nnot-actually-a-valid-png-body",
+            )
+
+        result = fetch_and_validate_image(
+            f"http://{PUBLIC_IP}/corrupt.png",
+            transport=_mock_transport(handler),
+        )
+        assert result.ok is False
+        assert result.reason == ImageIngestReason.DECODE_FAILED
+
+    def test_excessive_dimensions_are_rejected(self):
+        img = Image.new("RGB", (9000, 100), (1, 1, 1))
+        buffer = io.BytesIO()
+        img.save(buffer, format="PNG")
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, headers={"content-type": "image/png"}, content=buffer.getvalue())
+
+        result = fetch_and_validate_image(
+            f"http://{PUBLIC_IP}/wide.png",
+            transport=_mock_transport(handler),
+            max_dimension=8000,
+        )
+        assert result.ok is False
+        assert result.reason == ImageIngestReason.DIMENSIONS_TOO_LARGE
+
+    def test_excessive_pixel_count_decompression_bomb_is_rejected(self):
+        # A PNG that decodes within max_dimension per side but exceeds the
+        # overall pixel-count budget (decompression-bomb shape).
+        img = Image.new("RGB", (7000, 7000), (2, 2, 2))
+        buffer = io.BytesIO()
+        img.save(buffer, format="PNG", compress_level=9)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, headers={"content-type": "image/png"}, content=buffer.getvalue())
+
+        result = fetch_and_validate_image(
+            f"http://{PUBLIC_IP}/bomb.png",
+            transport=_mock_transport(handler),
+            max_bytes=200 * 1024 * 1024,
+            max_dimension=8000,
+            max_pixels=40_000_000,
+        )
+        assert result.ok is False
+        assert result.reason == ImageIngestReason.PIXEL_COUNT_TOO_LARGE
+
+
+# ── HTTP / timeout errors ────────────────────────────────────────────────
+
+class TestNetworkErrors:
+    def test_non_200_status_is_rejected(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404)
+
+        result = fetch_and_validate_image(
+            f"http://{PUBLIC_IP}/missing.png",
+            transport=_mock_transport(handler),
+        )
+        assert result.ok is False
+        assert result.reason == ImageIngestReason.HTTP_ERROR
+
+    def test_connect_timeout_is_reported(self):
+        class TimingOutTransport(httpx.BaseTransport):
+            def handle_request(self, request: httpx.Request) -> httpx.Response:
+                raise httpx.ConnectTimeout("connect timed out", request=request)
+
+        result = fetch_and_validate_image(
+            f"http://{PUBLIC_IP}/slow.png",
+            transport=TimingOutTransport(),
+        )
+        assert result.ok is False
+        assert result.reason == ImageIngestReason.TIMEOUT
+
+    def test_read_timeout_is_reported(self):
+        class ReadTimingOutTransport(httpx.BaseTransport):
+            def handle_request(self, request: httpx.Request) -> httpx.Response:
+                raise httpx.ReadTimeout("read timed out", request=request)
+
+        result = fetch_and_validate_image(
+            f"http://{PUBLIC_IP}/slow.png",
+            transport=ReadTimingOutTransport(),
+        )
+        assert result.ok is False
+        assert result.reason == ImageIngestReason.TIMEOUT
+
+    def test_generic_network_error_is_reported_without_leaking_detail(self):
+        class BrokenTransport(httpx.BaseTransport):
+            def handle_request(self, request: httpx.Request) -> httpx.Response:
+                raise httpx.ConnectError("connection refused by 10.9.9.9 secret-internal-host")
+
+        result = fetch_and_validate_image(
+            f"http://{PUBLIC_IP}/broken.png",
+            transport=BrokenTransport(),
+        )
+        assert result.ok is False
+        assert result.reason == ImageIngestReason.NETWORK_ERROR
+        # The stable reason string must not embed exception text.
+        assert "10.9.9.9" not in result.reason.value
+        assert "secret" not in result.reason.value


### PR DESCRIPTION
## Summary
- add a bounded streaming downloader for remote images
- revalidate DNS and destination IPs on every redirect hop
- validate MIME type, decoded format, dimensions, and pixel count before thumbnailing
- reject CGNAT, IPv6 site-local, and other non-public destinations
- expose stable ingestion errors without leaking remote response details

## Verification
- 40 focused image-ingestion tests pass
- real HTTPS image smoke test passed
- diff check passes

Closes #49