### PR TITLE
feat: add browser blog extension SDK

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,3 +90,14 @@ the callback URL from failed network requests via `page.on("request", ...)` — 
 
 GitHub CI is documented in `docs/ci.md`. Live-provider browser login tests remain
 opt-in and are excluded from the default Playwright gate.
+
+## Browser Blog Extensions
+
+Browser-backed blog platforms use the versioned extension contract documented
+in `docs/blog-extensions.md`. Each trusted extension supplies separate login and
+operations adapters plus a manifest. The CLI runner owns the persistent
+Playwright context and discovers only administrator-mounted extension paths.
+
+Hashnode and Medium are built-in protocol-1 adapters. New platforms must not add
+platform-specific runner routes; expose their behavior through the extension
+capabilities and normalized operation contract.

--- a/backend/routers/articles.py
+++ b/backend/routers/articles.py
@@ -540,29 +540,30 @@ def push_article(request: Request, article_id: str, body: dict = {}):
     return AsyncAccepted(jobId=job["job_id"], status=JobStatus.done)
 
 
-class HashnodeBrowserPublishRequest(BaseModel):
+class BrowserPublishRequest(BaseModel):
     mode: Literal["draft", "publish"] = "draft"
 
 
-@router.post("/{article_id}/browser-publish/hashnode", status_code=201)
-def request_hashnode_browser_publish(
+@router.post("/{article_id}/browser-publish/{platform}", status_code=201)
+def request_browser_publish(
     request: Request,
     article_id: str,
-    body: HashnodeBrowserPublishRequest = HashnodeBrowserPublishRequest(),
+    platform: str,
+    body: BrowserPublishRequest = BrowserPublishRequest(),
 ):
     if store.get_article(request.state.user_id, article_id) is None:
         raise HTTPException(status_code=404, detail="Article not found")
     browser_connection = store.get_browser_connection(
-        request.state.user_id, "hashnode"
+        request.state.user_id, platform
     )
     if not browser_connection or browser_connection["status"] != "connected":
         raise HTTPException(
             status_code=409,
-            detail="Connect Hashnode with browser login before browser publishing",
+            detail=f"Connect {platform.title()} with browser login before browser publishing",
         )
     return store.create_browser_publish_run(
         request.state.user_id, article_id,
-        platform="hashnode", mode=body.mode,
+        platform=platform, mode=body.mode,
     )
 
 
@@ -575,7 +576,7 @@ def get_browser_publish(request: Request, article_id: str, run_id: str):
 
 
 @router.post("/{article_id}/browser-publish/{run_id}/approve", status_code=202)
-def approve_hashnode_browser_publish(
+def approve_browser_publish(
     request: Request, article_id: str, run_id: str,
     background_tasks: BackgroundTasks,
 ):
@@ -587,7 +588,7 @@ def approve_hashnode_browser_publish(
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     background_tasks.add_task(
-        browser_publish.execute_hashnode_run,
+        browser_publish.execute_run,
         user_id=request.state.user_id, run_id=run_id,
     )
     return approved

--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import json
 import hashlib
 import os
+import re
 
 import httpx
 from fastapi import APIRouter, HTTPException, Request
@@ -52,7 +53,12 @@ _VALID_IDS = {"medium", "hashnode", "devto", "anthropic", "openai"}
 _BLOG_IDS = {"medium", "hashnode", "devto"}
 _CLI_IDS = {"anthropic", "openai"}
 _PROVIDER_MAP = {"anthropic": "anthropic", "openai": "openai"}
-_BROWSER_LOGIN_IDS = {"medium", "hashnode"}
+_BROWSER_EXTENSION_ID = re.compile(r"^[a-z][a-z0-9_.-]{1,79}$")
+
+
+def _require_browser_extension_id(platform: str) -> None:
+    if not _BROWSER_EXTENSION_ID.fullmatch(platform):
+        raise HTTPException(status_code=400, detail="Invalid browser extension id")
 
 # ── Mock draft data ───────────────────────────────────────────────────────────
 # Real implementation would call each platform's API with the stored token.
@@ -226,6 +232,14 @@ def list_connections(request: Request):
     user_id: str = request.state.user_id
     return ConnectionListResponse(
         connections=[ConnectionInfo(**c) for c in store.list_connections(user_id)])
+
+
+@router.get("/browser-extensions")
+def list_browser_extensions():
+    try:
+        return {"extensions": runner.browser_extensions()}
+    except runner.RunnerUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
 # ── Provider-neutral AI agent authentication ─────────────────────────────────
@@ -511,8 +525,7 @@ def get_hashnode_browser_connection(request: Request):
 
 @router.get("/{conn_id}/browser-connection")
 def get_browser_connection(request: Request, conn_id: str):
-    if conn_id not in _BROWSER_LOGIN_IDS:
-        raise HTTPException(status_code=400, detail=f"{conn_id} does not support browser login")
+    _require_browser_extension_id(conn_id)
     return _browser_connection_response(
         conn_id,
         store.get_browser_connection(request.state.user_id, conn_id)
@@ -526,8 +539,7 @@ def start_hashnode_browser_connection(request: Request):
 
 @router.post("/{conn_id}/browser-connection", status_code=201)
 def start_browser_connection(request: Request, conn_id: str):
-    if conn_id not in _BROWSER_LOGIN_IDS:
-        raise HTTPException(status_code=400, detail=f"{conn_id} does not support browser login")
+    _require_browser_extension_id(conn_id)
     previous = store.get_browser_connection(request.state.user_id, conn_id)
     if previous and previous.get("skyvern_session_id") and previous["status"] == "waiting_for_login":
         try:
@@ -557,8 +569,7 @@ def complete_hashnode_browser_connection(request: Request):
 
 @router.post("/{conn_id}/browser-connection/complete")
 def complete_browser_connection(request: Request, conn_id: str):
-    if conn_id not in _BROWSER_LOGIN_IDS:
-        raise HTTPException(status_code=400, detail=f"{conn_id} does not support browser login")
+    _require_browser_extension_id(conn_id)
     user_id = request.state.user_id
     connection = store.get_browser_connection(user_id, conn_id)
     if not connection or connection["status"] != "waiting_for_login":
@@ -607,8 +618,7 @@ def disconnect_hashnode_browser_connection(request: Request):
 
 @router.delete("/{conn_id}/browser-connection")
 def disconnect_browser_connection(request: Request, conn_id: str):
-    if conn_id not in _BROWSER_LOGIN_IDS:
-        raise HTTPException(status_code=400, detail=f"{conn_id} does not support browser login")
+    _require_browser_extension_id(conn_id)
     connection = store.get_browser_connection(request.state.user_id, conn_id)
     if connection and connection.get("skyvern_session_id") and connection["status"] == "waiting_for_login":
         try:

--- a/backend/security.py
+++ b/backend/security.py
@@ -6,18 +6,27 @@ import re
 from typing import Any
 
 _REDACTIONS = (
-    re.compile(r'(?i)("(?:access_token|refresh_token|token|code|cookie|api_key|client_secret)"\s*:\s*")[^"]*(")'),
+    re.compile(r'(?i)("(?:access_token|refresh_token|token|code|cookie|set-cookie|api_key|client_secret|password|session|authorization|proxy_authorization)"\s*:\s*")[^"]*(")'),
     re.compile(r"(?i)((?:authorization|proxy-authorization)\s*[:=]\s*(?:bearer\s+)?)[^\s,;]+"),
-    re.compile(r"(?i)((?:api[-_ ]?key|access[-_ ]?token|refresh[-_ ]?token|auth[-_ ]?code|client[-_ ]?secret|token)\s*[:=]\s*)[^\s,;]+"),
+    re.compile(r"(?i)((?:api[-_ ]?key|access[-_ ]?token|refresh[-_ ]?token|auth[-_ ]?code|client[-_ ]?secret|password|session|token)\s*[:=]\s*)[^\s,;]+"),
     re.compile(r"(?i)([?&](?:code|state|token)=)[^&#\s]+"),
-    re.compile(r"(?i)(cookie\s*[:=]\s*)[^\r\n]+"),
+    re.compile(r"(?i)((?:cookie|set-cookie)\s*[:=]\s*)[^\r\n]+"),
+    re.compile(r"(?i)(\bbearer\s+)[A-Za-z0-9._~+/=-]+"),
+    re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b"),
+    re.compile(r"\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opsu]_[A-Za-z0-9_]{12,}|github_pat_[A-Za-z0-9_]{12,})\b"),
 )
 
 
 def redact_secrets(value: Any) -> str:
     redacted = str(value)
     for pattern in _REDACTIONS:
-        redacted = pattern.sub(r"\1[REDACTED]\2" if pattern.groups == 2 else r"\1[REDACTED]", redacted)
+        if pattern.groups == 2:
+            replacement = r"\1[REDACTED]\2"
+        elif pattern.groups == 1:
+            replacement = r"\1[REDACTED]"
+        else:
+            replacement = "[REDACTED]"
+        redacted = pattern.sub(replacement, redacted)
     return redacted
 
 

--- a/backend/services/browser_publish.py
+++ b/backend/services/browser_publish.py
@@ -5,7 +5,7 @@ import backend.services.cli_runner as runner
 import backend.store as store
 
 
-def execute_hashnode_run(*, user_id: str, run_id: str) -> None:
+def execute_run(*, user_id: str, run_id: str) -> None:
     run = store.get_browser_publish_run(user_id, run_id)
     if run is None or run["status"] != "running":
         return
@@ -15,23 +15,27 @@ def execute_hashnode_run(*, user_id: str, run_id: str) -> None:
     if revision is None:
         store.complete_browser_publish_run(user_id, run_id, error="Article revision not found")
         return
-    browser_connection = store.get_browser_connection(user_id, "hashnode")
+    platform = run["platform"]
+    browser_connection = store.get_browser_connection(user_id, platform)
     if not browser_connection or browser_connection["status"] != "connected":
         store.complete_browser_publish_run(
-            user_id, run_id, error="Hashnode browser login required"
+            user_id, run_id, error=f"{platform.title()} browser login required"
         )
         return
     try:
-        result = runner.hashnode_browser_upload(
+        operation = "publish" if run["mode"] == "publish" else "create_draft"
+        result = runner.browser_operation(
+            platform,
+            operation,
             organization_id=browser_connection["skyvern_organization_id"],
             profile_id=browser_connection["skyvern_profile_id"],
-            title=revision["title"], article_md=revision["content"],
-            publish=run["mode"] == "publish",
+            article={"title": revision["title"], "body": revision["content"]},
+            approved=True,
         )
         if not result.get("success"):
-            error = result.get("error") or "Hashnode upload failed"
+            error = result.get("error") or f"{platform.title()} upload failed"
             store.apply_push_result(
-                user_id, run["article_id"], "hashnode", success=False,
+                user_id, run["article_id"], platform, success=False,
                 error=error, label="Browser upload failed",
             )
             store.complete_browser_publish_run(
@@ -39,7 +43,7 @@ def execute_hashnode_run(*, user_id: str, run_id: str) -> None:
             )
             return
         store.apply_push_result(
-            user_id, run["article_id"], "hashnode", success=True,
+            user_id, run["article_id"], platform, success=True,
             url=result.get("url"), draft_id=result.get("draft_id"),
             label="Published" if run["mode"] == "publish" else "Draft",
             status="published" if run["mode"] == "publish" else "draft",
@@ -47,7 +51,12 @@ def execute_hashnode_run(*, user_id: str, run_id: str) -> None:
         store.complete_browser_publish_run(user_id, run_id, result=result)
     except Exception as exc:
         store.apply_push_result(
-            user_id, run["article_id"], "hashnode", success=False,
+            user_id, run["article_id"], platform, success=False,
             error=str(exc)[:500], label="Browser upload failed",
         )
         store.complete_browser_publish_run(user_id, run_id, error=str(exc)[:500])
+
+
+def execute_hashnode_run(*, user_id: str, run_id: str) -> None:
+    """Compatibility alias for callers created before extension dispatch."""
+    execute_run(user_id=user_id, run_id=run_id)

--- a/backend/services/browser_publish.py
+++ b/backend/services/browser_publish.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 
 import backend.services.cli_runner as runner
 import backend.store as store
+from backend.security import redact_secrets
+
+
+def _safe_error(value: object, fallback: str) -> str:
+    return redact_secrets(value or fallback)[:500]
 
 
 def execute_run(*, user_id: str, run_id: str) -> None:
@@ -33,7 +38,10 @@ def execute_run(*, user_id: str, run_id: str) -> None:
             approved=True,
         )
         if not result.get("success"):
-            error = result.get("error") or f"{platform.title()} upload failed"
+            error = _safe_error(
+                result.get("error"), f"{platform.title()} upload failed"
+            )
+            result = {**result, "error": error}
             store.apply_push_result(
                 user_id, run["article_id"], platform, success=False,
                 error=error, label="Browser upload failed",
@@ -50,11 +58,12 @@ def execute_run(*, user_id: str, run_id: str) -> None:
         )
         store.complete_browser_publish_run(user_id, run_id, result=result)
     except Exception as exc:
+        error = _safe_error(exc, f"{platform.title()} upload failed")
         store.apply_push_result(
             user_id, run["article_id"], platform, success=False,
-            error=str(exc)[:500], label="Browser upload failed",
+            error=error, label="Browser upload failed",
         )
-        store.complete_browser_publish_run(user_id, run_id, error=str(exc)[:500])
+        store.complete_browser_publish_run(user_id, run_id, error=error)
 
 
 def execute_hashnode_run(*, user_id: str, run_id: str) -> None:

--- a/backend/services/cli_runner.py
+++ b/backend/services/cli_runner.py
@@ -145,15 +145,51 @@ def hashnode_browser_upload(
     *, organization_id: str, profile_id: str, title: str, article_md: str,
     publish: bool = False,
 ) -> dict:
-    """Create or publish a Hashnode article through the browser runner."""
+    """Compatibility wrapper around the generic browser extension operation."""
+    return browser_operation(
+        "hashnode",
+        "publish" if publish else "create_draft",
+        organization_id=organization_id,
+        profile_id=profile_id,
+        article={"title": title, "body": article_md},
+        approved=publish,
+    )
+
+
+def browser_extensions() -> list[dict]:
+    return _get("/browser/extensions").get("extensions", [])
+
+
+def browser_extension(platform: str) -> dict:
+    return _get(f"/browser/{platform}/capabilities")
+
+
+def browser_operation(
+    platform: str,
+    operation: str,
+    *,
+    organization_id: str,
+    profile_id: str,
+    article: dict | None = None,
+    remote_id: str | None = None,
+    cursor: str | None = None,
+    limit: int = 50,
+    approved: bool = False,
+) -> dict:
+    """Execute a normalized operation through an installed browser extension."""
     payload = {
-        "organization_id": organization_id, "profile_id": profile_id,
-        "title": title, "article_md": article_md, "publish": publish,
+        "organization_id": organization_id,
+        "profile_id": profile_id,
+        "article": article,
+        "remote_id": remote_id,
+        "cursor": cursor,
+        "limit": limit,
+        "approved": approved,
     }
     try:
         with _client() as client:
             response = client.post(
-                "/browser/hashnode/upload", json=payload,
+                f"/browser/{platform}/operations/{operation}", json=payload,
                 timeout=httpx.Timeout(connect=3, read=300, write=30, pool=5),
             )
             response.raise_for_status()

--- a/cli-runner/Dockerfile
+++ b/cli-runner/Dockerfile
@@ -20,6 +20,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 RUN patchright install --with-deps chromium
 COPY main.py hashnode_browser.py medium_browser.py skyvern_browser.py browser_selectors.json ./
+COPY blog_extensions ./blog_extensions
 
 # Credential directories (will be overridden by named volumes in docker-compose)
 RUN mkdir -p /root/.claude /root/.config/openai /data/skyvern-browser-sessions

--- a/cli-runner/blog_extensions/__init__.py
+++ b/cli-runner/blog_extensions/__init__.py
@@ -1,0 +1,32 @@
+"""Versioned extension contracts for browser-backed blog platforms."""
+
+from .contracts import (
+    ArticleInput,
+    BlogExtension,
+    BlogOperationsAdapter,
+    BrowserLoginAdapter,
+    Capability,
+    ExtensionManifest,
+    PUBLIC_OR_DESTRUCTIVE_CAPABILITIES,
+    OperationRequest,
+    OperationResult,
+    OperationNotSupported,
+    RemoteArticle,
+)
+from .registry import ExtensionRegistry, get_registry
+
+__all__ = [
+    "ArticleInput",
+    "BlogExtension",
+    "BlogOperationsAdapter",
+    "BrowserLoginAdapter",
+    "Capability",
+    "ExtensionManifest",
+    "PUBLIC_OR_DESTRUCTIVE_CAPABILITIES",
+    "ExtensionRegistry",
+    "OperationRequest",
+    "OperationResult",
+    "OperationNotSupported",
+    "RemoteArticle",
+    "get_registry",
+]

--- a/cli-runner/blog_extensions/builtin/__init__.py
+++ b/cli-runner/blog_extensions/builtin/__init__.py
@@ -1,0 +1,1 @@
+"""BlogHub-maintained browser extensions."""

--- a/cli-runner/blog_extensions/builtin/hashnode.py
+++ b/cli-runner/blog_extensions/builtin/hashnode.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from hashnode_browser import check_hashnode_profile, upload_hashnode_page
+
+from ..contracts import (
+    BlogOperationsAdapter,
+    BrowserLoginAdapter,
+    Capability,
+    OperationNotSupported,
+    OperationRequest,
+)
+
+
+class HashnodeLoginAdapter(BrowserLoginAdapter):
+    platform = "hashnode"
+    login_url = "https://hashnode.com/login"
+
+    def verify_profile(self, profile_dir: Path) -> dict:
+        return check_hashnode_profile(profile_dir=str(profile_dir))
+
+
+class HashnodeOperationsAdapter(BlogOperationsAdapter):
+    platform = "hashnode"
+    capabilities = frozenset({Capability.CREATE_DRAFT, Capability.PUBLISH})
+
+    def execute(self, page, operation: Capability, request: OperationRequest) -> dict:
+        if operation not in self.capabilities:
+            raise OperationNotSupported(self.platform, operation.value)
+        article = request.article
+        if article is None:
+            raise ValueError("Hashnode create and publish operations require article data")
+        result = upload_hashnode_page(
+            page,
+            title=article.title,
+            article_md=article.body,
+            publish=operation == Capability.PUBLISH,
+        )
+        if result.get("draft_id") and not result.get("remote_id"):
+            result["remote_id"] = result["draft_id"]
+        return result

--- a/cli-runner/blog_extensions/builtin/medium.py
+++ b/cli-runner/blog_extensions/builtin/medium.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from medium_browser import check_medium_profile
+
+from ..contracts import (
+    BlogOperationsAdapter,
+    BrowserLoginAdapter,
+    Capability,
+    OperationNotSupported,
+    OperationRequest,
+)
+
+
+class MediumLoginAdapter(BrowserLoginAdapter):
+    platform = "medium"
+    login_url = "https://medium.com/m/signin"
+
+    def verify_profile(self, profile_dir: Path) -> dict:
+        return check_medium_profile(profile_dir=str(profile_dir))
+
+
+class MediumOperationsAdapter(BlogOperationsAdapter):
+    """Capability placeholder for the Medium implementation tracked by #43/#67."""
+
+    platform = "medium"
+    capabilities = frozenset()
+
+    def execute(self, page, operation: Capability, request: OperationRequest) -> dict:
+        raise OperationNotSupported(self.platform, operation.value)

--- a/cli-runner/blog_extensions/contracts.py
+++ b/cli-runner/blog_extensions/contracts.py
@@ -1,0 +1,152 @@
+"""Public, versioned interfaces implemented by BlogHub browser extensions."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Mapping, NotRequired, TypedDict
+
+
+PROTOCOL_VERSION = 1
+
+
+class Capability(StrEnum):
+    LIST_ARTICLES = "list_articles"
+    GET_ARTICLE = "get_article"
+    CREATE_DRAFT = "create_draft"
+    UPDATE_ARTICLE = "update_article"
+    PUBLISH = "publish"
+    UNPUBLISH = "unpublish"
+    DELETE = "delete"
+
+
+PUBLIC_OR_DESTRUCTIVE_CAPABILITIES = frozenset({
+    Capability.UPDATE_ARTICLE,
+    Capability.PUBLISH,
+    Capability.UNPUBLISH,
+    Capability.DELETE,
+})
+
+
+@dataclass(frozen=True)
+class ArticleInput:
+    """Normalized article data passed to an operations adapter."""
+
+    title: str
+    body: str
+    remote_id: str | None = None
+    subtitle: str | None = None
+    cover_url: str | None = None
+    canonical_url: str | None = None
+    tags: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class OperationRequest:
+    """Normalized operation input for both reads and writes."""
+
+    article: ArticleInput | None = None
+    remote_id: str | None = None
+    cursor: str | None = None
+    limit: int = 50
+
+
+class RemoteArticle(TypedDict):
+    remote_id: str
+    title: str
+    body: str
+    status: str
+    subtitle: NotRequired[str | None]
+    cover_url: NotRequired[str | None]
+    canonical_url: NotRequired[str | None]
+    tags: NotRequired[list[str]]
+    created_at: NotRequired[str | None]
+    updated_at: NotRequired[str | None]
+    published_at: NotRequired[str | None]
+    fingerprint: NotRequired[str | None]
+    metadata: NotRequired[dict[str, Any]]
+
+
+class OperationResult(TypedDict):
+    success: bool
+    status: NotRequired[str]
+    remote_id: NotRequired[str | None]
+    url: NotRequired[str | None]
+    article: NotRequired[RemoteArticle]
+    articles: NotRequired[list[RemoteArticle]]
+    next_cursor: NotRequired[str | None]
+    error: NotRequired[str]
+    diagnostics: NotRequired[dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class ExtensionManifest:
+    protocol_version: int
+    extension_id: str
+    platform: str
+    display_name: str
+    version: str
+    login_entrypoint: str
+    operations_entrypoint: str
+    capabilities: frozenset[Capability]
+    source: Path
+
+
+class OperationNotSupported(RuntimeError):
+    def __init__(self, platform: str, operation: str) -> None:
+        super().__init__(f"{platform} does not support browser operation: {operation}")
+        self.platform = platform
+        self.operation = operation
+
+
+class BrowserLoginAdapter(ABC):
+    """Platform-specific login navigation and persisted-profile verification."""
+
+    platform: str
+    login_url: str
+
+    @abstractmethod
+    def verify_profile(self, profile_dir: Path) -> dict[str, Any]:
+        """Return an authentication result without exposing session material."""
+
+
+class BlogOperationsAdapter(ABC):
+    """Deterministic Playwright operations against an authenticated page."""
+
+    platform: str
+    capabilities: frozenset[Capability] = frozenset()
+
+    def supports(self, operation: str | Capability) -> bool:
+        try:
+            capability = Capability(operation)
+        except ValueError:
+            return False
+        return capability in self.capabilities
+
+    @abstractmethod
+    def execute(
+        self,
+        page: Any,
+        operation: Capability,
+        request: OperationRequest,
+    ) -> OperationResult:
+        """Execute one declared capability using only the supplied browser page."""
+
+
+@dataclass(frozen=True)
+class BlogExtension:
+    manifest: ExtensionManifest
+    login: BrowserLoginAdapter
+    operations: BlogOperationsAdapter
+
+    def descriptor(self) -> dict[str, Any]:
+        return {
+            "id": self.manifest.extension_id,
+            "platform": self.manifest.platform,
+            "display_name": self.manifest.display_name,
+            "version": self.manifest.version,
+            "protocol_version": self.manifest.protocol_version,
+            "capabilities": sorted(capability.value for capability in self.manifest.capabilities),
+        }

--- a/cli-runner/blog_extensions/manifests/hashnode/bloghub_extension.toml
+++ b/cli-runner/blog_extensions/manifests/hashnode/bloghub_extension.toml
@@ -1,0 +1,11 @@
+[extension]
+protocol_version = 1
+id = "bloghub.hashnode"
+platform = "hashnode"
+display_name = "Hashnode"
+version = "1.0.0"
+capabilities = ["create_draft", "publish"]
+
+[entrypoints]
+login = "blog_extensions.builtin.hashnode:HashnodeLoginAdapter"
+operations = "blog_extensions.builtin.hashnode:HashnodeOperationsAdapter"

--- a/cli-runner/blog_extensions/manifests/medium/bloghub_extension.toml
+++ b/cli-runner/blog_extensions/manifests/medium/bloghub_extension.toml
@@ -1,0 +1,11 @@
+[extension]
+protocol_version = 1
+id = "bloghub.medium"
+platform = "medium"
+display_name = "Medium"
+version = "1.0.0"
+capabilities = []
+
+[entrypoints]
+login = "blog_extensions.builtin.medium:MediumLoginAdapter"
+operations = "blog_extensions.builtin.medium:MediumOperationsAdapter"

--- a/cli-runner/blog_extensions/registry.py
+++ b/cli-runner/blog_extensions/registry.py
@@ -1,0 +1,203 @@
+"""Trusted manifest discovery and validation for browser blog extensions."""
+from __future__ import annotations
+
+from functools import lru_cache
+import importlib
+import os
+from pathlib import Path
+import re
+import sys
+import tomllib
+from typing import Iterable
+
+from .contracts import (
+    PROTOCOL_VERSION,
+    BlogExtension,
+    BlogOperationsAdapter,
+    BrowserLoginAdapter,
+    Capability,
+    ExtensionManifest,
+)
+
+
+_IDENTIFIER = re.compile(r"^[a-z][a-z0-9_.-]{1,79}$")
+_VERSION = re.compile(r"^\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?$")
+_BUILTIN_MANIFESTS = Path(__file__).with_name("manifests")
+
+
+class ExtensionConfigurationError(RuntimeError):
+    pass
+
+
+def _manifest_files(paths: Iterable[Path]) -> list[Path]:
+    manifests: list[Path] = []
+    for path in paths:
+        resolved = path.resolve()
+        if resolved.is_file() and resolved.name == "bloghub_extension.toml":
+            manifests.append(resolved)
+        elif resolved.is_dir():
+            direct = resolved / "bloghub_extension.toml"
+            if direct.is_file():
+                manifests.append(direct)
+            manifests.extend(sorted(resolved.glob("*/bloghub_extension.toml")))
+    return manifests
+
+
+def _entrypoint(value: object, *, field: str, source: Path) -> tuple[str, str]:
+    if not isinstance(value, str) or value.count(":") != 1:
+        raise ExtensionConfigurationError(
+            f"{source}: {field} must use module:Class syntax"
+        )
+    module_name, symbol_name = value.split(":", 1)
+    if not module_name or not symbol_name:
+        raise ExtensionConfigurationError(f"{source}: invalid {field}")
+    return module_name, symbol_name
+
+
+def _load_symbol(value: str, *, field: str, source: Path):
+    module_name, symbol_name = _entrypoint(value, field=field, source=source)
+    try:
+        module = importlib.import_module(module_name)
+        return getattr(module, symbol_name)
+    except (ImportError, AttributeError) as exc:
+        raise ExtensionConfigurationError(
+            f"{source}: cannot load {field} {value}"
+        ) from exc
+
+
+def _parse_manifest(source: Path) -> ExtensionManifest:
+    try:
+        document = tomllib.loads(source.read_text(encoding="utf-8"))
+        extension = document["extension"]
+        entrypoints = document["entrypoints"]
+    except (OSError, tomllib.TOMLDecodeError, KeyError, TypeError) as exc:
+        raise ExtensionConfigurationError(f"Invalid extension manifest: {source}") from exc
+
+    protocol_version = extension.get("protocol_version")
+    if protocol_version != PROTOCOL_VERSION:
+        raise ExtensionConfigurationError(
+            f"{source}: protocol {protocol_version!r} is incompatible with {PROTOCOL_VERSION}"
+        )
+
+    extension_id = extension.get("id")
+    platform = extension.get("platform")
+    version = extension.get("version")
+    display_name = extension.get("display_name")
+    for label, value in (("id", extension_id), ("platform", platform)):
+        if not isinstance(value, str) or not _IDENTIFIER.fullmatch(value):
+            raise ExtensionConfigurationError(f"{source}: invalid extension {label}")
+    if not isinstance(version, str) or not _VERSION.fullmatch(version):
+        raise ExtensionConfigurationError(f"{source}: version must be semantic")
+    if not isinstance(display_name, str) or not display_name.strip():
+        raise ExtensionConfigurationError(f"{source}: display_name is required")
+
+    raw_capabilities = extension.get("capabilities", [])
+    if not isinstance(raw_capabilities, list):
+        raise ExtensionConfigurationError(f"{source}: capabilities must be a list")
+    try:
+        capabilities = frozenset(Capability(item) for item in raw_capabilities)
+    except (TypeError, ValueError) as exc:
+        raise ExtensionConfigurationError(f"{source}: unknown capability") from exc
+
+    return ExtensionManifest(
+        protocol_version=protocol_version,
+        extension_id=extension_id,
+        platform=platform,
+        display_name=display_name.strip(),
+        version=version,
+        login_entrypoint=str(entrypoints.get("login", "")),
+        operations_entrypoint=str(entrypoints.get("operations", "")),
+        capabilities=capabilities,
+        source=source,
+    )
+
+
+def _instantiate(manifest: ExtensionManifest) -> BlogExtension:
+    login_type = _load_symbol(
+        manifest.login_entrypoint, field="login entrypoint", source=manifest.source
+    )
+    operations_type = _load_symbol(
+        manifest.operations_entrypoint,
+        field="operations entrypoint",
+        source=manifest.source,
+    )
+    login = login_type()
+    operations = operations_type()
+    if not isinstance(login, BrowserLoginAdapter):
+        raise ExtensionConfigurationError(
+            f"{manifest.source}: login adapter does not implement BrowserLoginAdapter"
+        )
+    if not isinstance(operations, BlogOperationsAdapter):
+        raise ExtensionConfigurationError(
+            f"{manifest.source}: operations adapter does not implement BlogOperationsAdapter"
+        )
+    if login.platform != manifest.platform or operations.platform != manifest.platform:
+        raise ExtensionConfigurationError(
+            f"{manifest.source}: adapter platform does not match manifest"
+        )
+    if operations.capabilities != manifest.capabilities:
+        raise ExtensionConfigurationError(
+            f"{manifest.source}: adapter capabilities do not match manifest"
+        )
+    if not login.login_url.startswith("https://"):
+        raise ExtensionConfigurationError(
+            f"{manifest.source}: login URL must use HTTPS"
+        )
+    return BlogExtension(manifest=manifest, login=login, operations=operations)
+
+
+class ExtensionRegistry:
+    def __init__(
+        self,
+        extension_paths: Iterable[Path] = (),
+        enabled: set[str] | None = None,
+    ) -> None:
+        paths = [_BUILTIN_MANIFESTS, *extension_paths]
+        self._extensions: dict[str, BlogExtension] = {}
+        for source in _manifest_files(paths):
+            # External modules are trusted administrator-installed code. Their
+            # directory is added explicitly, never inferred from user input.
+            module_root = source.parent
+            if str(module_root) not in sys.path:
+                sys.path.insert(0, str(module_root))
+            manifest = _parse_manifest(source)
+            if enabled is not None and not (
+                manifest.extension_id in enabled or manifest.platform in enabled
+            ):
+                continue
+            if manifest.platform in self._extensions:
+                raise ExtensionConfigurationError(
+                    f"Duplicate extension platform: {manifest.platform}"
+                )
+            self._extensions[manifest.platform] = _instantiate(manifest)
+
+    def get(self, platform: str) -> BlogExtension:
+        try:
+            return self._extensions[platform]
+        except KeyError as exc:
+            raise KeyError(f"Unknown browser blog extension: {platform}") from exc
+
+    def descriptors(self) -> list[dict]:
+        return [
+            extension.descriptor()
+            for extension in sorted(
+                self._extensions.values(), key=lambda item: item.manifest.platform
+            )
+        ]
+
+
+def _configured_paths() -> list[Path]:
+    value = os.environ.get("BLOGHUB_EXTENSION_PATHS", "")
+    return [Path(item) for item in value.split(os.pathsep) if item]
+
+
+def _enabled_extensions() -> set[str] | None:
+    value = os.environ.get("BLOGHUB_ENABLED_EXTENSIONS")
+    if value is None:
+        return None
+    return {item.strip() for item in value.split(",") if item.strip()}
+
+
+@lru_cache(maxsize=1)
+def get_registry() -> ExtensionRegistry:
+    return ExtensionRegistry(_configured_paths(), _enabled_extensions())

--- a/cli-runner/blog_extensions/runtime.py
+++ b/cli-runner/blog_extensions/runtime.py
@@ -1,0 +1,31 @@
+"""Core-owned Playwright runtime for trusted blog operation adapters."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .contracts import BlogExtension, Capability, OperationNotSupported, OperationRequest
+
+
+def execute_operation(
+    extension: BlogExtension,
+    *,
+    profile_dir: Path,
+    operation: Capability,
+    request: OperationRequest,
+) -> dict:
+    if operation not in extension.manifest.capabilities:
+        raise OperationNotSupported(extension.manifest.platform, operation.value)
+
+    from patchright.sync_api import sync_playwright
+
+    with sync_playwright() as playwright:
+        context = playwright.chromium.launch_persistent_context(
+            str(profile_dir),
+            headless=True,
+            viewport={"width": 1440, "height": 1000},
+        )
+        page = context.pages[0] if context.pages else context.new_page()
+        try:
+            return extension.operations.execute(page, operation, request)
+        finally:
+            context.close()

--- a/cli-runner/blog_extensions/testing.py
+++ b/cli-runner/blog_extensions/testing.py
@@ -1,0 +1,29 @@
+"""Small contract-test helpers extension authors can use in their own suite."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .contracts import ArticleInput, BlogExtension, PROTOCOL_VERSION
+
+
+def assert_extension_contract(extension: BlogExtension) -> None:
+    assert extension.manifest.protocol_version == PROTOCOL_VERSION
+    assert extension.login.platform == extension.manifest.platform
+    assert extension.operations.platform == extension.manifest.platform
+    assert extension.operations.capabilities == extension.manifest.capabilities
+    assert extension.login.login_url.startswith("https://")
+
+
+def article_from_fixture(path: str | Path) -> ArticleInput:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    return ArticleInput(
+        title=payload["title"],
+        body=payload["body"],
+        remote_id=payload.get("remote_id"),
+        subtitle=payload.get("subtitle"),
+        cover_url=payload.get("cover_url"),
+        canonical_url=payload.get("canonical_url"),
+        tags=tuple(payload.get("tags", [])),
+        metadata=payload.get("metadata", {}),
+    )

--- a/cli-runner/hashnode_browser.py
+++ b/cli-runner/hashnode_browser.py
@@ -63,161 +63,162 @@ def _normalized_markdown(markdown: str) -> str:
 def upload_hashnode_draft(
     *, profile_dir: str, title: str, article_md: str, publish: bool = False,
 ) -> dict:
+    """Compatibility wrapper; new extensions receive a core-owned page."""
     from patchright.sync_api import sync_playwright
 
-    selectors = json.loads(SELECTORS_PATH.read_text(encoding="utf-8"))
     with sync_playwright() as playwright:
         context = playwright.chromium.launch_persistent_context(
             profile_dir, headless=True, viewport={"width": 1440, "height": 1000},
         )
         page = context.pages[0] if context.pages else context.new_page()
         try:
-            page.goto(selectors["editor_url"], wait_until="domcontentloaded", timeout=45000)
-            if any(part in page.url.lower() for part in ("signin", "login", "onboard")):
-                return {
-                    "success": False,
-                    "error": "Hashnode browser session is not authenticated",
-                    "manual_handoff": {
-                        "reason": "hashnode_login_required",
-                        "url": "https://hashnode.com/login",
-                    },
-                }
-
-            editor_entry, _ = _wait_first_visible(page, selectors["editor_entry"])
-            if editor_entry is None:
-                raise SelectorFailure("editor_entry")
-            editor_entry.click()
-            page.wait_for_url("**/draft/**", timeout=30_000)
-            previous_draft_url = page.url
-            new_draft, _ = _wait_first_visible(
-                page, selectors["new_draft"], timeout_ms=60_000
+            return upload_hashnode_page(
+                page, title=title, article_md=article_md, publish=publish
             )
-            if new_draft is None:
-                raise SelectorFailure("new_draft")
-            new_draft.click()
-            deadline = time.monotonic() + 30
-            while page.url == previous_draft_url and time.monotonic() < deadline:
-                page.wait_for_timeout(250)
-            if page.url == previous_draft_url:
-                raise SelectorFailure("new_draft")
-
-            title_control, _ = _wait_first_visible(page, selectors["title"])
-            markdown_mode, _ = _wait_first_visible(page, selectors["markdown_mode"])
-            if title_control is None:
-                raise SelectorFailure("title")
-            if markdown_mode is None:
-                raise SelectorFailure("markdown_mode")
-            markdown_mode.click()
-            content_control, _ = _wait_first_visible(page, selectors["content"])
-            if content_control is None:
-                raise SelectorFailure("content")
-
-            title_control.fill(title)
-            content_control.fill(article_md)
-            draft_url = page.url
-            draft_id = _draft_id(draft_url)
-
-            # Hashnode autosaves drafts. A reload is the strongest deterministic
-            # confirmation available without clicking the public Publish action.
-            page.wait_for_timeout(6_000)
-            page.reload(wait_until="domcontentloaded", timeout=45_000)
-            title_control, _ = _wait_first_visible(page, selectors["title"])
-            content_control, _ = _wait_first_visible(
-                page, selectors["content"], timeout_ms=2_000
-            )
-            if content_control is None:
-                markdown_mode, _ = _wait_first_visible(page, selectors["markdown_mode"])
-                if markdown_mode is not None:
-                    markdown_mode.click()
-                    content_control, _ = _wait_first_visible(
-                        page, selectors["content"]
-                    )
-            if (
-                title_control is None
-                or content_control is None
-                or title_control.input_value() != title
-                or _normalized_markdown(content_control.input_value())
-                != _normalized_markdown(article_md)
-            ):
-                return {
-                    "success": False,
-                    "error": "Hashnode draft autosave could not be verified",
-                    "url": draft_url,
-                    "draft_id": draft_id,
-                }
-            if publish:
-                publish_open, _ = _wait_first_visible(
-                    page, selectors["publish_open"]
-                )
-                if publish_open is None:
-                    raise SelectorFailure("publish_open")
-                publish_open.click()
-                publish_confirm, _ = _wait_first_visible(
-                    page, selectors["publish_confirm"]
-                )
-                if publish_confirm is None:
-                    raise SelectorFailure("publish_confirm")
-                publish_confirm.click()
-                deadline = time.monotonic() + 45
-                while "/draft/" in page.url and time.monotonic() < deadline:
-                    page.wait_for_timeout(250)
-                if "/draft/" in page.url:
-                    return {
-                        "success": False,
-                        "error": "Hashnode public publish could not be verified",
-                        "url": draft_url,
-                        "draft_id": draft_id,
-                    }
-                post_id = _edit_id(page.url)
-                if post_id is None:
-                    return {
-                        "success": False,
-                        "error": "Hashnode published post identifier was not returned",
-                        "url": page.url,
-                        "draft_id": draft_id,
-                    }
-                response = page.request.get(
-                    f"https://hashnode.com/api/posts/{post_id}"
-                )
-                metadata = response.json() if response.ok else {}
-                post = metadata.get("post") if metadata.get("success") else None
-                if (
-                    not post
-                    or not post.get("isActive")
-                    or post.get("title") != title
-                    or _normalized_markdown(post.get("contentMarkdown") or "")
-                    != _normalized_markdown(article_md)
-                ):
-                    return {
-                        "success": False,
-                        "error": "Hashnode published post could not be verified",
-                        "url": page.url,
-                        "draft_id": draft_id,
-                    }
-                publication = post.get("publication") or {}
-                publication_name = publication.get("username")
-                slug = post.get("slug")
-                if not publication_name or not slug:
-                    return {
-                        "success": False,
-                        "error": "Hashnode public article URL was not returned",
-                        "url": page.url,
-                        "draft_id": draft_id,
-                    }
-                public_url = f"https://{publication_name}.hashnode.dev/{slug}"
-
-            result = {
-                "success": True,
-                "method": "deterministic",
-                "status": "published" if publish else "draft",
-                "url": public_url if publish else draft_url,
-                "draft_id": draft_id,
-            }
-            if publish:
-                result["post_id"] = post_id
         finally:
             context.close()
 
+
+def upload_hashnode_page(
+    page, *, title: str, article_md: str, publish: bool = False,
+) -> dict:
+    """Run Hashnode automation on a page owned by the extension runtime."""
+    selectors = json.loads(SELECTORS_PATH.read_text(encoding="utf-8"))
+    page.goto(selectors["editor_url"], wait_until="domcontentloaded", timeout=45000)
+    if any(part in page.url.lower() for part in ("signin", "login", "onboard")):
+        return {
+            "success": False,
+            "error": "Hashnode browser session is not authenticated",
+            "manual_handoff": {
+                "reason": "hashnode_login_required",
+                "url": "https://hashnode.com/login",
+            },
+        }
+
+    editor_entry, _ = _wait_first_visible(page, selectors["editor_entry"])
+    if editor_entry is None:
+        raise SelectorFailure("editor_entry")
+    editor_entry.click()
+    page.wait_for_url("**/draft/**", timeout=30_000)
+    previous_draft_url = page.url
+    new_draft, _ = _wait_first_visible(
+        page, selectors["new_draft"], timeout_ms=60_000
+    )
+    if new_draft is None:
+        raise SelectorFailure("new_draft")
+    new_draft.click()
+    deadline = time.monotonic() + 30
+    while page.url == previous_draft_url and time.monotonic() < deadline:
+        page.wait_for_timeout(250)
+    if page.url == previous_draft_url:
+        raise SelectorFailure("new_draft")
+
+    title_control, _ = _wait_first_visible(page, selectors["title"])
+    markdown_mode, _ = _wait_first_visible(page, selectors["markdown_mode"])
+    if title_control is None:
+        raise SelectorFailure("title")
+    if markdown_mode is None:
+        raise SelectorFailure("markdown_mode")
+    markdown_mode.click()
+    content_control, _ = _wait_first_visible(page, selectors["content"])
+    if content_control is None:
+        raise SelectorFailure("content")
+
+    title_control.fill(title)
+    content_control.fill(article_md)
+    draft_url = page.url
+    draft_id = _draft_id(draft_url)
+
+    # Hashnode autosaves drafts. A reload is the strongest deterministic
+    # confirmation available without clicking the public Publish action.
+    page.wait_for_timeout(6_000)
+    page.reload(wait_until="domcontentloaded", timeout=45_000)
+    title_control, _ = _wait_first_visible(page, selectors["title"])
+    content_control, _ = _wait_first_visible(
+        page, selectors["content"], timeout_ms=2_000
+    )
+    if content_control is None:
+        markdown_mode, _ = _wait_first_visible(page, selectors["markdown_mode"])
+        if markdown_mode is not None:
+            markdown_mode.click()
+            content_control, _ = _wait_first_visible(page, selectors["content"])
+    if (
+        title_control is None
+        or content_control is None
+        or title_control.input_value() != title
+        or _normalized_markdown(content_control.input_value())
+        != _normalized_markdown(article_md)
+    ):
+        return {
+            "success": False,
+            "error": "Hashnode draft autosave could not be verified",
+            "url": draft_url,
+            "draft_id": draft_id,
+        }
+    if publish:
+        publish_open, _ = _wait_first_visible(page, selectors["publish_open"])
+        if publish_open is None:
+            raise SelectorFailure("publish_open")
+        publish_open.click()
+        publish_confirm, _ = _wait_first_visible(page, selectors["publish_confirm"])
+        if publish_confirm is None:
+            raise SelectorFailure("publish_confirm")
+        publish_confirm.click()
+        deadline = time.monotonic() + 45
+        while "/draft/" in page.url and time.monotonic() < deadline:
+            page.wait_for_timeout(250)
+        if "/draft/" in page.url:
+            return {
+                "success": False,
+                "error": "Hashnode public publish could not be verified",
+                "url": draft_url,
+                "draft_id": draft_id,
+            }
+        post_id = _edit_id(page.url)
+        if post_id is None:
+            return {
+                "success": False,
+                "error": "Hashnode published post identifier was not returned",
+                "url": page.url,
+                "draft_id": draft_id,
+            }
+        response = page.request.get(f"https://hashnode.com/api/posts/{post_id}")
+        metadata = response.json() if response.ok else {}
+        post = metadata.get("post") if metadata.get("success") else None
+        if (
+            not post
+            or not post.get("isActive")
+            or post.get("title") != title
+            or _normalized_markdown(post.get("contentMarkdown") or "")
+            != _normalized_markdown(article_md)
+        ):
+            return {
+                "success": False,
+                "error": "Hashnode published post could not be verified",
+                "url": page.url,
+                "draft_id": draft_id,
+            }
+        publication = post.get("publication") or {}
+        publication_name = publication.get("username")
+        slug = post.get("slug")
+        if not publication_name or not slug:
+            return {
+                "success": False,
+                "error": "Hashnode public article URL was not returned",
+                "url": page.url,
+                "draft_id": draft_id,
+            }
+        public_url = f"https://{publication_name}.hashnode.dev/{slug}"
+
+    result = {
+        "success": True,
+        "method": "deterministic",
+        "status": "published" if publish else "draft",
+        "url": public_url if publish else draft_url,
+        "draft_id": draft_id,
+    }
+    if publish:
+        result["post_id"] = post_id
     return result
 
 

--- a/cli-runner/main.py
+++ b/cli-runner/main.py
@@ -28,6 +28,22 @@ from typing import Iterator, Optional
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 _DEVICE_CODE_RE = re.compile(r"\b[A-Z0-9]{4}-[A-Z0-9]{4,6}\b")
 _URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
+_SECRET_REDACTIONS = (
+    re.compile(r"(?i)((?:cookie|set-cookie)\s*[:=]\s*)[^\r\n]+"),
+    re.compile(
+        r'(?i)(["\']?(?:access_token|refresh_token|token|code|cookie|set-cookie|'
+        r'api_key|client_secret|password|session|authorization|'
+        r'proxy_authorization)["\']?\s*[:=]\s*["\']?)'
+        r'[^\s,;"\'}]+(["\']?)'
+    ),
+    re.compile(
+        r"(?i)((?:authorization|proxy-authorization)\s*[:=]\s*"
+        r"(?:bearer|basic)?\s*)[^\s,;]+"
+    ),
+    re.compile(r"(?i)(\bbearer\s+)[A-Za-z0-9._~+/=-]+"),
+    re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b"),
+    re.compile(r"\b(?:sk-[A-Za-z0-9_-]{12,}|gh[opsu]_[A-Za-z0-9_]{12,}|github_pat_[A-Za-z0-9_]{12,})\b"),
+)
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
@@ -181,13 +197,21 @@ class StatusResponse(BaseModel):
 
 
 def _safe_reason(value: str | None) -> str:
-    """Return an actionable error with auth URLs and one-time codes removed."""
+    """Return an actionable error with credentials and auth artifacts removed."""
     cleaned = _ANSI_RE.sub("", value or "Provider login failed")
     cleaned = _URL_RE.sub("[redacted-url]", cleaned)
     cleaned = _DEVICE_CODE_RE.sub("[redacted-code]", cleaned)
     cleaned = re.sub(
         r"(?i)((?:code|state|token)=)[^\s&#]+", r"\1[redacted]", cleaned
     )
+    for pattern in _SECRET_REDACTIONS:
+        if pattern.groups == 2:
+            replacement = r"\1[redacted]\2"
+        elif pattern.groups == 1:
+            replacement = r"\1[redacted]"
+        else:
+            replacement = "[redacted]"
+        cleaned = pattern.sub(replacement, cleaned)
     return " ".join(cleaned.split())[:300]
 
 

--- a/cli-runner/main.py
+++ b/cli-runner/main.py
@@ -22,6 +22,7 @@ import threading
 import time
 import urllib.parse
 import uuid
+from pathlib import Path
 from typing import Iterator, Optional
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
@@ -30,23 +31,25 @@ _URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
-from hashnode_browser import check_hashnode_profile, upload_hashnode_draft
-from medium_browser import check_medium_profile
+from blog_extensions import (
+    ArticleInput,
+    Capability,
+    OperationNotSupported,
+    OperationRequest as ExtensionOperationRequest,
+    PUBLIC_OR_DESTRUCTIVE_CAPABILITIES,
+    get_registry,
+)
+from blog_extensions.runtime import execute_operation
 from skyvern_browser import (
     SkyvernUnavailable,
-    close_hashnode_login,
-    close_medium_login,
-    delete_hashnode_profile,
-    delete_medium_profile,
-    finish_hashnode_login,
-    finish_medium_login,
-    get_hashnode_login,
-    get_medium_login,
+    close_browser_login,
+    delete_browser_profile,
+    finish_browser_login,
+    get_browser_login,
     profile_directory,
-    start_hashnode_login,
-    start_medium_login,
+    start_browser_login,
 )
 
 app = FastAPI(title="BlogHub CLI Runner", version="0.1.0")
@@ -227,6 +230,27 @@ class ChatRequest(BaseModel):
     api_key: Optional[str] = None
 
 
+class BrowserArticleRequest(BaseModel):
+    title: str
+    body: str
+    remote_id: Optional[str] = None
+    subtitle: Optional[str] = None
+    cover_url: Optional[str] = None
+    canonical_url: Optional[str] = None
+    tags: list[str] = Field(default_factory=list)
+    metadata: dict = Field(default_factory=dict)
+
+
+class BrowserOperationRequest(BaseModel):
+    organization_id: str
+    profile_id: str
+    article: Optional[BrowserArticleRequest] = None
+    remote_id: Optional[str] = None
+    cursor: Optional[str] = None
+    limit: int = Field(default=50, ge=1, le=100)
+    approved: bool = False
+
+
 class HashnodeBrowserUploadRequest(BaseModel):
     organization_id: str
     profile_id: str
@@ -251,48 +275,89 @@ class HashnodeBrowserProfileRequest(BaseModel):
 
 _chat_processes: dict[str, subprocess.Popen] = {}
 
-_BROWSER_LOGIN = {
-    "hashnode": {
-        "start": start_hashnode_login,
-        "get": get_hashnode_login,
-        "close": close_hashnode_login,
-        "finish": finish_hashnode_login,
-        "delete": delete_hashnode_profile,
-        "check": check_hashnode_profile,
-    },
-    "medium": {
-        "start": start_medium_login,
-        "get": get_medium_login,
-        "close": close_medium_login,
-        "finish": finish_medium_login,
-        "delete": delete_medium_profile,
-        "check": check_medium_profile,
-    },
-}
+def _browser_extension(platform: str):
+    try:
+        return get_registry().get(platform)
+    except KeyError as exc:
+        raise HTTPException(404, f"{platform} browser extension is not installed") from exc
 
 
-def _browser_provider(platform: str) -> dict:
-    provider = _BROWSER_LOGIN.get(platform)
-    if provider is None:
-        raise HTTPException(404, f"{platform} does not support browser login")
-    return provider
+def _article_input(article: BrowserArticleRequest | None) -> ArticleInput | None:
+    if article is None:
+        return None
+    return ArticleInput(
+        title=article.title,
+        body=article.body,
+        remote_id=article.remote_id,
+        subtitle=article.subtitle,
+        cover_url=article.cover_url,
+        canonical_url=article.canonical_url,
+        tags=tuple(article.tags),
+        metadata=article.metadata,
+    )
 
 
-@app.post("/browser/hashnode/upload")
-def hashnode_browser_upload(req: HashnodeBrowserUploadRequest):
+def _extension_operation_request(req: BrowserOperationRequest) -> ExtensionOperationRequest:
+    return ExtensionOperationRequest(
+        article=_article_input(req.article),
+        remote_id=req.remote_id,
+        cursor=req.cursor,
+        limit=req.limit,
+    )
+
+
+@app.get("/browser/extensions")
+def browser_extensions():
+    return {"protocol_version": 1, "extensions": get_registry().descriptors()}
+
+
+@app.get("/browser/{platform}/capabilities")
+def browser_capabilities(platform: str):
+    return _browser_extension(platform).descriptor()
+
+
+@app.post("/browser/{platform}/operations/{operation}")
+def browser_operation(platform: str, operation: str, req: BrowserOperationRequest):
+    extension = _browser_extension(platform)
+    try:
+        capability = Capability(operation)
+    except ValueError as exc:
+        raise HTTPException(404, f"Unknown browser operation: {operation}") from exc
+    if capability not in extension.manifest.capabilities:
+        raise HTTPException(409, str(OperationNotSupported(platform, operation)))
+    if capability in PUBLIC_OR_DESTRUCTIVE_CAPABILITIES and not req.approved:
+        raise HTTPException(409, f"{operation} requires explicit user approval")
     try:
         profile_dir = profile_directory(req.organization_id, req.profile_id)
     except ValueError as exc:
         raise HTTPException(422, str(exc)) from exc
     if not profile_dir.is_dir():
-        raise HTTPException(409, "Hashnode browser profile is unavailable")
+        raise HTTPException(409, f"{platform.title()} browser profile is unavailable")
     try:
-        return upload_hashnode_draft(
-            profile_dir=str(profile_dir), title=req.title, article_md=req.article_md,
-            publish=req.publish,
+        return execute_operation(
+            extension,
+            profile_dir=profile_dir,
+            operation=capability,
+            request=_extension_operation_request(req),
         )
+    except OperationNotSupported as exc:
+        raise HTTPException(409, str(exc)) from exc
     except Exception as exc:
         return {"success": False, "error": _safe_reason(str(exc))}
+
+
+@app.post("/browser/hashnode/upload")
+def hashnode_browser_upload(req: HashnodeBrowserUploadRequest):
+    return browser_operation(
+        "hashnode",
+        "publish" if req.publish else "create_draft",
+        BrowserOperationRequest(
+            organization_id=req.organization_id,
+            profile_id=req.profile_id,
+            article=BrowserArticleRequest(title=req.title, body=req.article_md),
+            approved=req.publish,
+        ),
+    )
 
 
 @app.post("/browser/hashnode/login", status_code=201)
@@ -302,8 +367,13 @@ def hashnode_browser_login(req: Optional[HashnodeBrowserLoginRequest] = None):
 
 @app.post("/browser/{platform}/login", status_code=201)
 def browser_login(platform: str, req: Optional[HashnodeBrowserLoginRequest] = None):
+    extension = _browser_extension(platform)
     try:
-        return _browser_provider(platform)["start"](req.profile_id if req else None)
+        return start_browser_login(
+            platform,
+            req.profile_id if req else None,
+            login_url=extension.login.login_url,
+        )
     except ValueError as exc:
         raise HTTPException(422, str(exc)) from exc
     except SkyvernUnavailable as exc:
@@ -317,8 +387,9 @@ def hashnode_browser_login_status(session_id: str):
 
 @app.get("/browser/{platform}/login/{session_id}")
 def browser_login_status(platform: str, session_id: str):
+    _browser_extension(platform)
     try:
-        return _browser_provider(platform)["get"](session_id)
+        return get_browser_login(session_id, platform)
     except ValueError as exc:
         raise HTTPException(422, str(exc)) from exc
     except SkyvernUnavailable as exc:
@@ -332,8 +403,9 @@ def hashnode_browser_login_cancel(session_id: str):
 
 @app.delete("/browser/{platform}/login/{session_id}")
 def browser_login_cancel(platform: str, session_id: str):
+    _browser_extension(platform)
     try:
-        _browser_provider(platform)["close"](session_id)
+        close_browser_login(session_id)
         return {"status": "canceled"}
     except ValueError as exc:
         raise HTTPException(422, str(exc)) from exc
@@ -352,15 +424,16 @@ def hashnode_browser_login_complete(
 def browser_login_complete(
     platform: str, session_id: str, req: HashnodeBrowserLoginCompleteRequest,
 ):
+    extension = _browser_extension(platform)
     try:
-        provider = _browser_provider(platform)
-        profile = provider["finish"](
+        profile = finish_browser_login(
             session_id,
             req.profile_name,
+            platform,
             profile_id=req.profile_id,
             organization_id=req.organization_id,
         )
-        verification = provider["check"](profile_dir=profile["profile_dir"])
+        verification = extension.login.verify_profile(Path(profile["profile_dir"]))
         return {**verification, **profile}
     except ValueError as exc:
         raise HTTPException(422, str(exc)) from exc
@@ -377,8 +450,9 @@ def hashnode_browser_profile_delete(profile_id: str):
 
 @app.delete("/browser/{platform}/profiles/{profile_id}")
 def browser_profile_delete(platform: str, profile_id: str):
+    _browser_extension(platform)
     try:
-        _browser_provider(platform)["delete"](profile_id)
+        delete_browser_profile(profile_id)
         return {"status": "disconnected"}
     except ValueError as exc:
         raise HTTPException(422, str(exc)) from exc

--- a/cli-runner/skyvern_browser.py
+++ b/cli-runner/skyvern_browser.py
@@ -87,10 +87,20 @@ _LOGIN_URLS = {
 }
 
 
-def start_browser_login(platform: str, profile_id: str | None = None) -> dict:
-    login_url = _LOGIN_URLS.get(platform)
+def start_browser_login(
+    platform: str,
+    profile_id: str | None = None,
+    *,
+    login_url: str | None = None,
+) -> dict:
+    # The fallback keeps old direct callers working. The runner passes the URL
+    # from the installed extension manifest through its login adapter.
+    login_url = login_url or _LOGIN_URLS.get(platform)
     if login_url is None:
         raise ValueError(f"{platform} does not support browser login")
+    parsed_login = urlsplit(login_url)
+    if parsed_login.scheme != "https" or not parsed_login.netloc:
+        raise ValueError("Browser login URL must use HTTPS")
     if profile_id is not None and not _PROFILE_ID.fullmatch(profile_id):
         raise ValueError("Invalid Skyvern profile id")
     payload = {

--- a/docs/blog-extensions.md
+++ b/docs/blog-extensions.md
@@ -1,0 +1,117 @@
+# Browser Blog Extensions
+
+BlogHub browser extensions let a trusted administrator add a blog platform by
+providing two small Python adapters instead of changing the backend and runner.
+The current protocol version is `1`.
+
+## Package shape
+
+An extension directory contains a manifest and importable Python code:
+
+```text
+my-blog-extension/
+  bloghub_extension.toml
+  my_blog_extension.py
+  tests/
+    fixtures/article.json
+    test_contract.py
+```
+
+The manifest pins the extension and protocol versions and declares exactly what
+the platform supports:
+
+```toml
+[extension]
+protocol_version = 1
+id = "example.my-blog"
+platform = "my-blog"
+display_name = "My Blog"
+version = "1.0.0"
+capabilities = ["list_articles", "get_article", "create_draft", "publish"]
+
+[entrypoints]
+login = "my_blog_extension:LoginAdapter"
+operations = "my_blog_extension:OperationsAdapter"
+```
+
+See `examples/blog-extension` for a complete minimal package.
+
+## The two interfaces
+
+`BrowserLoginAdapter` supplies the HTTPS login page and verifies whether a
+persisted Skyvern profile is authenticated. It receives a profile path only for
+verification. It must return a non-secret status and must never return cookies,
+tokens, callback URLs, or page storage.
+
+`BlogOperationsAdapter` declares capabilities and receives a Playwright page
+owned by BlogHub. The runner opens and closes the persistent browser context.
+The adapter implements only its declared operations and exchanges a normalized
+`OperationRequest` and `OperationResult` with core orchestration. Write requests
+carry an `ArticleInput`; read requests can carry a remote ID, pagination cursor,
+and bounded page size. Remote records use the `RemoteArticle` shape: remote ID,
+title, body, status, subtitle, cover and canonical URLs, tags, timestamps,
+fingerprint, and platform metadata.
+
+Protocol 1 capabilities are:
+
+- `list_articles`
+- `get_article`
+- `create_draft`
+- `update_article`
+- `publish`
+- `unpublish`
+- `delete`
+
+Operations that can change public content (`update_article`, `publish`,
+`unpublish`, and `delete`) require explicit approval at the runner API.
+An adapter should also verify the resulting remote state before returning
+`success: true`.
+
+## Install and enable
+
+Extensions are executable Python code. Only an administrator may install them.
+Mount extension directories read-only into the CLI runner and configure:
+
+```text
+BLOGHUB_EXTENSION_PATHS=/extensions
+BLOGHUB_ENABLED_EXTENSIONS=bloghub.hashnode,bloghub.medium,example.my-blog
+```
+
+`BLOGHUB_EXTENSION_PATHS` is an administrator-controlled allow-list of local
+directories. BlogHub does not accept extension uploads through its user API.
+Restart the CLI runner after installing or upgrading an extension. The runner
+rejects duplicate platforms, malformed entry points, unknown capabilities,
+non-HTTPS login URLs, mismatched adapter declarations, and incompatible protocol
+versions during registry construction.
+
+Use `GET /browser/extensions` on the runner or
+`GET /api/connections/browser-extensions` on the backend to discover installed
+platforms and capabilities. Clients should hide actions that are not declared.
+
+## Test contract
+
+Extensions can import `assert_extension_contract` and `article_from_fixture`
+from `blog_extensions.testing`. Default tests must use fixtures and fake pages;
+real account checks belong behind an explicit live or integration marker.
+
+At minimum, cover:
+
+- manifest and entry-point validation
+- authenticated and expired profile detection
+- every declared operation with deterministic page fixtures
+- missing selectors and partial remote responses
+- independent verification after writes
+- unsupported capabilities
+- redaction of errors and diagnostics
+
+## Compatibility
+
+Protocol versions are integers. BlogHub rejects a manifest whose protocol does
+not exactly match the runner. Extension releases use semantic versions and are
+pinned by the deployment configuration or image. A future protocol change must
+ship a migration guide and may keep an older loader only when its security and
+result semantics remain unambiguous.
+
+Hashnode is the first operations adapter. Medium is the second login adapter and
+currently declares no browser operations; #43 and #67 can add those operations
+without adding platform-specific runner routes.

--- a/examples/blog-extension/README.md
+++ b/examples/blog-extension/README.md
@@ -1,0 +1,10 @@
+# Example BlogHub extension
+
+This package demonstrates the protocol-1 manifest and the separate login and
+operations adapters. Its domain and selectors are placeholders; it is not
+enabled by default.
+
+Mount the directory into the CLI runner, add that mount point to
+`BLOGHUB_EXTENSION_PATHS`, and include `example.local-blog` in
+`BLOGHUB_ENABLED_EXTENSIONS`. See `docs/blog-extensions.md` for the trust model
+and required tests.

--- a/examples/blog-extension/bloghub_extension.toml
+++ b/examples/blog-extension/bloghub_extension.toml
@@ -1,0 +1,11 @@
+[extension]
+protocol_version = 1
+id = "example.local-blog"
+platform = "local-blog"
+display_name = "Local Blog"
+version = "1.0.0"
+capabilities = ["create_draft", "publish"]
+
+[entrypoints]
+login = "local_blog_extension:LoginAdapter"
+operations = "local_blog_extension:OperationsAdapter"

--- a/examples/blog-extension/local_blog_extension.py
+++ b/examples/blog-extension/local_blog_extension.py
@@ -1,0 +1,46 @@
+"""Minimal trusted extension example; selectors are intentionally illustrative."""
+from pathlib import Path
+
+from blog_extensions import (
+    BlogOperationsAdapter,
+    BrowserLoginAdapter,
+    Capability,
+    OperationNotSupported,
+    OperationRequest,
+)
+
+
+class LoginAdapter(BrowserLoginAdapter):
+    platform = "local-blog"
+    login_url = "https://blog.example.com/login"
+
+    def verify_profile(self, profile_dir: Path) -> dict:
+        # Real adapters inspect only the platform's non-expired session cookies.
+        authenticated = (profile_dir / ".example-session-present").is_file()
+        return {
+            "authenticated": authenticated,
+            "status": "connected" if authenticated else "login_required",
+        }
+
+
+class OperationsAdapter(BlogOperationsAdapter):
+    platform = "local-blog"
+    capabilities = frozenset({Capability.CREATE_DRAFT, Capability.PUBLISH})
+
+    def execute(self, page, operation: Capability, request: OperationRequest) -> dict:
+        if operation not in self.capabilities:
+            raise OperationNotSupported(self.platform, operation.value)
+        article = request.article
+        if article is None:
+            raise ValueError("Article data is required")
+
+        page.goto("https://blog.example.com/editor", wait_until="domcontentloaded")
+        page.get_by_label("Title").fill(article.title)
+        page.get_by_label("Content").fill(article.body)
+        page.get_by_role("button", name="Save draft").click()
+        if operation == Capability.PUBLISH:
+            page.get_by_role("button", name="Publish").click()
+
+        # A real adapter must read the saved article back and compare it before
+        # reporting success.
+        return {"success": True, "status": "published" if operation == Capability.PUBLISH else "draft"}

--- a/tests/tests_backend/fixtures/blog_extension_article.json
+++ b/tests/tests_backend/fixtures/blog_extension_article.json
@@ -1,0 +1,7 @@
+{
+  "title": "A fixture-backed extension article",
+  "subtitle": "Normalized input for adapter contract tests",
+  "body": "# A fixture-backed extension article\n\nBody text.",
+  "tags": ["bloghub", "extensions"],
+  "metadata": {"language": "en"}
+}

--- a/tests/tests_backend/test_blog_extension_runner.py
+++ b/tests/tests_backend/test_blog_extension_runner.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+from fastapi import HTTPException
+
+
+RUNNER = Path(__file__).resolve().parents[2] / "cli-runner"
+if str(RUNNER) not in sys.path:
+    sys.path.insert(0, str(RUNNER))
+spec = importlib.util.spec_from_file_location(
+    "blog_extension_runner_under_test", RUNNER / "main.py"
+)
+runner_main = importlib.util.module_from_spec(spec)
+assert spec.loader
+sys.modules[spec.name] = runner_main
+spec.loader.exec_module(runner_main)
+
+
+def test_runner_discovers_builtin_extension_capabilities():
+    payload = runner_main.browser_extensions()
+
+    by_platform = {item["platform"]: item for item in payload["extensions"]}
+    assert by_platform["hashnode"]["capabilities"] == ["create_draft", "publish"]
+    assert by_platform["medium"]["capabilities"] == []
+
+
+def test_login_dispatch_uses_extension_login_url(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        runner_main,
+        "start_browser_login",
+        lambda platform, profile_id, login_url: seen.update(
+            platform=platform, profile_id=profile_id, login_url=login_url
+        ) or {"session_id": "pbs_test"},
+    )
+
+    result = runner_main.browser_login("medium")
+
+    assert result == {"session_id": "pbs_test"}
+    assert seen["login_url"] == "https://medium.com/m/signin"
+
+
+def test_public_operation_requires_explicit_approval():
+    request = runner_main.BrowserOperationRequest(
+        organization_id="o_test",
+        profile_id="bp_test",
+        article=runner_main.BrowserArticleRequest(title="Title", body="Body"),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        runner_main.browser_operation("hashnode", "publish", request)
+
+    assert exc_info.value.status_code == 409
+    assert "approval" in exc_info.value.detail
+
+
+def test_unsupported_operation_is_rejected_before_browser_launch():
+    request = runner_main.BrowserOperationRequest(
+        organization_id="o_test", profile_id="bp_test"
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        runner_main.browser_operation("medium", "publish", request)
+
+    assert exc_info.value.status_code == 409
+    assert "does not support" in exc_info.value.detail
+
+
+def test_generic_operation_passes_normalized_article_to_runtime(tmp_path, monkeypatch):
+    seen = {}
+    monkeypatch.setattr(runner_main, "profile_directory", lambda *_args: tmp_path)
+    monkeypatch.setattr(
+        runner_main,
+        "execute_operation",
+        lambda extension, **kwargs: seen.update(extension=extension, **kwargs)
+        or {"success": True, "status": "draft"},
+    )
+    request = runner_main.BrowserOperationRequest(
+        organization_id="o_test",
+        profile_id="bp_test",
+        article=runner_main.BrowserArticleRequest(
+            title="Title", body="Body", tags=["one", "two"]
+        ),
+    )
+
+    result = runner_main.browser_operation("hashnode", "create_draft", request)
+
+    assert result["success"] is True
+    assert seen["operation"].value == "create_draft"
+    assert seen["request"].article.tags == ("one", "two")
+    assert seen["extension"].manifest.platform == "hashnode"

--- a/tests/tests_backend/test_blog_extension_runner.py
+++ b/tests/tests_backend/test_blog_extension_runner.py
@@ -93,3 +93,23 @@ def test_generic_operation_passes_normalized_article_to_runtime(tmp_path, monkey
     assert seen["operation"].value == "create_draft"
     assert seen["request"].article.tags == ("one", "two")
     assert seen["extension"].manifest.platform == "hashnode"
+
+
+def test_adapter_exception_is_sanitized_at_runner_boundary(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner_main, "profile_directory", lambda *_args: tmp_path)
+
+    def fail(*_args, **_kwargs):
+        raise RuntimeError(
+            "Playwright failed with Cookie: session=browser-secret; theme=dark"
+        )
+
+    monkeypatch.setattr(runner_main, "execute_operation", fail)
+    request = runner_main.BrowserOperationRequest(
+        organization_id="o_test", profile_id="bp_test"
+    )
+
+    result = runner_main.browser_operation("hashnode", "create_draft", request)
+
+    assert result["success"] is False
+    assert "browser-secret" not in result["error"]
+    assert "[redacted]" in result["error"]

--- a/tests/tests_backend/test_blog_extensions.py
+++ b/tests/tests_backend/test_blog_extensions.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+import sys
+
+import pytest
+
+
+RUNNER = Path(__file__).resolve().parents[2] / "cli-runner"
+if str(RUNNER) not in sys.path:
+    sys.path.insert(0, str(RUNNER))
+
+from blog_extensions import (
+    Capability,
+    ExtensionRegistry,
+    OperationNotSupported,
+    OperationRequest,
+)
+from blog_extensions.registry import ExtensionConfigurationError
+from blog_extensions.testing import assert_extension_contract, article_from_fixture
+
+
+FIXTURE = Path(__file__).with_name("fixtures") / "blog_extension_article.json"
+
+
+def test_builtin_extensions_satisfy_the_versioned_contract():
+    registry = ExtensionRegistry()
+
+    hashnode = registry.get("hashnode")
+    medium = registry.get("medium")
+    assert_extension_contract(hashnode)
+    assert_extension_contract(medium)
+
+    assert hashnode.manifest.capabilities == frozenset({
+        Capability.CREATE_DRAFT, Capability.PUBLISH,
+    })
+    assert medium.manifest.capabilities == frozenset()
+    assert [item["platform"] for item in registry.descriptors()] == [
+        "hashnode", "medium",
+    ]
+
+
+def test_fixture_loader_builds_normalized_article_input():
+    article = article_from_fixture(FIXTURE)
+
+    assert article.title == "A fixture-backed extension article"
+    assert article.tags == ("bloghub", "extensions")
+    assert article.metadata == {"language": "en"}
+
+
+def test_medium_rejects_undeclared_operations():
+    extension = ExtensionRegistry().get("medium")
+
+    with pytest.raises(OperationNotSupported):
+        extension.operations.execute(
+            object(),
+            Capability.PUBLISH,
+            OperationRequest(article=article_from_fixture(FIXTURE)),
+        )
+
+
+def test_external_extension_is_loaded_from_an_admin_path(tmp_path, monkeypatch):
+    module_name = "fixture_blog_extension"
+    (tmp_path / f"{module_name}.py").write_text(
+        """
+from blog_extensions import BrowserLoginAdapter, BlogOperationsAdapter, Capability
+class Login(BrowserLoginAdapter):
+    platform = 'fixture-blog'
+    login_url = 'https://example.com/login'
+    def verify_profile(self, profile_dir):
+        return {'authenticated': True, 'status': 'connected'}
+class Operations(BlogOperationsAdapter):
+    platform = 'fixture-blog'
+    capabilities = frozenset({Capability.GET_ARTICLE})
+    def execute(self, page, operation, article=None):
+        return {'success': True, 'remote_id': 'fixture'}
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "bloghub_extension.toml").write_text(
+        f"""
+[extension]
+protocol_version = 1
+id = "fixture.blog"
+platform = "fixture-blog"
+display_name = "Fixture Blog"
+version = "1.2.3"
+capabilities = ["get_article"]
+[entrypoints]
+login = "{module_name}:Login"
+operations = "{module_name}:Operations"
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    importlib.invalidate_caches()
+
+    registry = ExtensionRegistry([tmp_path], enabled={"fixture.blog"})
+
+    assert registry.get("fixture-blog").manifest.version == "1.2.3"
+
+
+def test_incompatible_protocol_is_rejected(tmp_path):
+    (tmp_path / "bloghub_extension.toml").write_text(
+        """
+[extension]
+protocol_version = 99
+id = "fixture.bad"
+platform = "fixture-bad"
+display_name = "Bad Fixture"
+version = "1.0.0"
+capabilities = []
+[entrypoints]
+login = "missing:Login"
+operations = "missing:Operations"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ExtensionConfigurationError, match="incompatible"):
+        ExtensionRegistry([tmp_path])

--- a/tests/tests_backend/test_browser_connections.py
+++ b/tests/tests_backend/test_browser_connections.py
@@ -5,6 +5,24 @@ import backend.services.cli_runner as runner
 import backend.store as store
 
 
+def test_browser_extension_capabilities_are_exposed_to_the_ui(client, monkeypatch):
+    monkeypatch.setattr(
+        connections_router.runner,
+        "browser_extensions",
+        lambda: [{
+            "id": "bloghub.hashnode",
+            "platform": "hashnode",
+            "capabilities": ["create_draft", "publish"],
+        }],
+    )
+
+    response = client.get("/api/connections/browser-extensions")
+
+    assert response.status_code == 200
+    assert response.json()["extensions"][0]["platform"] == "hashnode"
+    assert "publish" in response.json()["extensions"][0]["capabilities"]
+
+
 def test_hashnode_browser_login_persists_only_profile_references(client, monkeypatch):
     monkeypatch.setattr(
         connections_router.runner,
@@ -119,6 +137,8 @@ def test_hashnode_browser_disconnect_deletes_remote_profile(client, monkeypatch)
     assert response.status_code == 200
     assert deleted == [("hashnode", "bp_profile")]
     assert store.get_browser_connection("user_seed", "hashnode") is None
+
+
 def test_hashnode_browser_disconnect_retains_profile_when_remote_cleanup_fails(
     client, monkeypatch,
 ):

--- a/tests/tests_backend/test_browser_publish.py
+++ b/tests/tests_backend/test_browser_publish.py
@@ -130,6 +130,48 @@ def test_manual_handoff_is_retained_on_failed_browser_login(client, monkeypatch)
     assert persisted["result"]["manual_handoff"]["reason"] == "hashnode_login_required"
 
 
+def test_browser_publish_redacts_adapter_error_before_persistence(client, monkeypatch):
+    _connect()
+    monkeypatch.setattr(
+        browser_publish.runner,
+        "browser_operation",
+        lambda *_args, **_kwargs: {
+            "success": False,
+            "error": "Authorization: Bearer adapter-secret-token",
+        },
+    )
+    run = client.post("/api/articles/art_001/browser-publish/hashnode").json()
+
+    client.post(f"/api/articles/art_001/browser-publish/{run['id']}/approve")
+
+    persisted = client.get(
+        f"/api/articles/art_001/browser-publish/{run['id']}"
+    ).json()
+    assert "adapter-secret-token" not in persisted["error"]
+    assert "adapter-secret-token" not in persisted["result"]["error"]
+    assert "[REDACTED]" in persisted["error"]
+
+
+def test_browser_publish_redacts_transport_exception_before_persistence(
+    client, monkeypatch
+):
+    _connect()
+
+    def fail(*_args, **_kwargs):
+        raise RuntimeError("Cookie: session=transport-secret; path=/")
+
+    monkeypatch.setattr(browser_publish.runner, "browser_operation", fail)
+    run = client.post("/api/articles/art_001/browser-publish/hashnode").json()
+
+    client.post(f"/api/articles/art_001/browser-publish/{run['id']}/approve")
+
+    persisted = client.get(
+        f"/api/articles/art_001/browser-publish/{run['id']}"
+    ).json()
+    assert "transport-secret" not in persisted["error"]
+    assert "[REDACTED]" in persisted["error"]
+
+
 def test_approved_run_uploads_the_revision_captured_at_request(client, monkeypatch):
     _connect()
     article = client.get("/api/articles/art_001").json()

--- a/tests/tests_backend/test_browser_publish.py
+++ b/tests/tests_backend/test_browser_publish.py
@@ -18,14 +18,15 @@ def test_browser_publish_requires_approval_and_completes(client, monkeypatch):
     _connect()
     seen = {}
 
-    def upload(**kwargs):
+    def upload(platform, operation, **kwargs):
+        seen.update(platform=platform, operation=operation)
         seen.update(kwargs)
         return {
             "success": True, "method": "deterministic",
             "url": "https://hashnode.com/draft/example", "draft_id": "example",
         }
 
-    monkeypatch.setattr(browser_publish.runner, "hashnode_browser_upload", upload)
+    monkeypatch.setattr(browser_publish.runner, "browser_operation", upload)
     created = client.post(
         "/api/articles/art_001/browser-publish/hashnode",
     )
@@ -41,7 +42,8 @@ def test_browser_publish_requires_approval_and_completes(client, monkeypatch):
     assert persisted["status"] == "completed"
     assert persisted["result"]["method"] == "deterministic"
     assert persisted["mode"] == "draft"
-    assert seen["publish"] is False
+    assert seen["operation"] == "create_draft"
+    assert seen["approved"] is True
     assert seen["profile_id"] == "bp_test"
     assert seen["organization_id"] == "o_test"
 
@@ -51,8 +53,10 @@ def test_public_publish_mode_is_durable_and_updates_destination(client, monkeypa
     seen = {}
     monkeypatch.setattr(
         browser_publish.runner,
-        "hashnode_browser_upload",
-        lambda **kwargs: seen.update(kwargs) or {
+        "browser_operation",
+        lambda platform, operation, **kwargs: seen.update(
+            kwargs, platform=platform, operation=operation
+        ) or {
             "success": True,
             "method": "deterministic",
             "status": "published",
@@ -69,7 +73,7 @@ def test_public_publish_mode_is_durable_and_updates_destination(client, monkeypa
 
     client.post(f"/api/articles/art_001/browser-publish/{run['id']}/approve")
 
-    assert seen["publish"] is True
+    assert seen["operation"] == "publish"
     article = client.get("/api/articles/art_001").json()
     assert article["destinations"]["hashnode"]["status"] == "published"
     assert article["destinations"]["hashnode"]["url"] == (
@@ -80,8 +84,8 @@ def test_public_publish_mode_is_durable_and_updates_destination(client, monkeypa
 def test_browser_publish_cannot_be_approved_twice(client, monkeypatch):
     _connect()
     monkeypatch.setattr(
-        browser_publish.runner, "hashnode_browser_upload",
-        lambda **_kwargs: {"success": True, "method": "deterministic"},
+        browser_publish.runner, "browser_operation",
+        lambda *_args, **_kwargs: {"success": True, "method": "deterministic"},
     )
     run = client.post(
         "/api/articles/art_001/browser-publish/hashnode",
@@ -105,8 +109,8 @@ def test_browser_publish_requires_connected_browser_profile(client):
 def test_manual_handoff_is_retained_on_failed_browser_login(client, monkeypatch):
     _connect()
     monkeypatch.setattr(
-        browser_publish.runner, "hashnode_browser_upload",
-        lambda **_kwargs: {
+        browser_publish.runner, "browser_operation",
+        lambda *_args, **_kwargs: {
             "success": False,
             "error": "Hashnode browser session is not authenticated",
             "manual_handoff": {
@@ -131,8 +135,10 @@ def test_approved_run_uploads_the_revision_captured_at_request(client, monkeypat
     article = client.get("/api/articles/art_001").json()
     seen = {}
     monkeypatch.setattr(
-        browser_publish.runner, "hashnode_browser_upload",
-        lambda **kwargs: seen.update(kwargs) or {"success": True, "method": "deterministic"},
+        browser_publish.runner, "browser_operation",
+        lambda platform, operation, **kwargs: seen.update(
+            kwargs, platform=platform, operation=operation
+        ) or {"success": True, "method": "deterministic"},
     )
     run = client.post(
         "/api/articles/art_001/browser-publish/hashnode",
@@ -142,7 +148,7 @@ def test_approved_run_uploads_the_revision_captured_at_request(client, monkeypat
         "base_revision_id": article["revision_id"],
     })
     client.post(f"/api/articles/art_001/browser-publish/{run['id']}/approve")
-    assert seen["article_md"] == article["content"]
+    assert seen["article"]["body"] == article["content"]
 
 
 def test_interrupted_external_write_is_not_replayed(client):

--- a/tests/tests_backend/test_cli_runner_auth.py
+++ b/tests/tests_backend/test_cli_runner_auth.py
@@ -25,6 +25,19 @@ def test_runner_redacts_callback_secrets_and_device_codes():
     assert "ABCD-EFGH" not in reason
 
 
+def test_runner_redacts_browser_adapter_credentials():
+    runner = _runner_module()
+    reason = runner._safe_reason(
+        "request failed Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature "
+        "Cookie: session=browser-secret; csrf=private api_key=sk-adapter-secret123"
+    )
+    assert "eyJhbGci" not in reason
+    assert "browser-secret" not in reason
+    assert "private" not in reason
+    assert "sk-adapter" not in reason
+    assert "[redacted]" in reason
+
+
 def test_runner_normalizes_actionable_failure_states():
     runner = _runner_module()
     assert runner._failure_status("access denied")[0] == "rejected"

--- a/tests/tests_backend/test_credential_storage.py
+++ b/tests/tests_backend/test_credential_storage.py
@@ -181,7 +181,9 @@ def test_invalid_environment_key_fails_configuration(credential_environment, mon
     "value",
     [
         'Authorization: Bearer sk-test-secret',
+        '{"authorization":"Bearer browser-secret","status":401}',
         'api_key=sk-test-secret',
+        'password=private-secret',
         '{"access_token":"oauth-secret","ok":true}',
         'Cookie: session=private; theme=dark',
         'auth_code=temporary-code',

--- a/tests/tests_backend/test_hashnode_browser.py
+++ b/tests/tests_backend/test_hashnode_browser.py
@@ -157,6 +157,18 @@ def test_deterministic_selectors_fill_and_verify_autosaved_draft(monkeypatch):
     assert page.filled["textarea[placeholder*='writing markdown' i]"] == "# A title"
 
 
+def test_extension_page_entrypoint_uses_core_owned_page():
+    page = FakePage()
+
+    result = hashnode_browser.upload_hashnode_page(
+        page, title="Extension title", article_md="# Extension title"
+    )
+
+    assert result["success"] is True
+    assert result["draft_id"] == "draft_test"
+    assert page.filled["textarea[placeholder*='title' i]"] == "Extension title"
+
+
 def test_missing_deterministic_selector_fails(monkeypatch):
     page = FakePage()
     page.visible.clear()


### PR DESCRIPTION
## Summary

- introduce protocol-1 BrowserLoginAdapter and BlogOperationsAdapter contracts with normalized operation, article, pagination, and result types
- discover version-pinned extensions from built-in and administrator allow-listed manifests
- route browser login, capability discovery, and approved browser operations through generic runner endpoints
- migrate Hashnode login and deterministic draft/publish behavior to the extension contract
- migrate Medium login to the same contract so #43 and #67 can add retrieval and publishing without platform-specific routes
- expose installed capabilities to the backend and make browser publish orchestration platform-neutral
- add an example extension, contributor documentation, fixture-backed contract tests, and Docker packaging

## Security and behavior

Extensions are trusted administrator-installed executable code. BlogHub does not expose an extension upload API. The runner owns the persistent Playwright context and passes adapters a page plus normalized request data. Public-content and destructive operations require explicit approval, incompatible protocol versions are rejected, and extension errors are sanitized at the runner boundary.

Existing Hashnode endpoints remain as compatibility wrappers and preserve current user-visible behavior. Medium intentionally declares no browser operations until its retrieval/publishing implementation lands.

## Validation

- unit gate: 450 passed, 1 skipped, 307 deselected
- focused extension/browser suite: 44 passed
- CLI runner Docker image built successfully
- built image discovered Hashnode and Medium protocol-1 manifests
- npm contract check could not run locally because the checkout resolves Node through an unsupported WSL1/Windows installation; no generated API contracts were changed

Closes #68
