### PR TITLE
test: add Playwright PR gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,63 @@ jobs:
 
       - name: Validate generated contracts
         run: npm run check:contracts
+
+  playwright-tests:
+    name: Playwright gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      BLOGHUB_DB_PATH: ":memory:"
+      BLOGHUB_BLOBS_DIR: ${{ runner.temp }}/bloghub-blobs
+      BLOGHUB_CREDENTIAL_KEY_FILE: ${{ runner.temp }}/bloghub-credential-keys.json
+      BLOGHUB_DISABLE_AUTH: "true"
+      DEVTO_API_KEY: ""
+      HASHNODE_PAT: ""
+      HASHNODE_PUBLICATION_ID: ""
+      MEDIUM_CLIENT_ID: ""
+      MEDIUM_CLIENT_SECRET: ""
+      MEDIUM_SESSION_FILE: ""
+      MEDIUM_TOKEN: ""
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            backend/requirements.txt
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt -r backend/requirements.txt
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: npm run test:playwright:ci
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            tests/results
+          if-no-files-found: ignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ writes credentials into the mounted volume.
 cd blog-hub
 bash scripts/run-unit-tests.sh
 npm run check:contracts
+npm run test:playwright:ci
 
 # UI browser tests (requires backend on :8000 and cli-runner on :8001)
 .venv/Scripts/python.exe -m uvicorn backend.main:app --port 8000
@@ -87,5 +88,5 @@ npm run check:contracts
 The Playwright UI test for Claude login (`test_claude_browser_login_full_loopback_flow`) captures
 the callback URL from failed network requests via `page.on("request", ...)` — no manual copy needed.
 
-GitHub CI is documented in `docs/ci.md`. Browser and live-provider tests remain
-opt-in until their dedicated Playwright workflow lands.
+GitHub CI is documented in `docs/ci.md`. Live-provider browser login tests remain
+opt-in and are excluded from the default Playwright gate.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,6 +8,7 @@ The default PR checks are intentionally deterministic:
 ```bash
 bash scripts/run-unit-tests.sh
 npm run check:contracts
+npm run test:playwright:ci
 ```
 
 The `Unit test gate` job is the required Python gate for ordinary PRs. It runs
@@ -17,5 +18,6 @@ pytest with strict marker validation and explicitly excludes tests marked
 cleared in the baseline workflow.
 
 Playwright/browser coverage is tracked separately in issue #56. Those tests
-need browser setup, screenshots/traces on failure, and fixture-backed provider
-states before they become a required CI gate.
+run in the `Playwright gate` job with `BLOGHUB_DISABLE_AUTH=true` and fixture
+state from the in-memory store. Live provider browser login is tagged `@live`
+and remains opt-in through `BLOGHUB_LIVE_BROWSER_LOGIN=1`.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "private": true,
     "scripts": {
         "test": "playwright test",
+        "test:playwright:ci": "bash scripts/run-playwright-tests.sh",
         "test:headed": "playwright test --headed",
         "test:debug": "playwright test --debug",
         "generate:types": "node scripts/generate-types.mjs",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,22 +1,33 @@
 // @ts-check
 const { defineConfig, devices } = require('@playwright/test');
 const path = require('path');
+const fs = require('fs');
 
-const PYTHON = path.join(__dirname, '.venv', 'Scripts', 'python.exe');
+const windowsPython = path.join(__dirname, '.venv', 'Scripts', 'python.exe');
+const PYTHON = process.env.PYTHON ||
+  (process.platform === 'win32' && fs.existsSync(windowsPython) ? windowsPython : 'python');
+const PYTHON_COMMAND = process.env.BLOGHUB_PLAYWRIGHT_PYTHON_COMMAND || `"${PYTHON}"`;
 
 module.exports = defineConfig({
   testDir: './tests',
   outputDir: './tests/results',
   timeout: 15_000,
   retries: 0,
-  reporter: [['list'], ['json', { outputFile: 'tests/results/report.json' }]],
+  reporter: process.env.CI
+    ? [['list'], ['html', { outputFolder: 'tests/results/html', open: 'never' }], ['json', { outputFile: 'tests/results/report.json' }]]
+    : [['list'], ['json', { outputFile: 'tests/results/report.json' }]],
 
   webServer: {
-    command: `"${PYTHON}" -m uvicorn backend.main:app --port 8000 --no-access-log`,
+    command: `${PYTHON_COMMAND} -m uvicorn backend.main:app --port 8000 --no-access-log`,
     cwd: __dirname,
     url: 'http://localhost:8000/health',
     reuseExistingServer: true,
-    env: { ...process.env, PYTHONPATH: __dirname },
+    env: {
+      ...process.env,
+      BLOGHUB_DB_PATH: process.env.BLOGHUB_DB_PATH || ':memory:',
+      BLOGHUB_DISABLE_AUTH: process.env.BLOGHUB_DISABLE_AUTH || 'true',
+      PYTHONPATH: __dirname,
+    },
     timeout: 30_000,
   },
 
@@ -26,7 +37,6 @@ module.exports = defineConfig({
   },
 
   projects: [
-    { name: 'edge', use: { ...devices['Desktop Edge'], channel: 'msedge' } },
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
   ],
 });
-

--- a/scripts/run-playwright-tests.sh
+++ b/scripts/run-playwright-tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${BLOGHUB_PLAYWRIGHT_PYTHON_COMMAND:-}" ] && [ -z "${PYTHON:-}" ]; then
+  if command -v uv >/dev/null 2>&1; then
+    export BLOGHUB_PLAYWRIGHT_PYTHON_COMMAND="uv run --with-requirements requirements.txt --with-requirements backend/requirements.txt python"
+  fi
+fi
+
+if [ -z "${BLOGHUB_PLAYWRIGHT_PYTHON_COMMAND:-}" ] && [ -z "${PYTHON:-}" ]; then
+  for candidate in python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1 && "$candidate" -c "import uvicorn" >/dev/null 2>&1; then
+      export PYTHON="$candidate"
+      break
+    fi
+  done
+fi
+
+npx playwright test --grep-invert "@live" "$@"

--- a/tests/settings.spec.js
+++ b/tests/settings.spec.js
@@ -128,7 +128,9 @@ test.describe('Settings screen', () => {
    *  6. Poll /api/connections/anthropic/cli-login-status until connected.
    *  7. Assert the card shows Connected.
    */
-  test('Claude browser login: full loopback OAuth flow', async ({ page, context }) => {
+  test('Claude browser login: full loopback OAuth flow @live', async ({ page, context }) => {
+    test.skip(!process.env.BLOGHUB_LIVE_BROWSER_LOGIN, 'Live provider login is opt-in.');
+
     await openAiProviders(page);
 
     // Start login — runner spawns claude auth login and returns the loopback URL


### PR DESCRIPTION
## Summary
- Add a Playwright gate job to GitHub Actions for deterministic browser coverage.
- Add scripts/run-playwright-tests.sh and npm run test:playwright:ci for local/CI parity.
- Make playwright.config.js run on Linux CI with Chromium, in-memory store state, and auth disabled.
- Exclude the real Claude OAuth test from the default gate by tagging it @live.
- Upload Playwright reports from CI for failed-run inspection.

## Validation
- bash scripts/run-playwright-tests.sh --list

Selected 34 deterministic browser tests and excluded live provider login.

Full local browser execution is blocked in this WSL1 checkout because npm resolves to Windows Node/Python; the GitHub workflow runs under Linux Node/Python.

Refs #56
Stacked on #60 / feat/55.