### PR TITLE
test: add PR unit test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ permissions:
   contents: read
 
 jobs:
-  python-tests:
-    name: Python tests
+  unit-tests:
+    name: Unit test gate
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -33,6 +33,13 @@ jobs:
       BLOGHUB_DB_PATH: ":memory:"
       BLOGHUB_BLOBS_DIR: ${{ runner.temp }}/bloghub-blobs
       BLOGHUB_CREDENTIAL_KEY_FILE: ${{ runner.temp }}/bloghub-credential-keys.json
+      DEVTO_API_KEY: ""
+      HASHNODE_PAT: ""
+      HASHNODE_PUBLICATION_ID: ""
+      MEDIUM_CLIENT_ID: ""
+      MEDIUM_CLIENT_SECRET: ""
+      MEDIUM_SESSION_FILE: ""
+      MEDIUM_TOKEN: ""
 
     steps:
       - name: Check out repository
@@ -53,7 +60,7 @@ jobs:
           python -m pip install -r requirements.txt -r backend/requirements.txt
 
       - name: Run unit tests
-        run: python -m pytest
+        run: bash scripts/run-unit-tests.sh
 
   contract-checks:
     name: Contract checks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ writes credentials into the mounted volume.
 ```bash
 # CI baseline: unit tests and API contract checks
 cd blog-hub
-python -m pytest
+bash scripts/run-unit-tests.sh
 npm run check:contracts
 
 # UI browser tests (requires backend on :8000 and cli-runner on :8001)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -3,17 +3,18 @@
 GitHub Actions runs the baseline CI workflow for pull requests into `develop`,
 pushes to numbered work branches, and manual dispatches.
 
-The default checks are intentionally deterministic:
+The default PR checks are intentionally deterministic:
 
 ```bash
-python -m pytest
+bash scripts/run-unit-tests.sh
 npm run check:contracts
 ```
 
-`pytest.ini` excludes tests marked `integration` or `browser` from the default
-Python run. Live provider credentials such as `HASHNODE_PAT`, `DEVTO_API_KEY`,
-and Medium browser sessions are not required by CI and should not be used by the
-baseline workflow.
+The `Unit test gate` job is the required Python gate for ordinary PRs. It runs
+pytest with strict marker validation and explicitly excludes tests marked
+`integration` or `browser`. Live provider credentials such as `HASHNODE_PAT`,
+`DEVTO_API_KEY`, and Medium browser sessions are not required by CI and are
+cleared in the baseline workflow.
 
 Playwright/browser coverage is tracked separately in issue #56. Those tests
 need browser setup, screenshots/traces on failure, and fixture-backed provider

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pytest --strict-markers -m "not integration and not browser" "$@"


### PR DESCRIPTION
## Summary
- Rename the Python CI job to a stable Unit test gate check for PR branch protection.
- Add scripts/run-unit-tests.sh so CI and local reproduction use the same strict-marker pytest command.
- Clear live-provider credential environment variables in the PR unit-test job so ordinary PRs cannot accidentally run live provider checks.
- Update docs and developer notes to use the unit-test gate command.

## Validation
- uv run --with-requirements requirements.txt --with-requirements backend/requirements.txt bash scripts/run-unit-tests.sh -s --collect-only

Collected 370 unit tests and deselected 296 browser/integration tests.

Refs #55
Stacked on #58 / feat/54.