### PR TITLE
feat: serve authenticated article assets

### DIFF
--- a/backend/routers/articles.py
+++ b/backend/routers/articles.py
@@ -1,8 +1,12 @@
 import io
+import hashlib
+import re
 import zipfile
 from pathlib import Path
+from urllib.parse import quote
 
 from fastapi import APIRouter, BackgroundTasks, File, HTTPException, Query, Request, UploadFile
+from fastapi.responses import Response
 from typing import Literal, Optional
 
 from pydantic import BaseModel
@@ -129,7 +133,68 @@ class ArticleDetailResponse(BaseModel):
     gate: str
     source: str
     source_platform: Optional[str] = None
+    preview_image_url: Optional[str] = None
     destinations: dict[str, ArticleDestinationDetail]
+
+
+_MIME_TYPE = re.compile(r"^[A-Za-z0-9!#$&^_.+-]+/[A-Za-z0-9!#$&^_.+-]+$")
+
+
+def _asset_media_type(value: str | None) -> str:
+    if value and _MIME_TYPE.fullmatch(value.strip()):
+        return value.strip().lower()
+    return "application/octet-stream"
+
+
+def _asset_content_disposition(filename: str, media_type: str) -> str:
+    leaf = filename.replace("\\", "/").rsplit("/", 1)[-1]
+    leaf = "".join(character for character in leaf if 32 <= ord(character) < 127)
+    leaf = leaf[:255] or "asset"
+    ascii_name = re.sub(r'[^A-Za-z0-9._ -]', "_", leaf).strip(". ") or "asset"
+    disposition = "inline" if media_type in {
+        "image/avif",
+        "image/gif",
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+    } else "attachment"
+    return (
+        f'{disposition}; filename="{ascii_name}"; '
+        f"filename*=UTF-8''{quote(leaf, safe='')}"
+    )
+
+
+def _etag_matches(request: Request, etag: str) -> bool:
+    candidates = {
+        candidate.strip() for candidate in request.headers.get("if-none-match", "").split(",")
+    }
+    return "*" in candidates or etag in candidates or f"W/{etag}" in candidates
+
+
+@router.get("/{article_id}/assets/{asset_id}", response_class=Response)
+def get_article_asset(request: Request, article_id: str, asset_id: int):
+    asset = store.read_article_asset(request.state.user_id, article_id, asset_id)
+    if asset is None:
+        raise HTTPException(status_code=404, detail="Asset not found")
+
+    etag = f'"{hashlib.sha256(asset["data"]).hexdigest()}"'
+    media_type = _asset_media_type(asset["mime_type"])
+    headers = {
+        "ETag": etag,
+        "Cache-Control": "private, max-age=3600, must-revalidate",
+        "Vary": "Cookie",
+        "X-Content-Type-Options": "nosniff",
+        "Content-Disposition": _asset_content_disposition(
+            asset["filename"], media_type,
+        ),
+    }
+    if _etag_matches(request, etag):
+        return Response(status_code=304, headers=headers)
+    return Response(
+        content=asset["data"],
+        media_type=media_type,
+        headers=headers,
+    )
 
 
 @router.get("/{article_id}", response_model=ArticleDetailResponse)
@@ -152,6 +217,7 @@ def get_article(request: Request, article_id: str):
         gate=article["gate"],
         source=article["source"],
         source_platform=article.get("source_platform"),
+        preview_image_url=article.get("preview_image_url"),
         destinations={
             k:
                 ArticleDestinationDetail(

--- a/backend/store/__init__.py
+++ b/backend/store/__init__.py
@@ -41,6 +41,10 @@ def store_asset(user_id: str, *a, **kw):
     return _backend.store_asset(user_id, *a, **kw)
 
 
+def read_article_asset(user_id: str, *a, **kw):
+    return _backend.read_article_asset(user_id, *a, **kw)
+
+
 def update_article_title(user_id: str, *a, **kw):
     return _backend.update_article_title(user_id, *a, **kw)
 

--- a/backend/store/backends/sqlite.py
+++ b/backend/store/backends/sqlite.py
@@ -323,6 +323,21 @@ class SQLiteStore(
                 return full.read_text(encoding="utf-8")
         return row["body"]
 
+    def _local_preview_image_url(self, article_id: str) -> str | None:
+        row = self._con.execute(
+            """SELECT rai.cover_asset_id
+               FROM remote_article_identities rai
+               JOIN article_assets aa
+                 ON aa.id=rai.cover_asset_id AND aa.article_id=rai.article_id
+               WHERE rai.article_id=? AND rai.cover_asset_id IS NOT NULL
+               ORDER BY rai.updated_at DESC, rai.platform, rai.remote_id
+               LIMIT 1""",
+            (article_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return f"/api/articles/{article_id}/assets/{row['cover_asset_id']}"
+
     # ── Article assembly ─────────────────────────────────────────────────────
 
     def _load_article(self, row: sqlite3.Row) -> dict:
@@ -367,6 +382,8 @@ class SQLiteStore(
                 row["source_platform"],
             "canonical_url":
                 row["canonical_url"],
+            "preview_image_url":
+                self._local_preview_image_url(aid),
             "created_at":
                 _dt(row["created_at"]),
             "updated_at":
@@ -981,6 +998,42 @@ class SQLiteStore(
             )
             self._con.commit()
             return rel
+
+    def read_article_asset(
+        self, user_id: str, article_id: str, asset_id: int,
+    ) -> dict | None:
+        """Read a registered asset without exposing its filesystem location."""
+        with self._workspace_lock.acquire():
+            row = self._con.execute(
+                """SELECT aa.id, aa.filename, aa.asset_path, aa.mime_type
+                   FROM article_assets aa
+                   JOIN articles a ON a.id=aa.article_id
+                   WHERE aa.id=? AND aa.article_id=? AND a.user_id=?""",
+                (asset_id, article_id, user_id),
+            ).fetchone()
+            if row is None:
+                return None
+
+            assets_root = (
+                self._blobs_dir / "articles" / article_id / "assets"
+            ).resolve()
+            candidate = (self._blobs_dir / row["asset_path"]).resolve()
+            try:
+                candidate.relative_to(assets_root)
+            except ValueError:
+                return None
+            try:
+                if not candidate.is_file():
+                    return None
+                data = candidate.read_bytes()
+            except OSError:
+                return None
+            return {
+                "id": row["id"],
+                "filename": row["filename"],
+                "mime_type": row["mime_type"],
+                "data": data,
+            }
 
     def reset(self) -> None:
         """Drop all data and re-seed. Used by the /api/dev/reset endpoint in tests."""

--- a/backend/store/base.py
+++ b/backend/store/base.py
@@ -82,6 +82,11 @@ class ArticleStore(Protocol):
     ) -> str:
         ...
 
+    def read_article_asset(
+        self, user_id: str, article_id: str, asset_id: int,
+    ) -> dict | None:
+        ...
+
     def delete_articles(self, user_id: str, ids: list[str], force: bool = False) -> list[str]:
         ...
 

--- a/contracts/overview.ts
+++ b/contracts/overview.ts
@@ -64,6 +64,8 @@ export interface ArticleSummary {
     updatedAt: string;
     wordCount: number;                // character count is derived client-side
     gate: GateStatus;
+    /** Authenticated local cover URL, or null to use the deterministic fallback. */
+    previewImageUrl: string | null;
     destinations: Record<Platform, PlatformSummary>;
     /** Last 5 timeline events, newest first. Full history on article-detail. */
     recentTimeline: TimelineEvent[];

--- a/tests/tests_backend/test_article_assets.py
+++ b/tests/tests_backend/test_article_assets.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+import backend.store as store
+
+
+def _add_cover(
+    article_id: str = "art_001",
+    *,
+    filename: str = "cover.png",
+    content: bytes = b"png-cover",
+    mime_type: str = "image/png",
+) -> tuple[int, str]:
+    asset_path = store.store_asset(
+        store._backend.SEED_USER_ID,
+        article_id,
+        filename,
+        content,
+        mime_type,
+    )
+    asset_id = store._backend._con.execute(
+        "SELECT id FROM article_assets WHERE article_id=? AND filename=?",
+        (article_id, filename),
+    ).fetchone()[0]
+    store.upsert_remote_article_identity(
+        store._backend.SEED_USER_ID,
+        article_id,
+        "hashnode",
+        f"remote-{article_id}",
+        cover_asset_id=asset_id,
+    )
+    return asset_id, asset_path
+
+
+def _asset_url(article_id: str, asset_id: int) -> str:
+    return f"/api/articles/{article_id}/assets/{asset_id}"
+
+
+def test_owner_can_read_registered_cover_with_safe_headers(client: TestClient):
+    asset_id, _ = _add_cover()
+    with store._backend._con:
+        store._backend._con.execute(
+            "UPDATE article_assets SET filename=? WHERE id=?",
+            ('../../unsafe\ncover".png', asset_id),
+        )
+    response = client.get(_asset_url("art_001", asset_id))
+
+    assert response.status_code == 200
+    assert response.content == b"png-cover"
+    assert response.headers["content-type"] == "image/png"
+    assert response.headers["cache-control"] == "private, max-age=3600, must-revalidate"
+    assert response.headers["vary"] == "Cookie"
+    assert response.headers["x-content-type-options"] == "nosniff"
+    assert response.headers["etag"].startswith('"')
+    disposition = response.headers["content-disposition"]
+    assert disposition.startswith("inline;")
+    assert ".." not in disposition
+    assert "\n" not in disposition and "\r" not in disposition
+
+
+def test_asset_read_requires_authentication(anon_client: TestClient):
+    asset_id, _ = _add_cover()
+
+    response = anon_client.get(_asset_url("art_001", asset_id))
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Authentication required"}
+
+
+def test_other_user_and_missing_resources_share_non_leaking_404(client: TestClient):
+    asset_id, _ = _add_cover()
+    expected = {"detail": "Asset not found"}
+
+    with TestClient(app) as other_user:
+        registered = other_user.post(
+            "/api/auth/register",
+            json={"email": "asset-reader@example.com", "password": "password123"},
+        )
+        assert registered.status_code == 201
+        unauthorized = other_user.get(_asset_url("art_001", asset_id))
+
+    missing_article = client.get(_asset_url("art_missing", asset_id))
+    missing_asset = client.get(_asset_url("art_001", asset_id + 1000))
+
+    assert unauthorized.status_code == 404
+    assert missing_article.status_code == 404
+    assert missing_asset.status_code == 404
+    assert unauthorized.json() == missing_article.json() == missing_asset.json() == expected
+
+
+def test_missing_asset_file_uses_same_non_leaking_404(client: TestClient):
+    asset_id, asset_path = _add_cover()
+    (store._backend._blobs_dir / asset_path).unlink()
+
+    response = client.get(_asset_url("art_001", asset_id))
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Asset not found"}
+
+
+def test_registered_traversal_path_cannot_escape_article_assets(
+    client: TestClient,
+):
+    asset_id, _ = _add_cover()
+    secret = store._backend._blobs_dir.parent / "asset-read-secret.png"
+    secret.write_bytes(b"must-not-leak")
+    try:
+        with store._backend._con:
+            store._backend._con.execute(
+                "UPDATE article_assets SET asset_path=? WHERE id=?",
+                ("../asset-read-secret.png", asset_id),
+            )
+
+        response = client.get(_asset_url("art_001", asset_id))
+
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Asset not found"}
+        assert b"must-not-leak" not in response.content
+    finally:
+        secret.unlink(missing_ok=True)
+
+
+def test_unregistered_blob_cannot_be_requested(client: TestClient):
+    assets_dir = store._backend._blobs_dir / "articles" / "art_001" / "assets"
+    assets_dir.mkdir(parents=True, exist_ok=True)
+    unregistered = assets_dir / "unregistered.png"
+    unregistered.write_bytes(b"not-registered")
+
+    response = client.get(_asset_url("art_001", 999999))
+
+    assert response.status_code == 404
+    assert b"not-registered" not in response.content
+
+
+def test_etag_revalidation_and_content_change(client: TestClient):
+    asset_id, _ = _add_cover()
+    url = _asset_url("art_001", asset_id)
+    first = client.get(url)
+    etag = first.headers["etag"]
+
+    unchanged = client.get(url, headers={"If-None-Match": etag})
+    assert unchanged.status_code == 304
+    assert unchanged.content == b""
+    assert unchanged.headers["etag"] == etag
+    assert unchanged.headers["cache-control"].startswith("private")
+    assert unchanged.headers["x-content-type-options"] == "nosniff"
+
+    store.store_asset(
+        store._backend.SEED_USER_ID,
+        "art_001",
+        "cover.png",
+        b"changed-cover",
+        "image/png",
+    )
+    changed = client.get(url, headers={"If-None-Match": etag})
+    assert changed.status_code == 200
+    assert changed.content == b"changed-cover"
+    assert changed.headers["etag"] != etag
+
+
+def test_non_raster_asset_is_served_as_attachment(client: TestClient):
+    asset_id, _ = _add_cover(
+        filename="article.html",
+        content=b"<script>alert(1)</script>",
+        mime_type="text/html",
+    )
+
+    response = client.get(_asset_url("art_001", asset_id))
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+    assert response.headers["content-disposition"].startswith("attachment;")
+    assert response.headers["x-content-type-options"] == "nosniff"
+
+
+def test_article_list_and_detail_expose_stable_local_cover_url(client: TestClient):
+    asset_id, _ = _add_cover()
+    expected = _asset_url("art_001", asset_id)
+
+    summary = next(
+        item for item in client.get("/api/articles").json()["items"]
+        if item["id"] == "art_001"
+    )
+    detail = client.get("/api/articles/art_001").json()
+
+    assert summary["previewImageUrl"] == expected
+    assert detail["preview_image_url"] == expected
+    assert client.get(expected).content == b"png-cover"
+
+
+def test_article_without_cover_preserves_null_fallback_signal(client: TestClient):
+    summary = next(
+        item for item in client.get("/api/articles").json()["items"]
+        if item["id"] == "art_002"
+    )
+    detail = client.get("/api/articles/art_002").json()
+
+    assert summary["previewImageUrl"] is None
+    assert detail["preview_image_url"] is None


### PR DESCRIPTION
## Summary

- add an authenticated article-asset endpoint backed only by registered database records
- prevent cross-user reads, path traversal, symlink escapes, and filesystem-path disclosure
- expose stable local cover URLs through article list and detail responses
- return private cache headers, content-based ETags, `nosniff`, and safe content disposition

## Scope

This PR is stacked on `feat/47` and implements read access and URL exposure only. It does not download or synchronize remote assets.

## Validation

- `pytest -q -s tests/tests_backend/test_article_assets.py` (10 passed)
- `pytest -q -s tests/tests_backend -k "not TestDraftsIntegration and not test_default_key_file_encrypts_without_plaintext"` (300 passed, 13 deselected)
- `python3 -m compileall -q backend tests/tests_backend`
- `git diff --check`

Closes #50