### PR TITLE
fix: recover stacked PR changes on develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,63 @@ jobs:
 
       - name: Validate generated contracts
         run: npm run check:contracts
+
+  playwright-tests:
+    name: Playwright gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      BLOGHUB_DB_PATH: ":memory:"
+      BLOGHUB_BLOBS_DIR: ${{ runner.temp }}/bloghub-blobs
+      BLOGHUB_CREDENTIAL_KEY_FILE: ${{ runner.temp }}/bloghub-credential-keys.json
+      BLOGHUB_DISABLE_AUTH: "true"
+      DEVTO_API_KEY: ""
+      HASHNODE_PAT: ""
+      HASHNODE_PUBLICATION_ID: ""
+      MEDIUM_CLIENT_ID: ""
+      MEDIUM_CLIENT_SECRET: ""
+      MEDIUM_SESSION_FILE: ""
+      MEDIUM_TOKEN: ""
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            backend/requirements.txt
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt -r backend/requirements.txt
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: npm run test:playwright:ci
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            tests/results
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ permissions:
   contents: read
 
 jobs:
-  python-tests:
-    name: Python tests
+  unit-tests:
+    name: Unit test gate
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -33,6 +33,13 @@ jobs:
       BLOGHUB_DB_PATH: ":memory:"
       BLOGHUB_BLOBS_DIR: ${{ runner.temp }}/bloghub-blobs
       BLOGHUB_CREDENTIAL_KEY_FILE: ${{ runner.temp }}/bloghub-credential-keys.json
+      DEVTO_API_KEY: ""
+      HASHNODE_PAT: ""
+      HASHNODE_PUBLICATION_ID: ""
+      MEDIUM_CLIENT_ID: ""
+      MEDIUM_CLIENT_SECRET: ""
+      MEDIUM_SESSION_FILE: ""
+      MEDIUM_TOKEN: ""
 
     steps:
       - name: Check out repository
@@ -53,7 +60,7 @@ jobs:
           python -m pip install -r requirements.txt -r backend/requirements.txt
 
       - name: Run unit tests
-        run: python -m pytest
+        run: bash scripts/run-unit-tests.sh
 
   contract-checks:
     name: Contract checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
 
     env:
       BLOGHUB_DB_PATH: ":memory:"
-      BLOGHUB_BLOBS_DIR: ${{ runner.temp }}/bloghub-blobs
-      BLOGHUB_CREDENTIAL_KEY_FILE: ${{ runner.temp }}/bloghub-credential-keys.json
+      BLOGHUB_BLOBS_DIR: /tmp/bloghub-blobs
+      BLOGHUB_CREDENTIAL_KEY_FILE: /tmp/bloghub-credential-keys.json
       DEVTO_API_KEY: ""
       HASHNODE_PAT: ""
       HASHNODE_PUBLICATION_ID: ""
@@ -90,8 +90,8 @@ jobs:
 
     env:
       BLOGHUB_DB_PATH: ":memory:"
-      BLOGHUB_BLOBS_DIR: ${{ runner.temp }}/bloghub-blobs
-      BLOGHUB_CREDENTIAL_KEY_FILE: ${{ runner.temp }}/bloghub-credential-keys.json
+      BLOGHUB_BLOBS_DIR: /tmp/bloghub-blobs
+      BLOGHUB_CREDENTIAL_KEY_FILE: /tmp/bloghub-credential-keys.json
       BLOGHUB_DISABLE_AUTH: "true"
       DEVTO_API_KEY: ""
       HASHNODE_PAT: ""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ writes credentials into the mounted volume.
 cd blog-hub
 bash scripts/run-unit-tests.sh
 npm run check:contracts
+npm run test:playwright:ci
 
 # UI browser tests (requires backend on :8000 and cli-runner on :8001)
 .venv/Scripts/python.exe -m uvicorn backend.main:app --port 8000
@@ -87,5 +88,5 @@ npm run check:contracts
 The Playwright UI test for Claude login (`test_claude_browser_login_full_loopback_flow`) captures
 the callback URL from failed network requests via `page.on("request", ...)` — no manual copy needed.
 
-GitHub CI is documented in `docs/ci.md`. Browser and live-provider tests remain
-opt-in until their dedicated Playwright workflow lands.
+GitHub CI is documented in `docs/ci.md`. Live-provider browser login tests remain
+opt-in and are excluded from the default Playwright gate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ writes credentials into the mounted volume.
 ```bash
 # CI baseline: unit tests and API contract checks
 cd blog-hub
-python -m pytest
+bash scripts/run-unit-tests.sh
 npm run check:contracts
 
 # UI browser tests (requires backend on :8000 and cli-runner on :8001)

--- a/backend/routers/articles.py
+++ b/backend/routers/articles.py
@@ -1,8 +1,12 @@
 import io
+import hashlib
+import re
 import zipfile
 from pathlib import Path
+from urllib.parse import quote
 
 from fastapi import APIRouter, BackgroundTasks, File, HTTPException, Query, Request, UploadFile
+from fastapi.responses import Response
 from typing import Literal, Optional
 
 from pydantic import BaseModel
@@ -129,7 +133,68 @@ class ArticleDetailResponse(BaseModel):
     gate: str
     source: str
     source_platform: Optional[str] = None
+    preview_image_url: Optional[str] = None
     destinations: dict[str, ArticleDestinationDetail]
+
+
+_MIME_TYPE = re.compile(r"^[A-Za-z0-9!#$&^_.+-]+/[A-Za-z0-9!#$&^_.+-]+$")
+
+
+def _asset_media_type(value: str | None) -> str:
+    if value and _MIME_TYPE.fullmatch(value.strip()):
+        return value.strip().lower()
+    return "application/octet-stream"
+
+
+def _asset_content_disposition(filename: str, media_type: str) -> str:
+    leaf = filename.replace("\\", "/").rsplit("/", 1)[-1]
+    leaf = "".join(character for character in leaf if 32 <= ord(character) < 127)
+    leaf = leaf[:255] or "asset"
+    ascii_name = re.sub(r'[^A-Za-z0-9._ -]', "_", leaf).strip(". ") or "asset"
+    disposition = "inline" if media_type in {
+        "image/avif",
+        "image/gif",
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+    } else "attachment"
+    return (
+        f'{disposition}; filename="{ascii_name}"; '
+        f"filename*=UTF-8''{quote(leaf, safe='')}"
+    )
+
+
+def _etag_matches(request: Request, etag: str) -> bool:
+    candidates = {
+        candidate.strip() for candidate in request.headers.get("if-none-match", "").split(",")
+    }
+    return "*" in candidates or etag in candidates or f"W/{etag}" in candidates
+
+
+@router.get("/{article_id}/assets/{asset_id}", response_class=Response)
+def get_article_asset(request: Request, article_id: str, asset_id: int):
+    asset = store.read_article_asset(request.state.user_id, article_id, asset_id)
+    if asset is None:
+        raise HTTPException(status_code=404, detail="Asset not found")
+
+    etag = f'"{hashlib.sha256(asset["data"]).hexdigest()}"'
+    media_type = _asset_media_type(asset["mime_type"])
+    headers = {
+        "ETag": etag,
+        "Cache-Control": "private, max-age=3600, must-revalidate",
+        "Vary": "Cookie",
+        "X-Content-Type-Options": "nosniff",
+        "Content-Disposition": _asset_content_disposition(
+            asset["filename"], media_type,
+        ),
+    }
+    if _etag_matches(request, etag):
+        return Response(status_code=304, headers=headers)
+    return Response(
+        content=asset["data"],
+        media_type=media_type,
+        headers=headers,
+    )
 
 
 @router.get("/{article_id}", response_model=ArticleDetailResponse)
@@ -152,6 +217,7 @@ def get_article(request: Request, article_id: str):
         gate=article["gate"],
         source=article["source"],
         source_platform=article.get("source_platform"),
+        preview_image_url=article.get("preview_image_url"),
         destinations={
             k:
                 ArticleDestinationDetail(

--- a/backend/store/__init__.py
+++ b/backend/store/__init__.py
@@ -41,6 +41,10 @@ def store_asset(user_id: str, *a, **kw):
     return _backend.store_asset(user_id, *a, **kw)
 
 
+def read_article_asset(user_id: str, *a, **kw):
+    return _backend.read_article_asset(user_id, *a, **kw)
+
+
 def update_article_title(user_id: str, *a, **kw):
     return _backend.update_article_title(user_id, *a, **kw)
 

--- a/backend/store/backends/sqlite.py
+++ b/backend/store/backends/sqlite.py
@@ -323,6 +323,21 @@ class SQLiteStore(
                 return full.read_text(encoding="utf-8")
         return row["body"]
 
+    def _local_preview_image_url(self, article_id: str) -> str | None:
+        row = self._con.execute(
+            """SELECT rai.cover_asset_id
+               FROM remote_article_identities rai
+               JOIN article_assets aa
+                 ON aa.id=rai.cover_asset_id AND aa.article_id=rai.article_id
+               WHERE rai.article_id=? AND rai.cover_asset_id IS NOT NULL
+               ORDER BY rai.updated_at DESC, rai.platform, rai.remote_id
+               LIMIT 1""",
+            (article_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return f"/api/articles/{article_id}/assets/{row['cover_asset_id']}"
+
     # ── Article assembly ─────────────────────────────────────────────────────
 
     def _load_article(self, row: sqlite3.Row) -> dict:
@@ -367,6 +382,8 @@ class SQLiteStore(
                 row["source_platform"],
             "canonical_url":
                 row["canonical_url"],
+            "preview_image_url":
+                self._local_preview_image_url(aid),
             "created_at":
                 _dt(row["created_at"]),
             "updated_at":
@@ -981,6 +998,42 @@ class SQLiteStore(
             )
             self._con.commit()
             return rel
+
+    def read_article_asset(
+        self, user_id: str, article_id: str, asset_id: int,
+    ) -> dict | None:
+        """Read a registered asset without exposing its filesystem location."""
+        with self._workspace_lock.acquire():
+            row = self._con.execute(
+                """SELECT aa.id, aa.filename, aa.asset_path, aa.mime_type
+                   FROM article_assets aa
+                   JOIN articles a ON a.id=aa.article_id
+                   WHERE aa.id=? AND aa.article_id=? AND a.user_id=?""",
+                (asset_id, article_id, user_id),
+            ).fetchone()
+            if row is None:
+                return None
+
+            assets_root = (
+                self._blobs_dir / "articles" / article_id / "assets"
+            ).resolve()
+            candidate = (self._blobs_dir / row["asset_path"]).resolve()
+            try:
+                candidate.relative_to(assets_root)
+            except ValueError:
+                return None
+            try:
+                if not candidate.is_file():
+                    return None
+                data = candidate.read_bytes()
+            except OSError:
+                return None
+            return {
+                "id": row["id"],
+                "filename": row["filename"],
+                "mime_type": row["mime_type"],
+                "data": data,
+            }
 
     def reset(self) -> None:
         """Drop all data and re-seed. Used by the /api/dev/reset endpoint in tests."""

--- a/backend/store/base.py
+++ b/backend/store/base.py
@@ -82,6 +82,11 @@ class ArticleStore(Protocol):
     ) -> str:
         ...
 
+    def read_article_asset(
+        self, user_id: str, article_id: str, asset_id: int,
+    ) -> dict | None:
+        ...
+
     def delete_articles(self, user_id: str, ids: list[str], force: bool = False) -> list[str]:
         ...
 

--- a/contracts/overview.ts
+++ b/contracts/overview.ts
@@ -64,6 +64,8 @@ export interface ArticleSummary {
     updatedAt: string;
     wordCount: number;                // character count is derived client-side
     gate: GateStatus;
+    /** Authenticated local cover URL, or null to use the deterministic fallback. */
+    previewImageUrl: string | null;
     destinations: Record<Platform, PlatformSummary>;
     /** Last 5 timeline events, newest first. Full history on article-detail. */
     recentTimeline: TimelineEvent[];

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -3,17 +3,18 @@
 GitHub Actions runs the baseline CI workflow for pull requests into `develop`,
 pushes to numbered work branches, and manual dispatches.
 
-The default checks are intentionally deterministic:
+The default PR checks are intentionally deterministic:
 
 ```bash
-python -m pytest
+bash scripts/run-unit-tests.sh
 npm run check:contracts
 ```
 
-`pytest.ini` excludes tests marked `integration` or `browser` from the default
-Python run. Live provider credentials such as `HASHNODE_PAT`, `DEVTO_API_KEY`,
-and Medium browser sessions are not required by CI and should not be used by the
-baseline workflow.
+The `Unit test gate` job is the required Python gate for ordinary PRs. It runs
+pytest with strict marker validation and explicitly excludes tests marked
+`integration` or `browser`. Live provider credentials such as `HASHNODE_PAT`,
+`DEVTO_API_KEY`, and Medium browser sessions are not required by CI and are
+cleared in the baseline workflow.
 
 Playwright/browser coverage is tracked separately in issue #56. Those tests
 need browser setup, screenshots/traces on failure, and fixture-backed provider

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,6 +8,7 @@ The default PR checks are intentionally deterministic:
 ```bash
 bash scripts/run-unit-tests.sh
 npm run check:contracts
+npm run test:playwright:ci
 ```
 
 The `Unit test gate` job is the required Python gate for ordinary PRs. It runs
@@ -17,5 +18,6 @@ pytest with strict marker validation and explicitly excludes tests marked
 cleared in the baseline workflow.
 
 Playwright/browser coverage is tracked separately in issue #56. Those tests
-need browser setup, screenshots/traces on failure, and fixture-backed provider
-states before they become a required CI gate.
+run in the `Playwright gate` job with `BLOGHUB_DISABLE_AUTH=true` and fixture
+state from the in-memory store. Live provider browser login is tagged `@live`
+and remains opt-in through `BLOGHUB_LIVE_BROWSER_LOGIN=1`.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "private": true,
     "scripts": {
         "test": "playwright test",
+        "test:playwright:ci": "bash scripts/run-playwright-tests.sh",
         "test:headed": "playwright test --headed",
         "test:debug": "playwright test --debug",
         "generate:types": "node scripts/generate-types.mjs",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -10,6 +10,7 @@ const PYTHON_COMMAND = process.env.BLOGHUB_PLAYWRIGHT_PYTHON_COMMAND || `"${PYTH
 
 module.exports = defineConfig({
   testDir: './tests',
+  testMatch: ['settings.spec.js', 'overview-v3.spec.js'],
   outputDir: './tests/results/artifacts',
   timeout: 15_000,
   retries: 0,

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,22 +1,33 @@
 // @ts-check
 const { defineConfig, devices } = require('@playwright/test');
 const path = require('path');
+const fs = require('fs');
 
-const PYTHON = path.join(__dirname, '.venv', 'Scripts', 'python.exe');
+const windowsPython = path.join(__dirname, '.venv', 'Scripts', 'python.exe');
+const PYTHON = process.env.PYTHON ||
+  (process.platform === 'win32' && fs.existsSync(windowsPython) ? windowsPython : 'python');
+const PYTHON_COMMAND = process.env.BLOGHUB_PLAYWRIGHT_PYTHON_COMMAND || `"${PYTHON}"`;
 
 module.exports = defineConfig({
   testDir: './tests',
   outputDir: './tests/results',
   timeout: 15_000,
   retries: 0,
-  reporter: [['list'], ['json', { outputFile: 'tests/results/report.json' }]],
+  reporter: process.env.CI
+    ? [['list'], ['html', { outputFolder: 'tests/results/html', open: 'never' }], ['json', { outputFile: 'tests/results/report.json' }]]
+    : [['list'], ['json', { outputFile: 'tests/results/report.json' }]],
 
   webServer: {
-    command: `"${PYTHON}" -m uvicorn backend.main:app --port 8000 --no-access-log`,
+    command: `${PYTHON_COMMAND} -m uvicorn backend.main:app --port 8000 --no-access-log`,
     cwd: __dirname,
     url: 'http://localhost:8000/health',
     reuseExistingServer: true,
-    env: { ...process.env, PYTHONPATH: __dirname },
+    env: {
+      ...process.env,
+      BLOGHUB_DB_PATH: process.env.BLOGHUB_DB_PATH || ':memory:',
+      BLOGHUB_DISABLE_AUTH: process.env.BLOGHUB_DISABLE_AUTH || 'true',
+      PYTHONPATH: __dirname,
+    },
     timeout: 30_000,
   },
 
@@ -26,7 +37,6 @@ module.exports = defineConfig({
   },
 
   projects: [
-    { name: 'edge', use: { ...devices['Desktop Edge'], channel: 'msedge' } },
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
   ],
 });
-

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -10,9 +10,10 @@ const PYTHON_COMMAND = process.env.BLOGHUB_PLAYWRIGHT_PYTHON_COMMAND || `"${PYTH
 
 module.exports = defineConfig({
   testDir: './tests',
-  outputDir: './tests/results',
+  outputDir: './tests/results/artifacts',
   timeout: 15_000,
   retries: 0,
+  workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI
     ? [['list'], ['html', { outputFolder: 'tests/results/html', open: 'never' }], ['json', { outputFile: 'tests/results/report.json' }]]
     : [['list'], ['json', { outputFile: 'tests/results/report.json' }]],

--- a/scripts/run-playwright-tests.sh
+++ b/scripts/run-playwright-tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${BLOGHUB_PLAYWRIGHT_PYTHON_COMMAND:-}" ] && [ -z "${PYTHON:-}" ]; then
+  if command -v uv >/dev/null 2>&1; then
+    export BLOGHUB_PLAYWRIGHT_PYTHON_COMMAND="uv run --with-requirements requirements.txt --with-requirements backend/requirements.txt python"
+  fi
+fi
+
+if [ -z "${BLOGHUB_PLAYWRIGHT_PYTHON_COMMAND:-}" ] && [ -z "${PYTHON:-}" ]; then
+  for candidate in python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1 && "$candidate" -c "import uvicorn" >/dev/null 2>&1; then
+      export PYTHON="$candidate"
+      break
+    fi
+  done
+fi
+
+npx playwright test --grep-invert "@live" "$@"

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pytest --strict-markers -m "not integration and not browser" "$@"

--- a/tests/overview-v3.spec.js
+++ b/tests/overview-v3.spec.js
@@ -1,0 +1,36 @@
+const { test, expect } = require('@playwright/test');
+
+const OVERVIEW_URL = '/screens/overview/v3.html';
+
+test.describe('Current overview screen', () => {
+  test.beforeEach(async ({ page }) => {
+    const reset = await page.request.post('/api/dev/reset');
+    expect(reset.ok()).toBeTruthy();
+    await page.goto(OVERVIEW_URL);
+    await page.locator('.article-card').first().waitFor();
+  });
+
+  test('renders article cards from the backend', async ({ page }) => {
+    await expect(page.locator('.article-card')).not.toHaveCount(0);
+    await expect(page.locator('.article-card-title').first()).not.toBeEmpty();
+  });
+
+  test('shows all platform preview tabs on each card', async ({ page }) => {
+    const firstCard = page.locator('.article-card').first();
+    await expect(firstCard.locator('.plat-tab')).toHaveCount(3);
+    await expect(firstCard.locator('.plat-tab')).toHaveText(['Medium', 'Hashnode', 'Dev.to']);
+  });
+
+  test('filters cards by title without losing the matching article', async ({ page }) => {
+    const firstTitle = await page.locator('.article-card-title').first().innerText();
+    await page.locator('#search-input').fill(firstTitle);
+
+    await expect(page.locator('.article-card')).toHaveCount(1);
+    await expect(page.locator('.article-card-title')).toHaveText(firstTitle);
+  });
+
+  test('opens the selected article in the editor', async ({ page }) => {
+    await page.locator('.article-card').first().locator('.card-edit').click();
+    await expect(page).toHaveURL(/\/screens\/editor\/v2\.html\?id=/);
+  });
+});

--- a/tests/settings.spec.js
+++ b/tests/settings.spec.js
@@ -128,7 +128,9 @@ test.describe('Settings screen', () => {
    *  6. Poll /api/connections/anthropic/cli-login-status until connected.
    *  7. Assert the card shows Connected.
    */
-  test('Claude browser login: full loopback OAuth flow', async ({ page, context }) => {
+  test('Claude browser login: full loopback OAuth flow @live', async ({ page, context }) => {
+    test.skip(!process.env.BLOGHUB_LIVE_BROWSER_LOGIN, 'Live provider login is opt-in.');
+
     await openAiProviders(page);
 
     // Start login — runner spawns claude auth login and returns the loopback URL

--- a/tests/tests_backend/test_article_assets.py
+++ b/tests/tests_backend/test_article_assets.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+import backend.store as store
+
+
+def _add_cover(
+    article_id: str = "art_001",
+    *,
+    filename: str = "cover.png",
+    content: bytes = b"png-cover",
+    mime_type: str = "image/png",
+) -> tuple[int, str]:
+    asset_path = store.store_asset(
+        store._backend.SEED_USER_ID,
+        article_id,
+        filename,
+        content,
+        mime_type,
+    )
+    asset_id = store._backend._con.execute(
+        "SELECT id FROM article_assets WHERE article_id=? AND filename=?",
+        (article_id, filename),
+    ).fetchone()[0]
+    store.upsert_remote_article_identity(
+        store._backend.SEED_USER_ID,
+        article_id,
+        "hashnode",
+        f"remote-{article_id}",
+        cover_asset_id=asset_id,
+    )
+    return asset_id, asset_path
+
+
+def _asset_url(article_id: str, asset_id: int) -> str:
+    return f"/api/articles/{article_id}/assets/{asset_id}"
+
+
+def test_owner_can_read_registered_cover_with_safe_headers(client: TestClient):
+    asset_id, _ = _add_cover()
+    with store._backend._con:
+        store._backend._con.execute(
+            "UPDATE article_assets SET filename=? WHERE id=?",
+            ('../../unsafe\ncover".png', asset_id),
+        )
+    response = client.get(_asset_url("art_001", asset_id))
+
+    assert response.status_code == 200
+    assert response.content == b"png-cover"
+    assert response.headers["content-type"] == "image/png"
+    assert response.headers["cache-control"] == "private, max-age=3600, must-revalidate"
+    assert response.headers["vary"] == "Cookie"
+    assert response.headers["x-content-type-options"] == "nosniff"
+    assert response.headers["etag"].startswith('"')
+    disposition = response.headers["content-disposition"]
+    assert disposition.startswith("inline;")
+    assert ".." not in disposition
+    assert "\n" not in disposition and "\r" not in disposition
+
+
+def test_asset_read_requires_authentication(anon_client: TestClient):
+    asset_id, _ = _add_cover()
+
+    response = anon_client.get(_asset_url("art_001", asset_id))
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Authentication required"}
+
+
+def test_other_user_and_missing_resources_share_non_leaking_404(client: TestClient):
+    asset_id, _ = _add_cover()
+    expected = {"detail": "Asset not found"}
+
+    with TestClient(app) as other_user:
+        registered = other_user.post(
+            "/api/auth/register",
+            json={"email": "asset-reader@example.com", "password": "password123"},
+        )
+        assert registered.status_code == 201
+        unauthorized = other_user.get(_asset_url("art_001", asset_id))
+
+    missing_article = client.get(_asset_url("art_missing", asset_id))
+    missing_asset = client.get(_asset_url("art_001", asset_id + 1000))
+
+    assert unauthorized.status_code == 404
+    assert missing_article.status_code == 404
+    assert missing_asset.status_code == 404
+    assert unauthorized.json() == missing_article.json() == missing_asset.json() == expected
+
+
+def test_missing_asset_file_uses_same_non_leaking_404(client: TestClient):
+    asset_id, asset_path = _add_cover()
+    (store._backend._blobs_dir / asset_path).unlink()
+
+    response = client.get(_asset_url("art_001", asset_id))
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Asset not found"}
+
+
+def test_registered_traversal_path_cannot_escape_article_assets(
+    client: TestClient,
+):
+    asset_id, _ = _add_cover()
+    secret = store._backend._blobs_dir.parent / "asset-read-secret.png"
+    secret.write_bytes(b"must-not-leak")
+    try:
+        with store._backend._con:
+            store._backend._con.execute(
+                "UPDATE article_assets SET asset_path=? WHERE id=?",
+                ("../asset-read-secret.png", asset_id),
+            )
+
+        response = client.get(_asset_url("art_001", asset_id))
+
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Asset not found"}
+        assert b"must-not-leak" not in response.content
+    finally:
+        secret.unlink(missing_ok=True)
+
+
+def test_unregistered_blob_cannot_be_requested(client: TestClient):
+    assets_dir = store._backend._blobs_dir / "articles" / "art_001" / "assets"
+    assets_dir.mkdir(parents=True, exist_ok=True)
+    unregistered = assets_dir / "unregistered.png"
+    unregistered.write_bytes(b"not-registered")
+
+    response = client.get(_asset_url("art_001", 999999))
+
+    assert response.status_code == 404
+    assert b"not-registered" not in response.content
+
+
+def test_etag_revalidation_and_content_change(client: TestClient):
+    asset_id, _ = _add_cover()
+    url = _asset_url("art_001", asset_id)
+    first = client.get(url)
+    etag = first.headers["etag"]
+
+    unchanged = client.get(url, headers={"If-None-Match": etag})
+    assert unchanged.status_code == 304
+    assert unchanged.content == b""
+    assert unchanged.headers["etag"] == etag
+    assert unchanged.headers["cache-control"].startswith("private")
+    assert unchanged.headers["x-content-type-options"] == "nosniff"
+
+    store.store_asset(
+        store._backend.SEED_USER_ID,
+        "art_001",
+        "cover.png",
+        b"changed-cover",
+        "image/png",
+    )
+    changed = client.get(url, headers={"If-None-Match": etag})
+    assert changed.status_code == 200
+    assert changed.content == b"changed-cover"
+    assert changed.headers["etag"] != etag
+
+
+def test_non_raster_asset_is_served_as_attachment(client: TestClient):
+    asset_id, _ = _add_cover(
+        filename="article.html",
+        content=b"<script>alert(1)</script>",
+        mime_type="text/html",
+    )
+
+    response = client.get(_asset_url("art_001", asset_id))
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+    assert response.headers["content-disposition"].startswith("attachment;")
+    assert response.headers["x-content-type-options"] == "nosniff"
+
+
+def test_article_list_and_detail_expose_stable_local_cover_url(client: TestClient):
+    asset_id, _ = _add_cover()
+    expected = _asset_url("art_001", asset_id)
+
+    summary = next(
+        item for item in client.get("/api/articles").json()["items"]
+        if item["id"] == "art_001"
+    )
+    detail = client.get("/api/articles/art_001").json()
+
+    assert summary["previewImageUrl"] == expected
+    assert detail["preview_image_url"] == expected
+    assert client.get(expected).content == b"png-cover"
+
+
+def test_article_without_cover_preserves_null_fallback_signal(client: TestClient):
+    summary = next(
+        item for item in client.get("/api/articles").json()["items"]
+        if item["id"] == "art_002"
+    )
+    detail = client.get("/api/articles/art_002").json()
+
+    assert summary["previewImageUrl"] is None
+    assert detail["preview_image_url"] is None


### PR DESCRIPTION
## Summary
- recover the unit-test CI gate from PR #60
- recover the Playwright CI gate from PR #62
- recover authenticated article asset delivery from PR #63
- replay all three patches onto current develop in dependency order

## Why
PRs #60 and #63 were merged into feature branches after their parent branches had already reached develop. PR #62 remained stacked on those branches. Their changes therefore did not land on develop.

## Verification
- authenticated article asset tests: 10 passed
- recovered unit-test runner: 10 passed on the focused asset suite
- contract generation and TypeScript validation pass
- shell runner syntax validation passes
- diff check passes

Supersedes #62.
Closes #64