### PR TITLE
feat: land non-Pro Hashnode synchronization

### DIFF
--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -33,7 +33,10 @@ from fastapi.responses import HTMLResponse
 import backend.services.cli_runner as runner
 import backend.services.connection_auth as agent_auth
 import backend.store as store
-from backend.services.hashnode_sync import sync_hashnode_articles
+from backend.services.hashnode_sync import (
+    sync_hashnode_articles,
+    sync_hashnode_browser_records,
+)
 from backend.schemas.connections import (
     ActiveAgentAuthFlowsResponse,
     AgentAuthCallbackRequest,
@@ -855,20 +858,34 @@ def _fetch_devto_article_body(token: str, article_id: str) -> str:
 
 @router.post("/hashnode/sync", response_model=HashnodeSyncResponse)
 def sync_hashnode(request: Request):
-    """Import every PAT-visible Hashnode draft and published article."""
+    """Import Hashnode through browser login for non-Pro or PAT for Pro."""
     user_id: str = request.state.user_id
+    browser_connection = store.get_browser_connection(user_id, "hashnode")
+    if browser_connection and browser_connection["status"] == "connected":
+        try:
+            retrieval = runner.hashnode_browser_articles(
+                organization_id=browser_connection["skyvern_organization_id"],
+                profile_id=browser_connection["skyvern_profile_id"],
+            )
+        except runner.RunnerUnavailable as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+        return sync_hashnode_browser_records(user_id, retrieval)
+
     token = store.get_connection_token(user_id, "hashnode") or os.environ.get("HASHNODE_PAT")
     if not token:
         raise HTTPException(
             status_code=409,
-            detail={"error": "hashnode_pat_required"},
+            detail={
+                "error": "hashnode_connection_required",
+                "message": "Connect Hashnode with browser login or a Pro API token",
+            },
         )
     if token == "cli_session":
         raise HTTPException(
             status_code=409,
             detail={
-                "error": "hashnode_pat_required",
-                "message": "Browser-profile retrieval is not supported by this sync path",
+                "error": "hashnode_browser_profile_required",
+                "message": "Reconnect Hashnode browser login to restore its profile",
             },
         )
     return sync_hashnode_articles(user_id, token)

--- a/backend/services/cli_runner.py
+++ b/backend/services/cli_runner.py
@@ -198,6 +198,17 @@ def browser_operation(
         raise RunnerUnavailable(f"Browser runner unavailable: {exc}") from exc
 
 
+def hashnode_browser_articles(*, organization_id: str, profile_id: str) -> dict:
+    """Compatibility wrapper for Hashnode's extension list operation."""
+    return browser_operation(
+        "hashnode",
+        "list_articles",
+        organization_id=organization_id,
+        profile_id=profile_id,
+        limit=100,
+    )
+
+
 def start_browser_login(platform: str, profile_id: str | None = None) -> dict:
     if profile_id:
         return _post(f"/browser/{platform}/login", profile_id=profile_id)

--- a/backend/services/hashnode_sync.py
+++ b/backend/services/hashnode_sync.py
@@ -56,6 +56,15 @@ def _iso(value: datetime | None) -> str | None:
     return value.astimezone(timezone.utc).isoformat()
 
 
+def _datetime(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
 def _fingerprint(article: HashnodeRemoteArticle) -> str:
     normalized = json.dumps(
         {"title": article.title.strip(), "markdown": article.body_markdown},
@@ -239,6 +248,7 @@ def _sync_article(
         last_sync_status=article_status,
         last_sync_result=sync_result,
         last_sync_error=image_error,
+        remote_created_at=remote.raw.get("browser_created_at"),
         remote_updated_at=remote_updated_at,
         last_sync_started_at=started_at,
         last_synced_at=completed_at,
@@ -254,18 +264,18 @@ def _sync_article(
     }
 
 
-def sync_hashnode_articles(
+def _sync_remote_articles(
     user_id: str,
-    token: str,
+    remote_articles: list[HashnodeRemoteArticle],
+    source_errors: list[dict],
     *,
     store: HashnodeSyncStore = default_store,
-    client: HashnodeClient | None = None,
     image_fetcher: Callable[[str], IngestedImage] = fetch_and_validate_image,
+    failed_articles: list[dict] | None = None,
 ) -> dict[str, Any]:
-    """Run one bounded, synchronous Hashnode synchronization pass."""
+    """Synchronize normalized Hashnode records from any retrieval adapter."""
     started_at = _now().isoformat()
-    remote_articles, source_errors = _fetch_sources(client or HashnodeClient(token))
-    article_results: list[dict] = []
+    article_results: list[dict] = list(failed_articles or [])
     counters = {
         "imported": 0,
         "updated": 0,
@@ -276,6 +286,7 @@ def sync_hashnode_articles(
         "imagesFailed": 0,
     }
 
+    counters["failed"] = len(article_results)
     for remote in remote_articles:
         try:
             result = _sync_article(
@@ -329,3 +340,91 @@ def sync_hashnode_articles(
         "sourceErrors": source_errors,
         "articles": article_results,
     }
+
+
+def sync_hashnode_articles(
+    user_id: str,
+    token: str,
+    *,
+    store: HashnodeSyncStore = default_store,
+    client: HashnodeClient | None = None,
+    image_fetcher: Callable[[str], IngestedImage] = fetch_and_validate_image,
+) -> dict[str, Any]:
+    """Run one synchronous Hashnode GraphQL synchronization pass."""
+    remote_articles, source_errors = _fetch_sources(client or HashnodeClient(token))
+    return _sync_remote_articles(
+        user_id,
+        remote_articles,
+        source_errors,
+        store=store,
+        image_fetcher=image_fetcher,
+    )
+
+
+def sync_hashnode_browser_records(
+    user_id: str,
+    retrieval: dict,
+    *,
+    store: HashnodeSyncStore = default_store,
+    image_fetcher: Callable[[str], IngestedImage] = fetch_and_validate_image,
+) -> dict[str, Any]:
+    """Synchronize records returned by the authenticated browser runner."""
+    remote_articles: list[HashnodeRemoteArticle] = []
+    source_errors: list[dict] = []
+    failed_articles: list[dict] = []
+    diagnostics = retrieval.get("diagnostics") or {}
+    retrieval_errors = diagnostics.get("errors") or retrieval.get("errors") or []
+    if not retrieval.get("success", True) and not retrieval_errors:
+        retrieval_errors = [{
+            "source": "browser",
+            "error": retrieval.get("error") or "browser_retrieval_failed",
+        }]
+    for error in retrieval_errors:
+        if error.get("remote_id"):
+            failed_articles.append({
+                "remoteId": str(error["remote_id"]),
+                "articleId": None,
+                "status": "failed",
+                "action": "failed",
+                "revisionCreated": False,
+                "imageStatus": "not_attempted",
+                "error": str(error.get("error") or "article_retrieval_failed"),
+            })
+        else:
+            source_errors.append({
+                "source": str(error.get("source") or "browser"),
+                "error": str(error.get("error") or "browser_retrieval_failed"),
+            })
+
+    for record in retrieval.get("articles") or []:
+        try:
+            metadata = record.get("metadata") or {}
+            status = str(record.get("status") or "draft").lower()
+            remote_articles.append(HashnodeRemoteArticle(
+                article_id=str(record["remote_id"]),
+                title=str(record["title"]),
+                url=record.get("url") or metadata.get("url"),
+                canonical_url=record.get("canonical_url"),
+                subtitle=record.get("subtitle"),
+                body_markdown=str(record.get("body") or record.get("body_markdown") or ""),
+                published=status == "published" or bool(record.get("published")),
+                updated_at=_datetime(record.get("updated_at")),
+                cover_image_url=record.get("cover_url") or record.get("cover_image_url"),
+                raw={
+                    "browser_created_at": record.get("created_at"),
+                    "retrieval": "browser",
+                },
+            ))
+        except (KeyError, TypeError, ValueError):
+            source_errors.append({
+                "source": "browser",
+                "error": "invalid_article_record",
+            })
+    return _sync_remote_articles(
+        user_id,
+        remote_articles,
+        source_errors,
+        store=store,
+        image_fetcher=image_fetcher,
+        failed_articles=failed_articles,
+    )

--- a/cli-runner/blog_extensions/builtin/hashnode.py
+++ b/cli-runner/blog_extensions/builtin/hashnode.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from hashnode_browser import check_hashnode_profile, upload_hashnode_page
+from hashnode_browser import (
+    check_hashnode_profile,
+    retrieve_hashnode_articles,
+    upload_hashnode_page,
+)
 
 from ..contracts import (
     BlogOperationsAdapter,
@@ -23,11 +27,17 @@ class HashnodeLoginAdapter(BrowserLoginAdapter):
 
 class HashnodeOperationsAdapter(BlogOperationsAdapter):
     platform = "hashnode"
-    capabilities = frozenset({Capability.CREATE_DRAFT, Capability.PUBLISH})
+    capabilities = frozenset({
+        Capability.LIST_ARTICLES,
+        Capability.CREATE_DRAFT,
+        Capability.PUBLISH,
+    })
 
     def execute(self, page, operation: Capability, request: OperationRequest) -> dict:
         if operation not in self.capabilities:
             raise OperationNotSupported(self.platform, operation.value)
+        if operation == Capability.LIST_ARTICLES:
+            return retrieve_hashnode_articles(page=page)
         article = request.article
         if article is None:
             raise ValueError("Hashnode create and publish operations require article data")

--- a/cli-runner/blog_extensions/manifests/hashnode/bloghub_extension.toml
+++ b/cli-runner/blog_extensions/manifests/hashnode/bloghub_extension.toml
@@ -4,7 +4,7 @@ id = "bloghub.hashnode"
 platform = "hashnode"
 display_name = "Hashnode"
 version = "1.0.0"
-capabilities = ["create_draft", "publish"]
+capabilities = ["list_articles", "create_draft", "publish"]
 
 [entrypoints]
 login = "blog_extensions.builtin.hashnode:HashnodeLoginAdapter"

--- a/cli-runner/browser_selectors.json
+++ b/cli-runner/browser_selectors.json
@@ -6,6 +6,9 @@
   "title": ["textarea[placeholder*='title' i]", "input[placeholder*='title' i]"],
   "markdown_mode": ["button:has-text('Markdown')"],
   "content": ["textarea[placeholder*='writing markdown' i]"],
+  "drafts_tab": ["[role='tab']:has-text('Drafts')"],
+  "published_tab": ["[role='tab']:has-text('Published')"],
+  "load_more": ["button:has-text('Load more')"],
   "publish_open": ["button:has-text('Publish')"],
   "publish_confirm": ["[role='dialog'] button:has-text('Publish')"]
 }

--- a/cli-runner/hashnode_browser.py
+++ b/cli-runner/hashnode_browser.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 import re
 import sqlite3
@@ -58,6 +59,164 @@ def _normalized_markdown(markdown: str) -> str:
     normalized = re.sub(r"\n{3,}", "\n\n", normalized)
     normalized = re.sub(r"(^- .+)\n\n(?=- )", r"\1\n", normalized, flags=re.MULTILINE)
     return normalized.strip()
+
+
+def _remote_timestamp(value: object) -> str | None:
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value / 1000, tz=timezone.utc).isoformat()
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _image_url(value: object) -> str | None:
+    if isinstance(value, str):
+        return value.strip() or None
+    if isinstance(value, dict):
+        candidate = value.get("url")
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    return None
+
+
+def _browser_article(payload: dict, *, remote_id: str, published: bool) -> dict:
+    publication = payload.get("publication") or {}
+    publication_name = publication.get("username") if isinstance(publication, dict) else None
+    slug = payload.get("slug")
+    public_url = (
+        f"https://{publication_name}.hashnode.dev/{slug}"
+        if published and publication_name and slug else None
+    )
+    title = str(payload.get("title") or "").strip()
+    if not title and not published:
+        title = f"Untitled Hashnode draft ({remote_id[:8]})"
+    return {
+        "remote_id": str(payload.get("cuid") or payload.get("_id") or remote_id),
+        "title": title,
+        "body": str(payload.get("contentMarkdown") or ""),
+        "status": "published" if published else "draft",
+        "subtitle": str(payload.get("subtitle") or "").strip() or None,
+        "canonical_url": str(payload.get("originalArticleURL") or "").strip() or None,
+        "updated_at": _remote_timestamp(payload.get("dateUpdated")),
+        "created_at": _remote_timestamp(payload.get("dateAdded")),
+        "cover_url": _image_url(payload.get("coverImage") or payload.get("ogImage")),
+        "metadata": {"url": public_url},
+    }
+
+
+def _listing_ids(page, *, published: bool) -> list[str]:
+    marker = "/edit/" if published else "/draft/"
+    selector = f'a[href*="{marker}"]'
+    hrefs = page.locator(selector).evaluate_all("els => els.map(e => e.href)")
+    result: list[str] = []
+    for href in hrefs:
+        remote_id = str(href).rstrip("/").rsplit(marker, 1)[-1].split("?", 1)[0]
+        if remote_id and remote_id not in result:
+            result.append(remote_id)
+    return result
+
+
+def _wait_for_listing(page, *, published: bool, timeout_ms: int = 25_000) -> bool:
+    selector = 'a[href*="/edit/"]' if published else 'a[href*="/draft/"]'
+    label = "Published" if published else "Drafts"
+    deadline = time.monotonic() + timeout_ms / 1000
+    while time.monotonic() < deadline:
+        if page.locator(selector).count():
+            return True
+        try:
+            body = page.locator("body").inner_text()
+            match = re.search(rf"(?:^|\n){label}\s*\n(\d+)(?:\n|$)", body)
+            if match and int(match.group(1)) == 0:
+                return True
+        except Exception:
+            pass
+        page.wait_for_timeout(250)
+    return False
+
+
+def _exhaust_listing(page, selectors: dict, *, max_clicks: int = 100) -> bool:
+    """Click every Hashnode load-more batch. Returns False on a stalled control."""
+    article_links = 'a[href*="/draft/"], a[href*="/edit/"]'
+    for _ in range(max_clicks):
+        load_more, _ = _first_visible(page, selectors["load_more"])
+        if load_more is None:
+            return True
+        before = len(page.locator(article_links).all())
+        load_more.click()
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            page.wait_for_timeout(250)
+            if len(page.locator(article_links).all()) > before:
+                break
+        else:
+            return False
+    return False
+
+
+def retrieve_hashnode_articles(*, page) -> dict:
+    """Retrieve all Hashnode drafts and posts through the extension runtime page."""
+    selectors = json.loads(SELECTORS_PATH.read_text(encoding="utf-8"))
+    articles: list[dict] = []
+    errors: list[dict] = []
+    for source, published, tab_selector in (
+        ("drafts", False, "drafts_tab"),
+        ("published", True, "published_tab"),
+    ):
+        try:
+            page.goto(
+                "https://hashnode.com/drafts",
+                wait_until="domcontentloaded",
+                timeout=60_000,
+            )
+            if any(part in page.url.lower() for part in ("signin", "login", "onboard")):
+                errors.append({"source": source, "error": "hashnode_login_required"})
+                continue
+            tab, _ = _wait_first_visible(
+                page, selectors[tab_selector], timeout_ms=25_000,
+            )
+            if tab is None:
+                errors.append({"source": source, "error": "listing_tab_unavailable"})
+                continue
+            tab.click()
+            if not _wait_for_listing(page, published=published):
+                errors.append({"source": source, "error": "listing_retrieval_failed"})
+                continue
+            if not _exhaust_listing(page, selectors):
+                errors.append({"source": source, "error": "listing_pagination_stalled"})
+            remote_ids = _listing_ids(page, published=published)
+        except Exception:
+            errors.append({"source": source, "error": "listing_retrieval_failed"})
+            continue
+
+        endpoint = "posts" if published else "drafts"
+        payload_key = "post" if published else "draft"
+        for remote_id in remote_ids:
+            try:
+                response = page.request.get(
+                    f"https://hashnode.com/api/{endpoint}/{remote_id}"
+                )
+                payload = response.json() if response.ok else {}
+                record = payload.get(payload_key) if payload.get("success") else None
+                if not isinstance(record, dict):
+                    raise ValueError("article payload unavailable")
+                article = _browser_article(
+                    record, remote_id=remote_id, published=published,
+                )
+                if not article["title"]:
+                    raise ValueError("article title unavailable")
+                articles.append(article)
+            except Exception:
+                errors.append({
+                    "source": source,
+                    "remote_id": remote_id,
+                    "error": "article_retrieval_failed",
+                })
+
+    return {
+        "success": True,
+        "articles": articles,
+        "diagnostics": {"errors": errors},
+    }
 
 
 def upload_hashnode_draft(

--- a/screens/settings/v2.html
+++ b/screens/settings/v2.html
@@ -216,6 +216,7 @@ let _browserConnections = {
   hashnode: { platform: 'hashnode', status: 'disconnected' },
 };
 let _browserMethodMenus = { medium: false, hashnode: false };
+let _hashnodeSync = { status: 'idle', message: '' };
 let _browserLoginTabs = {};
 let _browserLoginTabTimers = {};
 const _authTimers = new Map();
@@ -424,7 +425,9 @@ function browserPlatformCard(conn) {
   let actions = '';
   if (connected) {
     const connectedMethod = apiConnected && browserConnected ? 'both' : apiConnected ? 'api' : 'browser';
-    actions = `<button onclick="disconnectBrowserPlatformConnection('${id}', '${connectedMethod}')"
+    const syncAction = id === 'hashnode' ? `<button id="hashnode-sync" onclick="syncHashnodeArticles()" ${_hashnodeSync.status === 'running' ? 'disabled' : ''}
+      style="font-size:11px;padding:4px 10px;border-radius:4px;border:1px solid #252a38;background:transparent;color:#c9cfe0;cursor:${_hashnodeSync.status === 'running' ? 'wait' : 'pointer'};font-family:inherit;">${_hashnodeSync.status === 'running' ? 'Syncing…' : 'Sync articles'}</button>` : '';
+    actions = `${syncAction}<button onclick="disconnectBrowserPlatformConnection('${id}', '${connectedMethod}')"
       style="font-size:11px;color:#f87171;background:transparent;border:none;cursor:pointer;font-family:inherit;">Disconnect</button>`;
   } else if (waiting) {
     actions = `<button onclick="openBrowserLogin('${id}')"
@@ -470,6 +473,7 @@ function browserPlatformCard(conn) {
             </div>
             ${method ? `<div style="font-size:11px;color:#c9cfe0;margin-top:3px;">${method}</div>` : ''}
             <div style="font-size:10px;color:#5a6080;margin-top:3px;">${helper}</div>
+            ${id === 'hashnode' && _hashnodeSync.message ? `<div role="status" style="font-size:10px;color:${_hashnodeSync.status === 'failed' ? '#f87171' : _hashnodeSync.status === 'partial' ? '#fbbf24' : '#71d892'};margin-top:3px;">${esc(_hashnodeSync.message)}</div>` : ''}
           </div>
         </div>
         <div style="display:flex;align-items:center;gap:8px;flex-shrink:0;">${actions}</div>
@@ -503,6 +507,28 @@ function chooseBrowserPlatformApiToken(id) {
 function chooseBrowserPlatformLogin(id) {
   _browserMethodMenus[id] = false;
   startBrowserLogin(id);
+}
+
+async function syncHashnodeArticles() {
+  if (_hashnodeSync.status === 'running') return;
+  _hashnodeSync = { status: 'running', message: '' };
+  renderPlatforms(_connections.filter(c => c.type === 'blog'));
+  try {
+    const res = await fetch('/api/connections/hashnode/sync', { method: 'POST' });
+    const data = await res.json();
+    if (!res.ok) {
+      const detail = data.detail;
+      throw new Error(typeof detail === 'string' ? detail : detail?.message || detail?.error || `HTTP ${res.status}`);
+    }
+    const status = data.status === 'partial' ? 'partial' : 'succeeded';
+    _hashnodeSync = {
+      status,
+      message: `${data.fetched} articles synced · ${data.imported} new · ${data.updated} updated`,
+    };
+  } catch (error) {
+    _hashnodeSync = { status: 'failed', message: error.message || 'Article sync failed' };
+  }
+  renderPlatforms(_connections.filter(c => c.type === 'blog'));
 }
 
 function createBrowserLoginTab(url='about:blank') {

--- a/tests/settings.spec.js
+++ b/tests/settings.spec.js
@@ -112,6 +112,41 @@ test.describe('Settings screen', () => {
     expect(body.token).toBe('sk-ant-test');
   });
 
+  test('[contract] connected Hashnode browser profile can sync articles', async ({ page }) => {
+    await page.route('**/api/connections/hashnode/browser-connection', route => route.fulfill({
+      json: {
+        platform: 'hashnode',
+        status: 'connected',
+        authorizationUrl: null,
+        verifiedAt: '2026-08-20T08:00:00Z',
+        error: null,
+      },
+    }));
+    await page.route('**/api/connections/hashnode/sync', route => route.fulfill({
+      json: {
+        status: 'succeeded',
+        fetched: 104,
+        imported: 103,
+        updated: 1,
+      },
+    }));
+    await page.reload();
+
+    const requestPromise = page.waitForRequest(
+      request => request.url().endsWith('/api/connections/hashnode/sync')
+        && request.method() === 'POST',
+    );
+    const card = page.locator('#plat-card-hashnode');
+    await card.getByRole('button', { name: 'Sync articles' }).click();
+    await requestPromise;
+
+    await expect(card.getByRole('status')).toHaveText(
+      '104 articles synced · 103 new · 1 updated',
+    );
+    await expect(card.getByText('Refresh login', { exact: true })).toHaveCount(0);
+    await expect(card.getByText('Test', { exact: true })).toHaveCount(0);
+  });
+
   // ── 3. Browser login flow ────────────────────────────────────────────────────
 
   /**

--- a/tests/tests_backend/test_blog_extension_runner.py
+++ b/tests/tests_backend/test_blog_extension_runner.py
@@ -24,7 +24,9 @@ def test_runner_discovers_builtin_extension_capabilities():
     payload = runner_main.browser_extensions()
 
     by_platform = {item["platform"]: item for item in payload["extensions"]}
-    assert by_platform["hashnode"]["capabilities"] == ["create_draft", "publish"]
+    assert by_platform["hashnode"]["capabilities"] == [
+        "create_draft", "list_articles", "publish",
+    ]
     assert by_platform["medium"]["capabilities"] == []
 
 

--- a/tests/tests_backend/test_blog_extensions.py
+++ b/tests/tests_backend/test_blog_extensions.py
@@ -33,7 +33,7 @@ def test_builtin_extensions_satisfy_the_versioned_contract():
     assert_extension_contract(medium)
 
     assert hashnode.manifest.capabilities == frozenset({
-        Capability.CREATE_DRAFT, Capability.PUBLISH,
+        Capability.LIST_ARTICLES, Capability.CREATE_DRAFT, Capability.PUBLISH,
     })
     assert medium.manifest.capabilities == frozenset()
     assert [item["platform"] for item in registry.descriptors()] == [

--- a/tests/tests_backend/test_hashnode_browser.py
+++ b/tests/tests_backend/test_hashnode_browser.py
@@ -197,6 +197,220 @@ def test_hashnode_markdown_normalization_accepts_editor_formatting():
     )
 
 
+def test_browser_article_normalizes_authenticated_hashnode_payload():
+    result = hashnode_browser._browser_article(
+        {
+            "_id": "mongo-id",
+            "cuid": "post-cuid",
+            "title": "  Browser post  ",
+            "contentMarkdown": "# Browser post\n",
+            "subtitle": "A subtitle",
+            "originalArticleURL": "https://example.com/original",
+            "coverImage": {"url": "https://cdn.example/cover.png"},
+            "dateAdded": "2026-08-19T08:00:00Z",
+            "dateUpdated": "2026-08-20T08:00:00Z",
+            "slug": "browser-post",
+            "publication": {"username": "tensorworks"},
+        },
+        remote_id="fallback",
+        published=True,
+    )
+
+    assert result == {
+        "remote_id": "post-cuid",
+        "title": "Browser post",
+        "body": "# Browser post\n",
+        "status": "published",
+        "subtitle": "A subtitle",
+        "canonical_url": "https://example.com/original",
+        "updated_at": "2026-08-20T08:00:00Z",
+        "created_at": "2026-08-19T08:00:00Z",
+        "cover_url": "https://cdn.example/cover.png",
+        "metadata": {"url": "https://tensorworks.hashnode.dev/browser-post"},
+    }
+
+
+def test_browser_article_preserves_blank_draft_with_stable_fallback_title():
+    result = hashnode_browser._browser_article(
+        {"_id": "69c6400c10e664c5dab32874", "title": "", "contentMarkdown": ""},
+        remote_id="69c6400c10e664c5dab32874",
+        published=False,
+    )
+
+    assert result["remote_id"] == "69c6400c10e664c5dab32874"
+    assert result["title"] == "Untitled Hashnode draft (69c6400c)"
+    assert result["body"] == ""
+
+
+class ListingLocator:
+    def __init__(self, page, selector):
+        self.page = page
+        self.selector = selector
+
+    @property
+    def first(self):
+        return self
+
+    def is_visible(self, timeout=None):
+        return "Load more" in self.selector and bool(self.page.batches)
+
+    def click(self):
+        self.page.ids.extend(self.page.batches.pop(0))
+
+    def all(self):
+        return [object() for _ in self.page.ids]
+
+    def evaluate_all(self, _script):
+        marker = "edit" if "/edit/" in self.selector else "draft"
+        return [f"https://hashnode.com/{marker}/{item}" for item in self.page.ids]
+
+
+class ListingPage:
+    def __init__(self):
+        self.ids = ["first"]
+        self.batches = [["second", "third"], ["fourth"]]
+
+    def locator(self, selector):
+        return ListingLocator(self, selector)
+
+    def wait_for_timeout(self, _timeout):
+        return None
+
+
+def test_browser_listing_exhausts_every_load_more_batch():
+    page = ListingPage()
+
+    complete = hashnode_browser._exhaust_listing(
+        page, {"load_more": ["button:has-text('Load more')"]},
+    )
+
+    assert complete is True
+    assert hashnode_browser._listing_ids(page, published=False) == [
+        "first", "second", "third", "fourth",
+    ]
+
+
+class RetrievalResponse:
+    ok = True
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def json(self):
+        return self.payload
+
+
+class RetrievalRequest:
+    def get(self, url):
+        if "/api/drafts/" in url:
+            return RetrievalResponse({
+                "success": True,
+                "draft": {
+                    "_id": "draft-one",
+                    "title": "Draft one",
+                    "contentMarkdown": "Draft body",
+                },
+            })
+        return RetrievalResponse({
+            "success": True,
+            "post": {
+                "_id": "mongo-post",
+                "cuid": "post-one",
+                "title": "Post one",
+                "contentMarkdown": "Post body",
+                "slug": "post-one",
+                "publication": {"username": "tensorworks"},
+            },
+        })
+
+
+class RetrievalLocator:
+    def __init__(self, page, selector):
+        self.page = page
+        self.selector = selector
+
+    @property
+    def first(self):
+        return self
+
+    def is_visible(self, timeout=None):
+        if "role='tab'" in self.selector:
+            return True
+        return False
+
+    def click(self):
+        self.page.mode = "published" if "Published" in self.selector else "drafts"
+
+    def count(self):
+        return len(self._ids())
+
+    def all(self):
+        return [object() for _ in self._ids()]
+
+    def inner_text(self):
+        return "Drafts\n1\nPublished\n1"
+
+    def evaluate_all(self, _script):
+        marker = "edit" if self.page.mode == "published" else "draft"
+        return [f"https://hashnode.com/{marker}/{item}" for item in self._ids()]
+
+    def _ids(self):
+        if "/edit/" in self.selector and self.page.mode == "published":
+            return ["post-one"]
+        if "/draft/" in self.selector and self.page.mode == "drafts":
+            return ["draft-one"]
+        if "/draft/" in self.selector and "/edit/" in self.selector:
+            return [self.page.mode]
+        return []
+
+
+class RetrievalPage:
+    def __init__(self):
+        self.url = "about:blank"
+        self.mode = None
+        self.request = RetrievalRequest()
+        self.closed = False
+
+    def goto(self, url, **_kwargs):
+        self.url = url
+
+    def locator(self, selector):
+        return RetrievalLocator(self, selector)
+
+    def wait_for_timeout(self, _timeout):
+        return None
+
+    def close(self):
+        self.closed = True
+
+
+class RetrievalContext:
+    def __init__(self):
+        self.created_pages = []
+        self.closed = False
+
+    def new_page(self):
+        page = RetrievalPage()
+        self.created_pages.append(page)
+        return page
+
+    def close(self):
+        self.closed = True
+
+
+def test_browser_retrieval_combines_explicit_draft_and_published_tabs():
+    page = RetrievalPage()
+
+    result = hashnode_browser.retrieve_hashnode_articles(page=page)
+
+    assert result["success"] is True
+    assert result["diagnostics"]["errors"] == []
+    assert [(item["remote_id"], item["status"]) for item in result["articles"]] == [
+        ("draft-one", "draft"),
+        ("post-one", "published"),
+    ]
+    assert page.closed is False
+
 def test_public_publish_requires_final_confirmation(monkeypatch):
     page = FakePage()
     sync_api = SimpleNamespace(sync_playwright=lambda: PlaywrightManager(page))

--- a/tests/tests_backend/test_hashnode_sync.py
+++ b/tests/tests_backend/test_hashnode_sync.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from dataclasses import replace
 from datetime import datetime, timezone
 
-from backend.services.hashnode_sync import sync_hashnode_articles
+from backend.services.hashnode_sync import (
+    sync_hashnode_articles,
+    sync_hashnode_browser_records,
+)
 from backend.services.image_ingest import (
     ImageIngestReason,
     IngestedImage,
@@ -293,7 +296,7 @@ def test_same_remote_id_is_isolated_per_user(tmp_path):
 def test_manual_sync_endpoint_requires_pat_and_returns_typed_result(client, monkeypatch):
     missing = client.post("/api/connections/hashnode/sync")
     assert missing.status_code == 409
-    assert missing.json()["detail"]["error"] == "hashnode_pat_required"
+    assert missing.json()["detail"]["error"] == "hashnode_connection_required"
 
     from backend.routers import connections
     import backend.store as global_store
@@ -444,3 +447,124 @@ def test_sync_reports_revision_conflict_on_concurrent_user_edit(tmp_path):
         assert current["content"] == "User's local edit, not from Hashnode."
     finally:
         store.close()
+
+
+def test_browser_records_use_the_same_idempotent_sync_pipeline(tmp_path):
+    store = _store(tmp_path)
+    retrieval = {
+        "success": True,
+        "articles": [{
+            "remote_id": "browser-draft",
+            "title": "Browser draft",
+            "body": "# Browser draft\n\nRetrieved content.\n",
+            "status": "draft",
+            "subtitle": "Retrieved without GraphQL",
+            "canonical_url": None,
+            "updated_at": "2026-08-20T08:00:00Z",
+            "created_at": "2026-08-19T08:00:00Z",
+            "cover_url": None,
+            "metadata": {"url": None},
+        }],
+        "diagnostics": {"errors": []},
+    }
+    try:
+        first = sync_hashnode_browser_records(
+            store.SEED_USER_ID, retrieval, store=store,
+        )
+        second = sync_hashnode_browser_records(
+            store.SEED_USER_ID, retrieval, store=store,
+        )
+
+        assert first["imported"] == 1
+        assert second["unchanged"] == 1
+        article_id = first["articles"][0]["articleId"]
+        identity = store.get_remote_article_identity(
+            store.SEED_USER_ID, "hashnode", "browser-draft",
+        )
+        assert identity["article_id"] == article_id
+        assert identity["remote_created_at"] == "2026-08-19T08:00:00Z"
+        assert len(store.list_article_revisions(store.SEED_USER_ID, article_id)) == 1
+    finally:
+        store.close()
+
+
+def test_browser_record_failures_are_partial_and_article_scoped(tmp_path):
+    store = _store(tmp_path)
+    try:
+        result = sync_hashnode_browser_records(
+            store.SEED_USER_ID,
+            {
+                "articles": [],
+                "errors": [{
+                    "source": "drafts",
+                    "remote_id": "unreadable-draft",
+                    "error": "article_retrieval_failed",
+                }],
+            },
+            store=store,
+        )
+
+        assert result["status"] == "partial"
+        assert result["failed"] == 1
+        assert result["articles"][0]["remoteId"] == "unreadable-draft"
+        assert result["articles"][0]["error"] == "article_retrieval_failed"
+    finally:
+        store.close()
+
+
+def test_manual_endpoint_prefers_connected_browser_profile(client, monkeypatch):
+    from backend.routers import connections
+    import backend.store as global_store
+
+    user_id = global_store._backend.SEED_USER_ID
+    global_store.start_browser_connection(
+        user_id,
+        "hashnode",
+        session_id="bs_test",
+        organization_id="o_test",
+        app_url="http://localhost/browser",
+        profile_id="bp_test",
+    )
+    global_store.update_browser_connection(
+        user_id, "hashnode", "connected", profile_id="bp_test",
+    )
+    global_store.save_connection(user_id, "hashnode", "pro-token")
+    retrieval = {"articles": [], "errors": []}
+    called = []
+
+    def retrieve(**kwargs):
+        called.append(kwargs)
+        return retrieval
+
+    monkeypatch.setattr(connections.runner, "hashnode_browser_articles", retrieve)
+    monkeypatch.setattr(
+        connections,
+        "sync_hashnode_browser_records",
+        lambda received_user_id, received: {
+            "status": "succeeded",
+            "startedAt": "2026-08-20T08:00:00Z",
+            "completedAt": "2026-08-20T08:00:01Z",
+            "fetched": 0,
+            "imported": 0,
+            "updated": 0,
+            "metadataUpdated": 0,
+            "unchanged": 0,
+            "failed": 0,
+            "imagesDownloaded": 0,
+            "imagesFailed": 0,
+            "sourceErrors": [],
+            "articles": [],
+        },
+    )
+    monkeypatch.setattr(
+        connections,
+        "sync_hashnode_articles",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("Pro API should not run when browser login is connected")
+        ),
+    )
+
+    response = client.post("/api/connections/hashnode/sync")
+
+    assert response.status_code == 200
+    assert called == [{"organization_id": "o_test", "profile_id": "bp_test"}]

--- a/tests/tests_ui/screens/test_settings.py
+++ b/tests/tests_ui/screens/test_settings.py
@@ -166,7 +166,7 @@ def test_hashnode_browser_login_opens_normal_tab(settings_page, context):
     assert login_tab.is_closed()
 
 
-def test_hashnode_connected_card_only_offers_disconnect(page):
+def test_hashnode_connected_card_offers_sync_and_disconnect(page):
     page.request.post(
         f"{BASE_URL}/api/auth/login",
         data={"email": "seed@example.com", "password": "seed1234", "remember_me": False},
@@ -187,10 +187,45 @@ def test_hashnode_connected_card_only_offers_disconnect(page):
     card.get_by_text("Browser login · Persistent profile", exact=True).wait_for()
 
     actions = card.get_by_role("button")
-    assert actions.count() == 1
-    assert actions.first.inner_text() == "Disconnect"
+    assert actions.count() == 2
+    assert actions.nth(0).inner_text() == "Sync articles"
+    assert actions.nth(1).inner_text() == "Disconnect"
     assert card.get_by_text("Test", exact=True).count() == 0
     assert card.get_by_text("Refresh login", exact=True).count() == 0
+
+
+def test_hashnode_sync_action_reports_import_result(page):
+    page.request.post(
+        f"{BASE_URL}/api/auth/login",
+        data={"email": "seed@example.com", "password": "seed1234", "remember_me": False},
+    )
+    page.route(
+        f"{BASE_URL}/api/connections/hashnode/browser-connection",
+        lambda route: route.fulfill(json={
+            "platform": "hashnode",
+            "status": "connected",
+            "authorizationUrl": None,
+            "verifiedAt": "2026-08-19T00:00:00Z",
+            "error": None,
+        }),
+    )
+    page.route(
+        f"{BASE_URL}/api/connections/hashnode/sync",
+        lambda route: route.fulfill(json={
+            "status": "succeeded",
+            "fetched": 104,
+            "imported": 103,
+            "updated": 1,
+        }),
+    )
+
+    page.goto(SETTINGS_URL)
+    card = page.locator("#plat-card-hashnode")
+    card.get_by_role("button", name="Sync articles").click()
+
+    card.get_by_role("status").get_by_text(
+        "104 articles synced · 103 new · 1 updated",
+    ).wait_for()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- recover the non-Pro Hashnode synchronization that PR #72 merged into the already-landed feat/51 branch
- retrieve drafts and published articles through the persisted browser profile
- route browser records through the same atomic, conflict-safe synchronization pipeline as Pro API records
- expose manual synchronization in settings

## Verification
- focused Hashnode browser, synchronization, and settings suite: 25 passed
- full unit gate: 455 passed, 308 deselected
- PR #72 unit, contract, and Playwright checks passed

Closes #71