### PR TITLE
feat: add normalized Medium browser retrieval

### DIFF
--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -911,7 +911,14 @@ def list_drafts(
         raise HTTPException(status_code=404, detail=f"Unknown platform: {conn_id}")
 
     token = store.get_connection_token(user_id, conn_id)
-    if not token:
+    browser_connection = (
+        store.get_browser_connection(user_id, "medium")
+        if conn_id == "medium" else None
+    )
+    has_medium_browser = bool(
+        browser_connection and browser_connection["status"] == "connected"
+    )
+    if not token and not has_medium_browser:
         raise HTTPException(
             status_code=404,
             detail={
@@ -926,8 +933,14 @@ def list_drafts(
         elif conn_id == "devto":
             all_drafts = _fetch_devto_drafts(token)
         else:
-            # Medium: API does not support draft listing; use mock data
-            all_drafts = _MOCK_DRAFTS.get(conn_id, [])
+            if has_medium_browser:
+                all_drafts = runner.list_medium_browser_articles(
+                    organization_id=browser_connection["skyvern_organization_id"],
+                    profile_id=browser_connection["skyvern_profile_id"],
+                    limit=100,
+                )
+            else:
+                all_drafts = _MOCK_DRAFTS.get(conn_id, [])
     except HTTPException:
         raise
     except httpx.HTTPStatusError as exc:
@@ -971,7 +984,14 @@ def get_draft(request: Request, conn_id: str, draft_id: str):
         raise HTTPException(status_code=404, detail=f"Unknown platform: {conn_id}")
 
     token = store.get_connection_token(user_id, conn_id)
-    if not token:
+    browser_connection = (
+        store.get_browser_connection(user_id, "medium")
+        if conn_id == "medium" else None
+    )
+    has_medium_browser = bool(
+        browser_connection and browser_connection["status"] == "connected"
+    )
+    if not token and not has_medium_browser:
         raise HTTPException(
             status_code=404,
             detail={
@@ -997,7 +1017,13 @@ def get_draft(request: Request, conn_id: str, draft_id: str):
             return DraftContent(**draft)
 
         else:
-            # Medium: use mock data
+            if has_medium_browser:
+                article = runner.get_medium_browser_article(
+                    draft_id,
+                    organization_id=browser_connection["skyvern_organization_id"],
+                    profile_id=browser_connection["skyvern_profile_id"],
+                )
+                return DraftContent(**article)
             drafts = _MOCK_DRAFTS.get(conn_id, [])
             draft = next((d for d in drafts if d["id"] == draft_id), None)
             if draft is None:

--- a/backend/services/cli_runner.py
+++ b/backend/services/cli_runner.py
@@ -209,6 +209,58 @@ def hashnode_browser_articles(*, organization_id: str, profile_id: str) -> dict:
     )
 
 
+def list_medium_browser_articles(
+    *, organization_id: str, profile_id: str, limit: int = 100,
+) -> list[dict]:
+    result = browser_operation(
+        "medium",
+        "list_articles",
+        organization_id=organization_id,
+        profile_id=profile_id,
+        limit=limit,
+    )
+    if not result.get("success"):
+        raise RunnerUnavailable(result.get("error") or "Medium listing failed")
+    return [
+        {
+            "id": article["remote_id"],
+            "title": article["title"],
+            "snippet": article.get("subtitle") or "",
+            "status": article.get("status") or "draft",
+            "word_count": (article.get("metadata") or {}).get("word_count") or 0,
+            "updated_at": article.get("updated_at") or "",
+            "body": article.get("body") or "",
+            "cover_image": article.get("cover_url"),
+        }
+        for article in result.get("articles") or []
+    ]
+
+
+def get_medium_browser_article(
+    article_id: str, *, organization_id: str, profile_id: str,
+) -> dict:
+    result = browser_operation(
+        "medium",
+        "get_article",
+        organization_id=organization_id,
+        profile_id=profile_id,
+        remote_id=article_id,
+    )
+    if not result.get("success") or not result.get("article"):
+        raise RunnerUnavailable(result.get("error") or "Medium article retrieval failed")
+    article = result["article"]
+    return {
+        "id": article["remote_id"],
+        "title": article["title"],
+        "word_count": len((article.get("body") or "").split()),
+        "updated_at": article.get("updated_at") or "",
+        "status": article.get("status") or "draft",
+        "body": article.get("body") or "",
+        "canonical_url": article.get("canonical_url"),
+        "cover_image": article.get("cover_url"),
+    }
+
+
 def start_browser_login(platform: str, profile_id: str | None = None) -> dict:
     if profile_id:
         return _post(f"/browser/{platform}/login", profile_id=profile_id)

--- a/cli-runner/blog_extensions/builtin/medium.py
+++ b/cli-runner/blog_extensions/builtin/medium.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from medium_browser import check_medium_profile
+from medium_browser import (
+    check_medium_profile,
+    get_medium_article,
+    list_medium_articles,
+)
 
 from ..contracts import (
     BlogOperationsAdapter,
@@ -22,10 +26,14 @@ class MediumLoginAdapter(BrowserLoginAdapter):
 
 
 class MediumOperationsAdapter(BlogOperationsAdapter):
-    """Capability placeholder for the Medium implementation tracked by #43/#67."""
-
     platform = "medium"
-    capabilities = frozenset()
+    capabilities = frozenset({Capability.LIST_ARTICLES, Capability.GET_ARTICLE})
 
     def execute(self, page, operation: Capability, request: OperationRequest) -> dict:
+        if operation == Capability.LIST_ARTICLES:
+            return list_medium_articles(page=page, limit=request.limit)
+        if operation == Capability.GET_ARTICLE:
+            if not request.remote_id:
+                raise ValueError("Medium get_article requires a remote_id")
+            return get_medium_article(page=page, article_id=request.remote_id)
         raise OperationNotSupported(self.platform, operation.value)

--- a/cli-runner/blog_extensions/contracts.py
+++ b/cli-runner/blog_extensions/contracts.py
@@ -54,6 +54,7 @@ class OperationRequest:
 
 
 class RemoteArticle(TypedDict):
+    platform: str
     remote_id: str
     title: str
     body: str

--- a/cli-runner/blog_extensions/manifests/medium/bloghub_extension.toml
+++ b/cli-runner/blog_extensions/manifests/medium/bloghub_extension.toml
@@ -4,7 +4,7 @@ id = "bloghub.medium"
 platform = "medium"
 display_name = "Medium"
 version = "1.0.0"
-capabilities = []
+capabilities = ["list_articles", "get_article"]
 
 [entrypoints]
 login = "blog_extensions.builtin.medium:MediumLoginAdapter"

--- a/cli-runner/hashnode_browser.py
+++ b/cli-runner/hashnode_browser.py
@@ -91,6 +91,7 @@ def _browser_article(payload: dict, *, remote_id: str, published: bool) -> dict:
     if not title and not published:
         title = f"Untitled Hashnode draft ({remote_id[:8]})"
     return {
+        "platform": "hashnode",
         "remote_id": str(payload.get("cuid") or payload.get("_id") or remote_id),
         "title": title,
         "body": str(payload.get("contentMarkdown") or ""),

--- a/cli-runner/medium_browser.py
+++ b/cli-runner/medium_browser.py
@@ -3,11 +3,180 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import re
 import sqlite3
 import time
 
 
 _CHROMIUM_EPOCH_OFFSET_SECONDS = 11_644_473_600
+_DRAFTS_URL = "https://medium.com/me/stories/drafts"
+_PUBLISHED_URL = "https://medium.com/me/stories/public"
+_ARTICLE_ID_RE = re.compile(r"[A-Za-z0-9_-]{6,64}")
+
+
+class MediumBrowserError(RuntimeError):
+    pass
+
+
+def _is_login_url(url: str) -> bool:
+    lowered = url.lower()
+    return any(part in lowered for part in ("/signin", "/m/signin", "/login"))
+
+
+def _list_source(page, *, status: str, url: str, limit: int) -> list[dict]:
+    page.goto(url, wait_until="domcontentloaded", timeout=60_000)
+    if _is_login_url(page.url):
+        raise MediumBrowserError("Medium browser session is not authenticated")
+
+    stable_rounds = 0
+    previous_count = -1
+    for _ in range(100):
+        count = page.locator("h2").count()
+        stable_rounds = stable_rounds + 1 if count == previous_count else 0
+        if count >= limit or stable_rounds >= 2:
+            break
+        previous_count = count
+        page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+        page.wait_for_timeout(500)
+
+    return page.evaluate(
+        r"""({status, limit}) => Array.from(document.querySelectorAll('h2')).map((heading) => {
+          const container = heading.closest('article') || heading.parentElement?.parentElement?.parentElement;
+          const root = container || heading.parentElement;
+          const links = Array.from(root?.querySelectorAll('a[href]') || []);
+          const edit = links.find((link) => /\/p\/[a-z0-9_-]+\/edit/i.test(link.href));
+          const storyLink = heading.closest('a[href]') || links.find((link) => link.innerText.trim() === heading.innerText.trim());
+          const publicLink = storyLink || links.find((link) => link.href.includes('medium.com/') && !link.href.includes('/me/stories'));
+          const idMatch = edit?.href.match(/\/p\/([a-z0-9_-]+)\/edit/i);
+          const publicId = publicLink?.href.match(/-([a-f0-9]{12})(?:[/?#]|$)/i)?.[1];
+          const dataId = container?.getAttribute('data-post-id') || container?.querySelector('[data-post-id]')?.getAttribute('data-post-id');
+          const remoteId = idMatch?.[1] || dataId || publicId || '';
+          const href = ((status === 'draft' ? edit : publicLink) || edit || publicLink)?.href?.split('?')[0] || '';
+          const text = (container?.innerText || '').replace(/\s+/g, ' ').trim();
+          const words = text.match(/\((\d+)\s+words\)/i);
+          const image = root?.querySelector('img[src]');
+          const time = root?.querySelector('time');
+          return {
+            platform: 'medium',
+            remote_id: remoteId,
+            title: heading.innerText.trim(),
+            body: '',
+            status,
+            subtitle: text.slice(0, 280),
+            canonical_url: status === 'published' ? href || null : null,
+            cover_url: image?.src || null,
+            updated_at: time?.dateTime || time?.getAttribute('datetime') || null,
+            metadata: {url: href || null, word_count: words ? Number(words[1]) : 0},
+          };
+        }).filter((item) => item.remote_id && item.title).slice(0, limit)""",
+        {"status": status, "limit": limit},
+    )
+
+
+def list_medium_articles(*, page, limit: int = 100) -> dict:
+    """List normalized Medium drafts and published stories without local writes."""
+    articles: dict[str, dict] = {}
+    errors: list[dict] = []
+    for status, url in (("draft", _DRAFTS_URL), ("published", _PUBLISHED_URL)):
+        try:
+            rows = _list_source(page, status=status, url=url, limit=limit)
+        except MediumBrowserError:
+            errors.append({"source": status, "error": "medium_login_required"})
+            continue
+        except Exception:
+            errors.append({"source": status, "error": "listing_retrieval_failed"})
+            continue
+        for row in rows:
+            remote_id = str(row.get("remote_id") or "")
+            if not remote_id:
+                continue
+            if remote_id not in articles or status == "published":
+                articles[remote_id] = row
+    failed = not articles and bool(errors)
+    return {
+        "success": not failed,
+        "articles": list(articles.values()),
+        "next_cursor": None,
+        **({"error": errors[0]["error"]} if failed else {}),
+        "diagnostics": {"errors": errors},
+    }
+
+
+def get_medium_article(*, page, article_id: str) -> dict:
+    """Retrieve one Medium article as normalized Markdown and metadata."""
+    if not _ARTICLE_ID_RE.fullmatch(article_id):
+        raise ValueError("Invalid Medium article id")
+    page.goto(
+        f"https://medium.com/p/{article_id}/edit",
+        wait_until="domcontentloaded",
+        timeout=60_000,
+    )
+    if _is_login_url(page.url):
+        raise MediumBrowserError("Medium browser session is not authenticated")
+    page.wait_for_timeout(1_000)
+    article = page.evaluate(
+        r"""(articleId) => {
+          const root = document.querySelector('.postArticle-content, article, [data-testid="richTextEditor"], .pw-editor, main [contenteditable="true"]');
+          if (!root) return null;
+          const clone = root.cloneNode(true);
+          const titleNode = clone.querySelector('h1, h2.graf--title, [data-testid="storyTitle"]');
+          const title = (titleNode?.innerText || document.title.replace(/^Editing /, '').replace(/ [\u2013-] Medium$/, '')).trim();
+          if (titleNode) titleNode.remove();
+          const render = (node) => {
+            if (node.nodeType === Node.TEXT_NODE) return node.textContent;
+            if (node.nodeType !== Node.ELEMENT_NODE) return '';
+            const tag = node.tagName.toLowerCase();
+            const inside = Array.from(node.childNodes).map(render).join('');
+            if (tag === 'img') return `![${node.alt || ''}](${node.src || ''})`;
+            if (tag === 'a') return `[${inside}](${node.href})`;
+            if (tag === 'strong' || tag === 'b') return `**${inside}**`;
+            if (tag === 'em' || tag === 'i') return `*${inside}*`;
+            if (tag === 'code' && node.parentElement?.tagName.toLowerCase() !== 'pre') return `\`${inside}\``;
+            if (tag === 'pre') return `\n\n\`\`\`\n${node.innerText}\n\`\`\`\n\n`;
+            if (tag === 'h2') return `\n\n## ${inside.trim()}\n\n`;
+            if (tag === 'h3') return `\n\n### ${inside.trim()}\n\n`;
+            if (tag === 'blockquote') return `\n\n> ${node.innerText.replace(/\n/g, '\n> ')}\n\n`;
+            if (tag === 'li') return `\n- ${inside.trim()}`;
+            if (tag === 'p' || tag === 'figure') return `\n\n${inside.trim()}\n\n`;
+            if (tag === 'br') return '\n';
+            return inside;
+          };
+          const stateText = Array.from(document.scripts).map((node) => node.textContent || '').find((text) => text.includes('canonicalUrl')) || '';
+          const read = (name) => stateText.match(new RegExp(`"${name}":"([^"]*)"`))?.[1] || '';
+          const number = (name) => Number(stateText.match(new RegExp(`"${name}":(\\d+)`))?.[1] || 0);
+          const jsonLd = Array.from(document.querySelectorAll('script[type="application/ld+json"]'))
+            .map((node) => { try { return JSON.parse(node.textContent); } catch (_) { return null; } })
+            .find((value) => value?.articleBody || value?.headline) || {};
+          const canonicalUrl = read('canonicalUrl') || read('mediumUrl') || jsonLd.url || '';
+          const jsonImage = typeof jsonLd.image === 'string' ? jsonLd.image : jsonLd.image?.url;
+          const cover = jsonImage || clone.querySelector('img[src]')?.src || null;
+          const domTags = Array.from(document.querySelectorAll('a[href*="/tag/"]')).map((node) => node.innerText.trim()).filter(Boolean);
+          const jsonTags = Array.isArray(jsonLd.keywords) ? jsonLd.keywords : String(jsonLd.keywords || '').split(',');
+          const tags = [...new Set([...domTags, ...jsonTags.map((tag) => tag.trim()).filter(Boolean)])];
+          const subtitle = document.querySelector('h2[data-testid="storySubtitle"], h2.graf--subtitle')?.innerText?.trim() || jsonLd.description || null;
+          const publishedMillis = number('latestPublishedAt');
+          return {
+            platform: 'medium',
+            remote_id: articleId,
+            title,
+            body: render(clone).replace(/\n{3,}/g, '\n\n').trim(),
+            status: number('latestPublishedAt') > 0 ? 'published' : 'draft',
+            subtitle,
+            canonical_url: canonicalUrl || null,
+            cover_url: cover,
+            tags,
+            updated_at: jsonLd.dateModified || read('updatedAt') || null,
+            published_at: jsonLd.datePublished || (publishedMillis ? new Date(publishedMillis).toISOString() : null),
+            metadata: {url: canonicalUrl || null},
+          };
+        }""",
+        article_id,
+    )
+    if not article or not article.get("title"):
+        raise MediumBrowserError("Medium article content was not found")
+    return {"success": True, "article": article}
+
+
 def check_medium_profile(*, profile_dir: str) -> dict:
     profile = Path(profile_dir)
     authenticated = _chromium_cookie_db_has_medium_session(profile)

--- a/tests/tests_backend/test_blog_extension_runner.py
+++ b/tests/tests_backend/test_blog_extension_runner.py
@@ -27,7 +27,9 @@ def test_runner_discovers_builtin_extension_capabilities():
     assert by_platform["hashnode"]["capabilities"] == [
         "create_draft", "list_articles", "publish",
     ]
-    assert by_platform["medium"]["capabilities"] == []
+    assert by_platform["medium"]["capabilities"] == [
+        "get_article", "list_articles",
+    ]
 
 
 def test_login_dispatch_uses_extension_login_url(monkeypatch):

--- a/tests/tests_backend/test_blog_extensions.py
+++ b/tests/tests_backend/test_blog_extensions.py
@@ -35,7 +35,9 @@ def test_builtin_extensions_satisfy_the_versioned_contract():
     assert hashnode.manifest.capabilities == frozenset({
         Capability.LIST_ARTICLES, Capability.CREATE_DRAFT, Capability.PUBLISH,
     })
-    assert medium.manifest.capabilities == frozenset()
+    assert medium.manifest.capabilities == frozenset({
+        Capability.LIST_ARTICLES, Capability.GET_ARTICLE,
+    })
     assert [item["platform"] for item in registry.descriptors()] == [
         "hashnode", "medium",
     ]

--- a/tests/tests_backend/test_connections_drafts.py
+++ b/tests/tests_backend/test_connections_drafts.py
@@ -53,6 +53,20 @@ def _mock_response(json_data: Any, status_code: int = 200) -> MagicMock:
     return resp
 
 
+def _connect_medium_browser():
+    store.start_browser_connection(
+        "user_seed",
+        "medium",
+        session_id="pbs_medium_test",
+        organization_id="o_medium_test",
+        app_url="http://localhost/browser",
+        profile_id="bp_medium_test",
+    )
+    store.update_browser_connection(
+        "user_seed", "medium", "connected", profile_id="bp_medium_test",
+    )
+
+
 def _hashnode_gql_response(drafts: list[dict], posts: list[dict]) -> dict:
     """Build a fake Hashnode GraphQL response shaped like _fetch_hashnode_drafts expects."""
     return {
@@ -303,6 +317,38 @@ class TestListDraftsUnit:
         assert body["total"] == len(_MOCK_DRAFTS["medium"])
         assert len(body["drafts"]) > 0
 
+    def test_list_medium_uses_connected_browser_profile(
+        self, client: TestClient, monkeypatch,
+    ):
+        from backend.routers import connections
+
+        _connect_medium_browser()
+        seen = {}
+        monkeypatch.setattr(
+            connections.runner,
+            "list_medium_browser_articles",
+            lambda **kwargs: seen.update(kwargs) or [{
+                "id": "medium123abc",
+                "title": "Remote Medium story",
+                "snippet": "Retrieved through the browser extension",
+                "status": "draft",
+                "word_count": 42,
+                "updated_at": "2026-08-20T10:00:00Z",
+                "body": "",
+                "cover_image": None,
+            }],
+        )
+
+        response = client.get("/api/connections/medium/drafts")
+
+        assert response.status_code == 200
+        assert response.json()["drafts"][0]["id"] == "medium123abc"
+        assert seen == {
+            "organization_id": "o_medium_test",
+            "profile_id": "bp_medium_test",
+            "limit": 100,
+        }
+
 
 class TestGetDraftUnit:
 
@@ -414,6 +460,41 @@ class TestGetDraftUnit:
         body = r.json()
         assert body["id"] == first_id
         assert len(body["body"]) > 0
+
+    def test_get_medium_article_uses_connected_browser_profile(
+        self, client: TestClient, monkeypatch,
+    ):
+        from backend.routers import connections
+
+        _connect_medium_browser()
+        seen = {}
+
+        def retrieve(article_id, **kwargs):
+            seen.update(article_id=article_id, **kwargs)
+            return {
+                "id": article_id,
+                "title": "Remote Medium story",
+                "word_count": 5,
+                "updated_at": "2026-08-20T10:00:00Z",
+                "status": "published",
+                "body": "# Remote Medium story\n\nFull body.",
+                "canonical_url": "https://medium.com/@author/story-medium123abc",
+                "cover_image": None,
+            }
+
+        monkeypatch.setattr(
+            connections.runner, "get_medium_browser_article", retrieve,
+        )
+
+        response = client.get("/api/connections/medium/drafts/medium123abc")
+
+        assert response.status_code == 200
+        assert response.json()["body"].endswith("Full body.")
+        assert seen == {
+            "article_id": "medium123abc",
+            "organization_id": "o_medium_test",
+            "profile_id": "bp_medium_test",
+        }
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/tests_backend/test_hashnode_browser.py
+++ b/tests/tests_backend/test_hashnode_browser.py
@@ -217,6 +217,7 @@ def test_browser_article_normalizes_authenticated_hashnode_payload():
     )
 
     assert result == {
+        "platform": "hashnode",
         "remote_id": "post-cuid",
         "title": "Browser post",
         "body": "# Browser post\n",

--- a/tests/tests_backend/test_medium_browser.py
+++ b/tests/tests_backend/test_medium_browser.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import sqlite3
 import time
 
+import pytest
+
 
 RUNNER = Path(__file__).resolve().parents[2] / "cli-runner"
 spec = importlib.util.spec_from_file_location(
@@ -87,3 +89,133 @@ def test_profile_check_rejects_expired_chromium_medium_session(tmp_path):
     result = medium_browser.check_medium_profile(profile_dir=str(tmp_path))
 
     assert result == {"authenticated": False, "status": "login_required"}
+
+
+class _HeadingLocator:
+    def __init__(self, page):
+        self.page = page
+
+    def count(self):
+        return len(self.page.rows.get(self.page.status, []))
+
+
+class _MediumPage:
+    def __init__(self, *, rows=None, article=None, fail_status=None, login=False):
+        self.url = "about:blank"
+        self.status = "draft"
+        self.rows = rows or {"draft": [], "published": []}
+        self.article = article
+        self.fail_status = fail_status
+        self.login = login
+
+    def goto(self, url, **_kwargs):
+        self.status = "published" if url.endswith("/public") else "draft"
+        if self.status == self.fail_status:
+            raise RuntimeError("fixture listing failed")
+        self.url = "https://medium.com/m/signin" if self.login else url
+
+    def locator(self, _selector):
+        return _HeadingLocator(self)
+
+    def evaluate(self, script, argument=None):
+        if "window.scrollTo" in script:
+            return None
+        if isinstance(argument, dict):
+            return self.rows[argument["status"]][:argument["limit"]]
+        return self.article
+
+    def wait_for_timeout(self, _timeout):
+        return None
+
+
+def _summary(remote_id, status, title):
+    return {
+        "platform": "medium",
+        "remote_id": remote_id,
+        "title": title,
+        "body": "",
+        "status": status,
+        "subtitle": f"{title} summary",
+        "canonical_url": f"https://medium.com/@author/{remote_id}" if status == "published" else None,
+        "cover_url": None,
+        "updated_at": "2026-08-20T10:00:00Z",
+        "metadata": {"url": f"https://medium.com/p/{remote_id}/edit", "word_count": 12},
+    }
+
+
+def test_listing_normalizes_drafts_and_published_stories():
+    page = _MediumPage(rows={
+        "draft": [_summary("draft123abc", "draft", "Draft story")],
+        "published": [_summary("public123abc", "published", "Public story")],
+    })
+
+    result = medium_browser.list_medium_articles(page=page, limit=50)
+
+    assert result["success"] is True
+    assert result["next_cursor"] is None
+    assert result["diagnostics"] == {"errors": []}
+    assert [(item["remote_id"], item["status"]) for item in result["articles"]] == [
+        ("draft123abc", "draft"),
+        ("public123abc", "published"),
+    ]
+
+
+def test_listing_returns_partial_results_with_structured_source_error():
+    page = _MediumPage(
+        rows={
+            "draft": [_summary("draft123abc", "draft", "Draft story")],
+            "published": [],
+        },
+        fail_status="published",
+    )
+
+    result = medium_browser.list_medium_articles(page=page)
+
+    assert len(result["articles"]) == 1
+    assert result["diagnostics"]["errors"] == [{
+        "source": "published", "error": "listing_retrieval_failed",
+    }]
+
+
+def test_listing_reports_stale_browser_profile_as_failed_operation():
+    result = medium_browser.list_medium_articles(page=_MediumPage(login=True))
+
+    assert result["success"] is False
+    assert result["error"] == "medium_login_required"
+    assert result["articles"] == []
+    assert len(result["diagnostics"]["errors"]) == 2
+
+
+def test_detail_returns_normalized_article():
+    normalized = {
+        "platform": "medium",
+        "remote_id": "abc123def456",
+        "title": "A Medium story",
+        "body": "## Section\n\nBody with ![image](https://cdn.example/image.png)",
+        "status": "published",
+        "subtitle": "A subtitle",
+        "canonical_url": "https://example.com/canonical",
+        "cover_url": "https://cdn.example/cover.png",
+        "tags": ["Python"],
+        "updated_at": "2026-08-20T10:00:00Z",
+        "published_at": "2026-08-19T10:00:00Z",
+        "metadata": {"url": "https://example.com/canonical"},
+    }
+    page = _MediumPage(article=normalized)
+
+    result = medium_browser.get_medium_article(
+        page=page, article_id="abc123def456",
+    )
+
+    assert result == {"success": True, "article": normalized}
+    assert result["article"]["platform"] == "medium"
+    assert page.url == "https://medium.com/p/abc123def456/edit"
+
+
+def test_detail_rejects_invalid_remote_id_before_navigation():
+    page = _MediumPage()
+
+    with pytest.raises(ValueError, match="Invalid Medium article id"):
+        medium_browser.get_medium_article(page=page, article_id="../cookie")
+
+    assert page.url == "about:blank"


### PR DESCRIPTION
## Summary
- add normalized Medium list and article-detail operations to the browser extension SDK
- expose Medium browser retrieval through the existing connection draft APIs
- preserve the retrieval-only boundary: no local writes, revisions, image ingestion, or publishing
- keep Hashnode compatible with the shared platform-aware article contract

## Tests
- 49 focused backend/runner tests passed
- npm run check:contracts
- full backend unit suite: 480 passed before the final platform-contract compatibility pass

Closes #67