### PR TITLE
feat: paginate the overview beyond 100 articles

### DIFF
--- a/screens/overview/v3.html
+++ b/screens/overview/v3.html
@@ -296,6 +296,67 @@
       border-radius: 0;
     }
 
+    /* Load-more region */
+    #load-more-region {
+      margin-top: 16px;
+    }
+    #load-more-region:empty {
+      margin-top: 0;
+    }
+    .load-more-panel {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 10px;
+      padding: 20px 0 8px;
+      width: 100%;
+    }
+    .load-more-status {
+      font-size: 12px;
+      color: #5a6080;
+      font-family: 'JetBrains Mono', monospace;
+      text-align: center;
+    }
+    .load-more-btn {
+      font-size: 12px;
+      font-weight: 500;
+      padding: 8px 18px;
+      border-radius: 6px;
+      background: #181c27;
+      color: #c9cfe0;
+      border: 1px solid #252a38;
+      cursor: pointer;
+      font-family: inherit;
+      transition: border-color 100ms, color 100ms, background 100ms;
+    }
+    .load-more-btn:hover  { border-color: #3a3f52; color: #e8eaf2; background: #1b2030; }
+    .load-more-btn:focus-visible { outline: 2px solid #6366f1; outline-offset: 2px; }
+    .load-more-btn:disabled { cursor: default; opacity: 0.6; }
+    .load-more-error {
+      font-size: 12px;
+      color: #f87171;
+      text-align: center;
+    }
+    .load-more-retry-btn {
+      font-size: 12px;
+      font-weight: 500;
+      padding: 8px 18px;
+      border-radius: 6px;
+      background: #1e1818;
+      color: #f87171;
+      border: 1px solid #3a2828;
+      cursor: pointer;
+      font-family: inherit;
+    }
+    .load-more-retry-btn:hover { border-color: #4d2a2a; }
+    .load-more-retry-btn:focus-visible { outline: 2px solid #f87171; outline-offset: 2px; }
+    .load-more-skeletons {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      width: 100%;
+    }
+
     @media (max-width: 760px) {
       .article-card {
         height: auto;
@@ -455,6 +516,8 @@
     <div id="grid-area" style="flex:1;overflow-y:auto;padding:24px 32px;">
       <div id="card-grid" style="display:grid;grid-template-columns:minmax(0, 750px);justify-content:center;gap:12px;width:100%;margin:0 auto;"></div>
 
+      <div id="load-more-region" style="display:grid;grid-template-columns:minmax(0, 750px);justify-content:center;width:100%;margin:0 auto;"></div>
+
       <div id="empty-state" style="display:none;flex-direction:column;align-items:center;justify-content:center;min-height:360px;text-align:center;">
         <div style="font-size:40px;color:#252a38;margin-bottom:16px;line-height:1;">?</div>
         <div style="color:#e8eaf2;font-weight:600;font-size:15px;margin-bottom:6px;">Nothing here yet</div>
@@ -562,6 +625,16 @@ let detailsPanelOpen = true;
 // Per-card active preview platform: Map<articleId, 'medium'|'hashnode'|'devto'>
 const activePreview = new Map();
 
+// --- Pagination state ------------------------------------------------
+const PAGE_SIZE = 100;
+let currentPage       = 1;     // number of raw pages currently loaded (from page 1)
+let totalArticleCount = 0;     // server-reported total, across all pages
+let isLoadingMore     = false; // a "Load more" fetch is in flight
+let loadMoreError     = null;  // message from the last failed "Load more" attempt
+let loadGeneration     = 0;    // bumped on every full reload / filter change to
+                                // invalidate stale in-flight page-load responses
+const loadedArticleIds = new Set();
+
 // --- Helpers -------------------------------------------------------
 const DOT_COLOR = {
   draft: '#6ea8fe', ready: '#4ade80', published: '#38bdf8',
@@ -651,12 +724,48 @@ async function fetchJson(url, options = {}) {
   return response.json();
 }
 
+function articlesPageUrl(page) {
+  return `/api/articles?sortBy=updatedAt&sortDir=desc&page=${page}&pageSize=${PAGE_SIZE}`;
+}
+
+// Fetch pages 1..pagesToLoad and concatenate them, preserving server order.
+// Returns null if a newer load generation started while this was in flight.
+async function fetchArticlePages(pagesToLoad, generation) {
+  let items = [];
+  let total = 0;
+  for (let page = 1; page <= pagesToLoad; page += 1) {
+    const payload = await fetchJson(articlesPageUrl(page));
+    if (generation !== loadGeneration) return null; // superseded — discard
+    items = items.concat(payload.items);
+    total = payload.total;
+  }
+  return { items, total };
+}
+
+// Full reload: re-fetches from page 1 up to the current pagination depth, so an
+// action-triggered refresh (push/inspect/etc.) never collapses an already
+// expanded list back down to the first 100 articles.
 async function loadOverview() {
-  const [articlesPayload, connectionsPayload] = await Promise.all([
-    fetchJson('/api/articles?sortBy=updatedAt&sortDir=desc&page=1&pageSize=100'),
+  const generation = (loadGeneration += 1);
+  isLoadingMore = false;
+  loadMoreError = null;
+
+  const pagesToLoad = Math.max(1, currentPage);
+  const [articlesResult, connectionsPayload] = await Promise.all([
+    fetchArticlePages(pagesToLoad, generation),
     fetchJson('/api/connections'),
   ]);
-  ARTICLES = articlesPayload.items.map(buildLiveArticle);
+
+  if (generation !== loadGeneration || articlesResult === null) return; // stale
+
+  loadedArticleIds.clear();
+  ARTICLES = articlesResult.items.map((raw, index) => {
+    loadedArticleIds.add(raw.id);
+    return buildLiveArticle(raw, index);
+  });
+  totalArticleCount = articlesResult.total;
+  currentPage = pagesToLoad;
+
   const connected = connectionsPayload.connections.filter(
     item => ['medium', 'hashnode', 'devto'].includes(item.id) && item.status === 'connected'
   );
@@ -664,6 +773,58 @@ async function loadOverview() {
     <span style="width:6px;height:6px;border-radius:50%;background:#4ade80;display:inline-block;"></span>
     ${connected.length} platforms connected
   `;
+}
+
+function hasMoreArticles() {
+  return ARTICLES.length < totalArticleCount;
+}
+
+// Incremental "Load more": fetches the next raw page and appends it without
+// touching already-rendered cards (so activePreview / selection state for
+// existing cards is untouched — see renderCard()).
+async function loadMoreArticles() {
+  if (isLoadingMore || !hasMoreArticles()) return;
+  const generation = loadGeneration;
+  const nextPage = currentPage + 1;
+
+  isLoadingMore = true;
+  loadMoreError = null;
+  render();
+
+  try {
+    const payload = await fetchJson(articlesPageUrl(nextPage));
+    if (generation !== loadGeneration) return; // a full reload / filter change superseded this
+
+    const newItems = payload.items.filter(raw => !loadedArticleIds.has(raw.id));
+    const startIndex = ARTICLES.length;
+    const mapped = newItems.map((raw, i) => {
+      loadedArticleIds.add(raw.id);
+      return buildLiveArticle(raw, startIndex + i);
+    });
+
+    ARTICLES = ARTICLES.concat(mapped);
+    totalArticleCount = payload.total;
+    currentPage = nextPage;
+  } catch (error) {
+    if (generation === loadGeneration) {
+      loadMoreError = error.message || 'Failed to load more articles.';
+    }
+  } finally {
+    if (generation === loadGeneration) isLoadingMore = false;
+    render();
+  }
+}
+
+// Any change to search/status/platform filters invalidates an in-flight
+// "Load more" response: the response itself is still valid data, but by the
+// time it would land the user has already moved on to a different filtered
+// view, so we drop it rather than risk it landing after — and clobbering —
+// state the user has since changed. The user can simply press "Load more"
+// again once filters settle.
+function invalidateInFlightPageLoad() {
+  loadGeneration += 1;
+  isLoadingMore = false;
+  loadMoreError = null;
 }
 
 async function runArticleAction(article, overrideKind = null) {
@@ -975,18 +1136,98 @@ function renderSkeleton() {
   return card;
 }
 
+// --- Load-more region -------------------------------------------------
+// Renders the count/status text plus whichever control applies: a "Load
+// more" button, an in-progress state (skeleton cards + status text), an
+// error/retry state, or a "you've seen everything" completion message.
+// This region lives below #card-grid so appending to it never resizes or
+// reflows already-rendered cards above it.
+function renderLoadMoreRegion() {
+  const region = document.getElementById('load-more-region');
+  region.innerHTML = '';
+
+  const loadedCount = ARTICLES.length;
+  if (loadedCount === 0) return;
+
+  const panel = document.createElement('div');
+  panel.className = 'load-more-panel';
+
+  if (isLoadingMore) {
+    const skeletons = document.createElement('div');
+    skeletons.className = 'load-more-skeletons';
+    for (let i = 0; i < 3; i += 1) skeletons.appendChild(renderSkeleton());
+    panel.appendChild(skeletons);
+
+    const status = document.createElement('div');
+    status.className = 'load-more-status';
+    status.setAttribute('role', 'status');
+    status.setAttribute('aria-live', 'polite');
+    status.textContent = `Loading more articles… (showing ${loadedCount} of ${totalArticleCount})`;
+    panel.appendChild(status);
+  } else if (loadMoreError) {
+    const message = document.createElement('div');
+    message.className = 'load-more-error';
+    message.setAttribute('role', 'alert');
+    message.textContent = `Couldn't load more articles: ${loadMoreError}`;
+    panel.appendChild(message);
+
+    const retry = document.createElement('button');
+    retry.type = 'button';
+    retry.className = 'load-more-retry-btn';
+    retry.textContent = 'Retry';
+    retry.onclick = () => loadMoreArticles();
+    panel.appendChild(retry);
+  } else if (hasMoreArticles()) {
+    const status = document.createElement('div');
+    status.className = 'load-more-status';
+    status.setAttribute('role', 'status');
+    status.setAttribute('aria-live', 'polite');
+    status.id = 'load-more-status';
+    status.textContent = `Showing ${loadedCount} of ${totalArticleCount} articles`;
+    panel.appendChild(status);
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.id = 'load-more-button';
+    button.className = 'load-more-btn';
+    button.setAttribute('aria-describedby', 'load-more-status');
+    button.textContent = 'Load more';
+    button.onclick = () => loadMoreArticles();
+    panel.appendChild(button);
+  } else {
+    const status = document.createElement('div');
+    status.className = 'load-more-status';
+    status.setAttribute('role', 'status');
+    status.setAttribute('aria-live', 'polite');
+    status.textContent = totalArticleCount === 1
+      ? 'Showing the only article'
+      : `Showing all ${totalArticleCount} articles`;
+    panel.appendChild(status);
+  }
+
+  region.appendChild(panel);
+}
+
 // --- Render --------------------------------------------------------
 function render() {
   const grid    = document.getElementById('card-grid');
   const emptyEl = document.getElementById('empty-state');
   const noRes   = document.getElementById('no-results');
+  const loadMoreRegion = document.getElementById('load-more-region');
   grid.innerHTML = '';
   emptyEl.style.display = 'none';
   noRes.style.display   = 'none';
 
-  if (showEmpty)    { emptyEl.style.display = 'flex'; document.getElementById('article-count').textContent = '0 articles'; syncDetailsPanel(); return; }
+  if (showEmpty)    {
+    emptyEl.style.display = 'flex';
+    loadMoreRegion.innerHTML = '';
+    document.getElementById('article-count').textContent = '0 articles';
+    syncDetailsPanel();
+    return;
+  }
   if (showSkeleton) {
     for (let i = 0; i < 5; i++) grid.appendChild(renderSkeleton());
+    loadMoreRegion.innerHTML = '';
     document.getElementById('article-count').textContent = '— articles';
     syncDetailsPanel();
     return;
@@ -995,8 +1236,9 @@ function render() {
   const filtered = ARTICLES.filter(matchesFilters).sort((a, b) => a.urgency - b.urgency);
   document.getElementById('article-count').textContent = `${filtered.length} article${filtered.length !== 1 ? 's' : ''}`;
 
-  if (filtered.length === 0) { noRes.style.display = 'flex'; syncDetailsPanel(); return; }
+  if (filtered.length === 0) { noRes.style.display = 'flex'; renderLoadMoreRegion(); syncDetailsPanel(); return; }
   filtered.forEach(a => grid.appendChild(renderCard(a)));
+  renderLoadMoreRegion();
   syncDetailsPanel();
 }
 
@@ -1088,7 +1330,10 @@ function togglePlatform(p, el) {
   applyFilters();
 }
 
-function applyFilters() { render(); }
+function applyFilters() {
+  invalidateInFlightPageLoad();
+  render();
+}
 
 function clearFilters() {
   document.getElementById('search-input').value = '';
@@ -1097,6 +1342,7 @@ function clearFilters() {
   document.querySelectorAll('.pill-filter').forEach(b => b.classList.remove('active'));
   document.getElementById('sf-all').classList.add('active');
   document.querySelectorAll('.pill-platform').forEach(b => b.classList.remove('active'));
+  invalidateInFlightPageLoad();
   render();
 }
 

--- a/screens/overview/v3.html
+++ b/screens/overview/v3.html
@@ -631,8 +631,8 @@ let currentPage       = 1;     // number of raw pages currently loaded (from pag
 let totalArticleCount = 0;     // server-reported total, across all pages
 let isLoadingMore     = false; // a "Load more" fetch is in flight
 let loadMoreError     = null;  // message from the last failed "Load more" attempt
-let loadGeneration     = 0;    // bumped on every full reload / filter change to
-                                // invalidate stale in-flight page-load responses
+let overviewLoadGeneration = 0; // invalidates stale full-overview reloads
+let pageLoadGeneration     = 0; // invalidates stale incremental page loads
 const loadedArticleIds = new Set();
 
 // --- Helpers -------------------------------------------------------
@@ -735,7 +735,7 @@ async function fetchArticlePages(pagesToLoad, generation) {
   let total = 0;
   for (let page = 1; page <= pagesToLoad; page += 1) {
     const payload = await fetchJson(articlesPageUrl(page));
-    if (generation !== loadGeneration) return null; // superseded — discard
+    if (generation !== overviewLoadGeneration) return null; // superseded — discard
     items = items.concat(payload.items);
     total = payload.total;
   }
@@ -746,7 +746,8 @@ async function fetchArticlePages(pagesToLoad, generation) {
 // action-triggered refresh (push/inspect/etc.) never collapses an already
 // expanded list back down to the first 100 articles.
 async function loadOverview() {
-  const generation = (loadGeneration += 1);
+  const generation = (overviewLoadGeneration += 1);
+  pageLoadGeneration += 1;
   isLoadingMore = false;
   loadMoreError = null;
 
@@ -756,7 +757,7 @@ async function loadOverview() {
     fetchJson('/api/connections'),
   ]);
 
-  if (generation !== loadGeneration || articlesResult === null) return; // stale
+  if (generation !== overviewLoadGeneration || articlesResult === null) return; // stale
 
   loadedArticleIds.clear();
   ARTICLES = articlesResult.items.map((raw, index) => {
@@ -773,10 +774,29 @@ async function loadOverview() {
     <span style="width:6px;height:6px;border-radius:50%;background:#4ade80;display:inline-block;"></span>
     ${connected.length} platforms connected
   `;
+
+  if (hasActiveFilters()) await loadRemainingArticlesForFilters();
 }
 
 function hasMoreArticles() {
   return ARTICLES.length < totalArticleCount;
+}
+
+function hasActiveFilters() {
+  const query = document.getElementById('search-input').value.trim();
+  return query.length > 0 || statusFilter !== 'all' || platformFilter.size > 0;
+}
+
+function appendArticlePage(payload, page) {
+  const newItems = payload.items.filter(raw => !loadedArticleIds.has(raw.id));
+  const startIndex = ARTICLES.length;
+  const mapped = newItems.map((raw, i) => {
+    loadedArticleIds.add(raw.id);
+    return buildLiveArticle(raw, startIndex + i);
+  });
+  ARTICLES = ARTICLES.concat(mapped);
+  totalArticleCount = payload.total;
+  currentPage = page;
 }
 
 // Incremental "Load more": fetches the next raw page and appends it without
@@ -784,7 +804,7 @@ function hasMoreArticles() {
 // existing cards is untouched — see renderCard()).
 async function loadMoreArticles() {
   if (isLoadingMore || !hasMoreArticles()) return;
-  const generation = loadGeneration;
+  const generation = pageLoadGeneration;
   const nextPage = currentPage + 1;
 
   isLoadingMore = true;
@@ -793,24 +813,38 @@ async function loadMoreArticles() {
 
   try {
     const payload = await fetchJson(articlesPageUrl(nextPage));
-    if (generation !== loadGeneration) return; // a full reload / filter change superseded this
-
-    const newItems = payload.items.filter(raw => !loadedArticleIds.has(raw.id));
-    const startIndex = ARTICLES.length;
-    const mapped = newItems.map((raw, i) => {
-      loadedArticleIds.add(raw.id);
-      return buildLiveArticle(raw, startIndex + i);
-    });
-
-    ARTICLES = ARTICLES.concat(mapped);
-    totalArticleCount = payload.total;
-    currentPage = nextPage;
+    if (generation !== pageLoadGeneration) return; // superseded
+    appendArticlePage(payload, nextPage);
   } catch (error) {
-    if (generation === loadGeneration) {
+    if (generation === pageLoadGeneration) {
       loadMoreError = error.message || 'Failed to load more articles.';
     }
   } finally {
-    if (generation === loadGeneration) isLoadingMore = false;
+    if (generation === pageLoadGeneration) isLoadingMore = false;
+    render();
+  }
+}
+
+async function loadRemainingArticlesForFilters() {
+  if (isLoadingMore || !hasActiveFilters() || !hasMoreArticles()) return;
+  const generation = pageLoadGeneration;
+  isLoadingMore = true;
+  loadMoreError = null;
+  render();
+
+  try {
+    while (generation === pageLoadGeneration && hasMoreArticles()) {
+      const nextPage = currentPage + 1;
+      const payload = await fetchJson(articlesPageUrl(nextPage));
+      if (generation !== pageLoadGeneration) return;
+      appendArticlePage(payload, nextPage);
+    }
+  } catch (error) {
+    if (generation === pageLoadGeneration) {
+      loadMoreError = error.message || 'Failed to load all articles for filtering.';
+    }
+  } finally {
+    if (generation === pageLoadGeneration) isLoadingMore = false;
     render();
   }
 }
@@ -822,7 +856,7 @@ async function loadMoreArticles() {
 // state the user has since changed. The user can simply press "Load more"
 // again once filters settle.
 function invalidateInFlightPageLoad() {
-  loadGeneration += 1;
+  pageLoadGeneration += 1;
   isLoadingMore = false;
   loadMoreError = null;
 }
@@ -1236,7 +1270,12 @@ function render() {
   const filtered = ARTICLES.filter(matchesFilters).sort((a, b) => a.urgency - b.urgency);
   document.getElementById('article-count').textContent = `${filtered.length} article${filtered.length !== 1 ? 's' : ''}`;
 
-  if (filtered.length === 0) { noRes.style.display = 'flex'; renderLoadMoreRegion(); syncDetailsPanel(); return; }
+  if (filtered.length === 0) {
+    if (!isLoadingMore) noRes.style.display = 'flex';
+    renderLoadMoreRegion();
+    syncDetailsPanel();
+    return;
+  }
   filtered.forEach(a => grid.appendChild(renderCard(a)));
   renderLoadMoreRegion();
   syncDetailsPanel();
@@ -1333,6 +1372,7 @@ function togglePlatform(p, el) {
 function applyFilters() {
   invalidateInFlightPageLoad();
   render();
+  void loadRemainingArticlesForFilters();
 }
 
 function clearFilters() {

--- a/tests/tests_backend/test_articles_pagination.py
+++ b/tests/tests_backend/test_articles_pagination.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import backend.store as store
+from backend.store.schema import SEED_USER_ID
+
+
+def _create_articles(n: int, prefix: str = "Paginated article") -> None:
+    for i in range(n):
+        store.create_article(SEED_USER_ID, title=f"{prefix} {i:04d}")
+
+
+def test_list_articles_default_page_size_still_100_cap(client) -> None:
+    _create_articles(130)
+    response = client.get("/api/articles?sortBy=updatedAt&sortDir=desc&page=1&pageSize=100")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["page"] == 1
+    assert payload["pageSize"] == 100
+    assert len(payload["items"]) == 100
+    # 6 seed articles + 130 created
+    assert payload["total"] == 136
+
+
+def test_second_page_reaches_articles_beyond_the_first_hundred(client) -> None:
+    _create_articles(130)
+
+    first = client.get("/api/articles?sortBy=updatedAt&sortDir=desc&page=1&pageSize=100").json()
+    second = client.get("/api/articles?sortBy=updatedAt&sortDir=desc&page=2&pageSize=100").json()
+
+    assert first["total"] == second["total"] == 136
+    assert len(first["items"]) == 100
+    assert len(second["items"]) == 36
+
+    first_ids = [item["id"] for item in first["items"]]
+    second_ids = [item["id"] for item in second["items"]]
+
+    # No duplicates and no gaps across pages.
+    assert len(set(first_ids)) == 100
+    assert len(set(second_ids)) == 36
+    assert set(first_ids).isdisjoint(second_ids)
+    assert len(set(first_ids) | set(second_ids)) == 136
+
+
+def test_pagination_preserves_sort_order_across_pages(client) -> None:
+    _create_articles(130)
+
+    first = client.get("/api/articles?sortBy=updatedAt&sortDir=desc&page=1&pageSize=100").json()
+    second = client.get("/api/articles?sortBy=updatedAt&sortDir=desc&page=2&pageSize=100").json()
+
+    paged_updated_at = [item["updatedAt"] for item in first["items"]] + [
+        item["updatedAt"] for item in second["items"]
+    ]
+
+    # updatedAt must be non-increasing across the full paged sequence (descending sort).
+    assert paged_updated_at == sorted(paged_updated_at, reverse=True)
+    # The last item of page 1 must not be "newer" than the first item of page 2.
+    assert first["items"][-1]["updatedAt"] >= second["items"][0]["updatedAt"]
+
+
+def test_final_page_is_a_partial_page(client) -> None:
+    _create_articles(130)
+    third = client.get("/api/articles?sortBy=updatedAt&sortDir=desc&page=3&pageSize=100").json()
+    assert third["items"] == []
+    assert third["total"] == 136
+
+    # page=2 pageSize=100 -> items 101..136 (36 items), a genuine partial final page.
+    second = client.get("/api/articles?sortBy=updatedAt&sortDir=desc&page=2&pageSize=100").json()
+    assert len(second["items"]) == 36
+
+
+def test_pagination_max_page_size_is_capped_at_100(client) -> None:
+    response = client.get("/api/articles?page=1&pageSize=500")
+    assert response.status_code == 422
+
+
+def test_empty_workspace_page_one_is_empty_not_an_error(client) -> None:
+    store.delete_articles(SEED_USER_ID, ids=[a["id"] for a in store.list_articles(SEED_USER_ID, page=1, page_size=100)[0]], force=True)
+    response = client.get("/api/articles?page=1&pageSize=100")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"] == []
+    assert payload["total"] == 0

--- a/tests/tests_ui/screens/test_overview_pagination.py
+++ b/tests/tests_ui/screens/test_overview_pagination.py
@@ -181,6 +181,44 @@ def test_changing_filter_while_page_load_in_flight_does_not_corrupt_state(page):
     page.unroute(re.compile(r"/api/articles\?.*"))
 
 
+def test_filter_change_during_initial_load_does_not_discard_page_one(page):
+    page.set_viewport_size({"width": 1440, "height": 1000})
+    _login(page)
+
+    def _delay_page_one(route, request):
+        if "page=1" in request.url:
+            page.wait_for_timeout(300)
+        route.continue_()
+
+    page.route(re.compile(r"/api/articles\?.*"), _delay_page_one)
+    page.goto(OVERVIEW_URL)
+    page.locator("#search-input").fill("article")
+
+    page.wait_for_selector(".article-card")
+    assert page.locator(".article-card").count() > 0
+
+    page.unroute(re.compile(r"/api/articles\?.*"))
+
+
+def test_search_automatically_includes_matches_beyond_page_one(page):
+    page.set_viewport_size({"width": 1440, "height": 1000})
+    _login(page)
+    target = page.request.post(
+        f"{BASE_URL}/api/articles",
+        data={"title": "Unique deep pagination target"},
+    )
+    assert target.ok
+    _seed_extra_articles(page, 110, prefix="Newer filler article")
+
+    page.goto(OVERVIEW_URL)
+    page.wait_for_selector(".article-card")
+    page.locator("#search-input").fill("Unique deep pagination target")
+
+    match = page.locator(".article-card").filter(has_text="Unique deep pagination target")
+    match.wait_for()
+    assert match.count() == 1
+
+
 # ── preview-tab selection survives incremental rendering ───────────────────
 
 

--- a/tests/tests_ui/screens/test_overview_pagination.py
+++ b/tests/tests_ui/screens/test_overview_pagination.py
@@ -1,0 +1,230 @@
+import re
+
+import pytest
+
+from tests.tests_ui.conftest import BASE_URL
+
+
+pytestmark = pytest.mark.browser
+
+OVERVIEW_URL = f"{BASE_URL}/screens/overview/v3.html"
+
+# 6 seed articles ship out of the box (see backend/store/backends/sqlite.py).
+SEED_ARTICLE_COUNT = 6
+
+
+def _login(page):
+    response = page.request.post(
+        f"{BASE_URL}/api/auth/login",
+        data={
+            "email": "seed@example.com",
+            "password": "seed1234",
+            "remember_me": False,
+        },
+    )
+    assert response.ok
+    return response
+
+
+def _seed_extra_articles(page, count, prefix="Bulk seeded article"):
+    for i in range(count):
+        response = page.request.post(
+            f"{BASE_URL}/api/articles",
+            data={"title": f"{prefix} {i:04d}"},
+        )
+        assert response.ok, response.text()
+
+
+def _delete_all_articles(page):
+    listing = page.request.get(f"{BASE_URL}/api/articles?page=1&pageSize=100").json()
+    ids = [item["id"] for item in listing["items"]]
+    if ids:
+        response = page.request.delete(
+            f"{BASE_URL}/api/articles",
+            data={"ids": ids, "force": True},
+        )
+        assert response.ok, response.text()
+
+
+def open_overview(page, width=1440, height=1000, extra_articles=0):
+    """Log in, optionally seed extra articles, then land on the overview screen."""
+    page.set_viewport_size({"width": width, "height": height})
+    _login(page)
+    if extra_articles:
+        _seed_extra_articles(page, extra_articles)
+    page.goto(OVERVIEW_URL)
+    page.wait_for_selector(".article-card")
+
+
+def card_ids(page):
+    return page.locator(".article-card").evaluate_all(
+        "elements => elements.map(el => el.dataset.id)"
+    )
+
+
+# ── multiple pages / final partial page ────────────────────────────────────
+
+
+def test_load_more_reveals_articles_beyond_the_first_hundred(page):
+    open_overview(page, extra_articles=110)  # total = 116
+
+    assert page.locator(".article-card").count() == 100
+    status = page.locator("#load-more-status")
+    assert status.inner_text().strip() == "Showing 100 of 116 articles"
+
+    page.locator("#load-more-button").click()
+    page.wait_for_function("document.querySelectorAll('.article-card').length === 116")
+
+    assert page.locator(".article-card").count() == 116
+    assert page.locator(".article-card").last.get_attribute("data-id") is not None
+
+
+def test_final_page_is_partial_and_load_more_disappears_when_exhausted(page):
+    open_overview(page, extra_articles=110)  # total = 116, second page = 16 items
+
+    page.locator("#load-more-button").click()
+    page.wait_for_function("document.querySelectorAll('.article-card').length === 116")
+
+    assert page.locator("#load-more-button").count() == 0
+    status = page.locator(".load-more-status")
+    assert status.inner_text().strip() == "Showing all 116 articles"
+
+
+def test_load_more_does_not_duplicate_or_reorder_already_rendered_cards(page):
+    open_overview(page, extra_articles=110)
+
+    ids_before = card_ids(page)
+    assert len(ids_before) == 100
+    assert len(set(ids_before)) == 100
+
+    page.locator("#load-more-button").click()
+    page.wait_for_function("document.querySelectorAll('.article-card').length === 116")
+
+    ids_after = card_ids(page)
+    assert len(ids_after) == 116
+    assert len(set(ids_after)) == 116  # no duplicates
+    assert ids_after[:100] == ids_before  # already-rendered order untouched
+
+
+# ── empty results ───────────────────────────────────────────────────────────
+
+
+def test_empty_workspace_shows_no_results_without_load_more_control(page):
+    # Note: a genuinely article-free workspace renders through the same
+    # "no matches" state as an over-filtered one (#no-results) — this is
+    # pre-existing overview behavior, unchanged by pagination. What matters
+    # for this issue is that no load-more control appears when there is
+    # nothing to page through.
+    page.set_viewport_size({"width": 1440, "height": 1000})
+    _login(page)
+    _delete_all_articles(page)
+    page.goto(OVERVIEW_URL)
+    page.wait_for_selector("#no-results")
+
+    assert page.locator(".article-card").count() == 0
+    assert page.locator("#load-more-button").count() == 0
+    assert page.locator("#no-results").is_visible()
+
+
+# ── request failure / retry ─────────────────────────────────────────────────
+
+
+def test_load_more_failure_shows_retry_and_recovers(page):
+    open_overview(page, extra_articles=110)
+
+    attempts = {"count": 0}
+
+    def _maybe_fail(route, request):
+        if "page=2" in request.url:
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                route.fulfill(status=500, body="boom")
+                return
+        route.continue_()
+
+    page.route(re.compile(r"/api/articles\?.*"), _maybe_fail)
+
+    page.locator("#load-more-button").click()
+    page.wait_for_selector("text=Couldn't load more articles")
+    assert page.locator(".article-card").count() == 100  # unchanged after failure
+
+    retry = page.get_by_role("button", name="Retry")
+    retry.click()
+    page.wait_for_function("document.querySelectorAll('.article-card').length === 116")
+    assert page.locator(".article-card").count() == 116
+
+    page.unroute(re.compile(r"/api/articles\?.*"))
+
+
+# ── filter changes during in-flight loading ─────────────────────────────────
+
+
+def test_changing_filter_while_page_load_in_flight_does_not_corrupt_state(page):
+    open_overview(page, extra_articles=110)
+
+    def _delay_page_two(route, request):
+        if "page=2" in request.url:
+            page.wait_for_timeout(300)
+        route.continue_()
+
+    page.route(re.compile(r"/api/articles\?.*"), _delay_page_two)
+
+    page.locator("#load-more-button").click()
+    # Change filters while the page-2 request is still in flight.
+    page.locator("#sf-drafting").click()
+
+    page.wait_for_timeout(600)  # let the delayed response land (and be ignored/applied)
+
+    ids = card_ids(page)
+    assert len(ids) == len(set(ids))  # never duplicated regardless of race outcome
+
+    page.unroute(re.compile(r"/api/articles\?.*"))
+
+
+# ── preview-tab selection survives incremental rendering ───────────────────
+
+
+def test_active_preview_tab_survives_load_more(page):
+    open_overview(page, extra_articles=110)
+
+    first_card = page.locator(".article-card").first
+    first_card.locator(".plat-tab").filter(has_text="HASHNODE").click()
+
+    page.locator("#load-more-button").click()
+    page.wait_for_function("document.querySelectorAll('.article-card').length === 116")
+
+    active_tab = page.locator(".article-card").first.locator(".plat-tab.active")
+    assert active_tab.inner_text().strip() == "HASHNODE"
+
+
+# ── accessibility ────────────────────────────────────────────────────────────
+
+
+def test_load_more_control_is_accessible(page):
+    open_overview(page, extra_articles=110)
+
+    button = page.locator("#load-more-button")
+    assert button.get_attribute("aria-describedby") == "load-more-status"
+
+    status = page.locator("#load-more-status")
+    assert status.get_attribute("role") == "status"
+    assert status.get_attribute("aria-live") == "polite"
+
+    # Keyboard: focus and activate via Enter.
+    button.focus()
+    page.keyboard.press("Enter")
+    page.wait_for_function("document.querySelectorAll('.article-card').length === 116")
+    assert page.locator(".article-card").count() == 116
+
+
+# ── mobile layout: no overlap/resize from the load-more control ────────────
+
+
+def test_load_more_control_does_not_overlap_cards_on_mobile(page):
+    open_overview(page, width=390, height=844, extra_articles=110)
+
+    last_card_box = page.locator(".article-card").last.bounding_box()
+    button_box = page.locator("#load-more-button").bounding_box()
+
+    assert button_box["y"] >= last_card_box["y"] + last_card_box["height"] - 1
+    assert button_box["width"] <= 390


### PR DESCRIPTION
## Summary
- add incremental Load more pagination beyond the first 100 articles
- append and deduplicate cards while preserving platform-tab state
- prevent stale page responses from corrupting the current overview
- keep initial page loading alive when filters change
- automatically load remaining pages while filtering so matches beyond page one are included
- add accessible loading, completion, retry, and mobile states

## Verification
- 6 backend pagination contract tests pass
- 16 Playwright tests collect successfully
- browser execution is currently blocked on this WSL host because Chromium runtime library libnspr4.so is missing and sudo requires an interactive password
- diff check passes

Closes #52