### PR TITLE
feat: sync Medium articles into local overview

### DIFF
--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -37,6 +37,7 @@ from backend.services.hashnode_sync import (
     sync_hashnode_articles,
     sync_hashnode_browser_records,
 )
+from backend.services.medium_sync import sync_medium_browser_records
 from backend.schemas.connections import (
     ActiveAgentAuthFlowsResponse,
     AgentAuthCallbackRequest,
@@ -47,6 +48,7 @@ from backend.schemas.connections import (
     DraftListResponse,
     DraftSummary,
     HashnodeSyncResponse,
+    MediumSyncResponse,
     OAuthStartResponse,
     SaveTokenRequest,
     SaveTokenResponse,
@@ -889,6 +891,29 @@ def sync_hashnode(request: Request):
             },
         )
     return sync_hashnode_articles(user_id, token)
+
+
+@router.post("/medium/sync", response_model=MediumSyncResponse)
+def sync_medium(request: Request):
+    """Import Medium stories through the connected browser profile."""
+    user_id: str = request.state.user_id
+    browser_connection = store.get_browser_connection(user_id, "medium")
+    if not browser_connection or browser_connection["status"] != "connected":
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "medium_browser_connection_required",
+                "message": "Connect Medium with browser login before synchronizing",
+            },
+        )
+    try:
+        retrieval = runner.medium_browser_articles(
+            organization_id=browser_connection["skyvern_organization_id"],
+            profile_id=browser_connection["skyvern_profile_id"],
+        )
+    except runner.RunnerUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return sync_medium_browser_records(user_id, retrieval)
 
 
 @router.get("/{conn_id}/drafts", response_model=DraftListResponse)

--- a/backend/schemas/connections.py
+++ b/backend/schemas/connections.py
@@ -146,3 +146,7 @@ class HashnodeSyncResponse(_CamelModel):
     images_failed: int
     source_errors: list[HashnodeSyncSourceError]
     articles: list[HashnodeSyncArticleResult]
+
+
+class MediumSyncResponse(HashnodeSyncResponse):
+    pass

--- a/backend/services/cli_runner.py
+++ b/backend/services/cli_runner.py
@@ -209,6 +209,75 @@ def hashnode_browser_articles(*, organization_id: str, profile_id: str) -> dict:
     )
 
 
+def medium_browser_articles(*, organization_id: str, profile_id: str) -> dict:
+    """Retrieve Medium listings and hydrate each record with article detail."""
+    listing = browser_operation(
+        "medium",
+        "list_articles",
+        organization_id=organization_id,
+        profile_id=profile_id,
+        limit=100,
+    )
+    if not listing.get("success"):
+        return listing
+
+    articles: list[dict] = []
+    errors = list((listing.get("diagnostics") or {}).get("errors") or [])
+    for summary in listing.get("articles") or []:
+        remote_id = str(summary.get("remote_id") or "")
+        if not remote_id:
+            errors.append({"source": "listing", "error": "invalid_article_record"})
+            continue
+        try:
+            detail = browser_operation(
+                "medium",
+                "get_article",
+                organization_id=organization_id,
+                profile_id=profile_id,
+                remote_id=remote_id,
+            )
+        except RunnerUnavailable:
+            errors.append({
+                "source": "article_detail",
+                "remote_id": remote_id,
+                "error": "article_retrieval_failed",
+            })
+            continue
+        if not detail.get("success") or not detail.get("article"):
+            errors.append({
+                "source": "article_detail",
+                "remote_id": remote_id,
+                "error": detail.get("error") or "article_retrieval_failed",
+            })
+            continue
+        detail_article = detail["article"]
+        summary_metadata = summary.get("metadata") or {}
+        detail_metadata = detail_article.get("metadata") or {}
+        hydrated = {
+            **summary,
+            **detail_article,
+            "subtitle": detail_article.get("subtitle") or summary.get("subtitle"),
+            "cover_url": detail_article.get("cover_url") or summary.get("cover_url"),
+            "updated_at": detail_article.get("updated_at") or summary.get("updated_at"),
+            "metadata": {
+                **summary_metadata,
+                **{
+                    key: value for key, value in detail_metadata.items()
+                    if value is not None
+                },
+            },
+        }
+        articles.append(hydrated)
+
+    return {
+        "success": bool(articles) or not errors,
+        "articles": articles,
+        "next_cursor": listing.get("next_cursor"),
+        "diagnostics": {"errors": errors},
+        **({"error": "medium_retrieval_failed"} if errors and not articles else {}),
+    }
+
+
 def list_medium_browser_articles(
     *, organization_id: str, profile_id: str, limit: int = 100,
 ) -> list[dict]:

--- a/backend/services/hashnode_sync.py
+++ b/backend/services/hashnode_sync.py
@@ -1,8 +1,9 @@
-"""Synchronous PAT-backed Hashnode-to-workspace synchronization."""
+"""Synchronous remote-blog-to-workspace synchronization."""
 from __future__ import annotations
 
 import hashlib
 import json
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Callable, Protocol
 
@@ -65,7 +66,21 @@ def _datetime(value: object) -> datetime | None:
         return None
 
 
-def _fingerprint(article: HashnodeRemoteArticle) -> str:
+@dataclass(frozen=True)
+class RemoteSyncArticle:
+    article_id: str
+    title: str
+    body_markdown: str
+    published: bool
+    url: str | None = None
+    canonical_url: str | None = None
+    subtitle: str | None = None
+    updated_at: datetime | None = None
+    cover_image_url: str | None = None
+    raw: dict = field(default_factory=dict)
+
+
+def _fingerprint(article: HashnodeRemoteArticle | RemoteSyncArticle) -> str:
     normalized = json.dumps(
         {"title": article.title.strip(), "markdown": article.body_markdown},
         ensure_ascii=False,
@@ -75,15 +90,15 @@ def _fingerprint(article: HashnodeRemoteArticle) -> str:
     return "sha256:" + hashlib.sha256(normalized).hexdigest()
 
 
-def _cover_filename(remote_id: str) -> str:
+def _cover_filename(platform: str, remote_id: str) -> str:
     digest = hashlib.sha256(remote_id.encode("utf-8")).hexdigest()[:16]
-    return f"hashnode-cover-{digest}.png"
+    return f"{platform}-cover-{digest}.png"
 
 
-def _safe_error_code(exc: Exception) -> str:
+def _safe_error_code(exc: Exception, platform: str = "hashnode") -> str:
     if isinstance(exc, RevisionConflict):
         return "revision_conflict"
-    return "hashnode_request_failed" if exc.__class__.__module__.startswith(
+    return f"{platform}_request_failed" if exc.__class__.__module__.startswith(
         ("requests", "httpx", "blogs.hashnode")
     ) else "article_sync_failed"
 
@@ -111,7 +126,8 @@ def _sync_cover(
     *,
     user_id: str,
     article_id: str,
-    remote: HashnodeRemoteArticle,
+    platform: str,
+    remote: HashnodeRemoteArticle | RemoteSyncArticle,
     identity: dict | None,
     store: HashnodeSyncStore,
     image_fetcher: Callable[[str], IngestedImage],
@@ -139,7 +155,7 @@ def _sync_cover(
     data = image.thumbnail_bytes or image.image_bytes
     if not data:
         return (identity or {}).get("cover_asset_id"), "failed", "decode_failed"
-    filename = _cover_filename(remote.article_id)
+    filename = _cover_filename(platform, remote.article_id)
     mime_type = "image/png" if image.thumbnail_bytes else image.content_type
     store.store_asset(user_id, article_id, filename, data, mime_type)
     asset = store.get_article_asset_by_filename(user_id, article_id, filename)
@@ -151,7 +167,8 @@ def _sync_cover(
 def _sync_article(
     *,
     user_id: str,
-    remote: HashnodeRemoteArticle,
+    platform: str,
+    remote: HashnodeRemoteArticle | RemoteSyncArticle,
     started_at: str,
     store: HashnodeSyncStore,
     image_fetcher: Callable[[str], IngestedImage],
@@ -162,7 +179,7 @@ def _sync_article(
 
     article, created = store.get_or_create_remote_article(
         user_id,
-        "hashnode",
+        platform,
         remote.article_id,
         title=remote.title,
         body=remote.body_markdown,
@@ -176,7 +193,7 @@ def _sync_article(
         action = "imported"
         revision_created = True
     else:
-        identity = store.get_remote_article_identity(user_id, "hashnode", remote.article_id)
+        identity = store.get_remote_article_identity(user_id, platform, remote.article_id)
         current = store.get_current_article_revision(user_id, article_id)
         content_changed = (
             identity is not None
@@ -198,7 +215,7 @@ def _sync_article(
                 title=remote.title,
                 content=remote.body_markdown,
                 source="remote-sync",
-                description="Synchronized from Hashnode",
+                description=f"Synchronized from {platform.title()}",
                 expected_revision_id=current["id"] if current else None,
             )
             revision_created = True
@@ -209,7 +226,7 @@ def _sync_article(
     metadata_changed = store.sync_remote_article_metadata(
         user_id,
         article_id,
-        platform="hashnode",
+        platform=platform,
         status="published" if remote.published else "draft",
         url=remote.url,
         remote_id=remote.article_id,
@@ -222,6 +239,7 @@ def _sync_article(
     cover_asset_id, image_status, image_error = _sync_cover(
         user_id=user_id,
         article_id=article_id,
+        platform=platform,
         remote=remote,
         identity=identity,
         store=store,
@@ -240,7 +258,7 @@ def _sync_article(
     store.upsert_remote_article_identity(
         user_id,
         article_id,
-        "hashnode",
+        platform,
         remote.article_id,
         remote_content_fingerprint=fingerprint,
         subtitle=remote.subtitle,
@@ -266,14 +284,15 @@ def _sync_article(
 
 def _sync_remote_articles(
     user_id: str,
-    remote_articles: list[HashnodeRemoteArticle],
+    remote_articles: list[HashnodeRemoteArticle | RemoteSyncArticle],
     source_errors: list[dict],
     *,
+    platform: str = "hashnode",
     store: HashnodeSyncStore = default_store,
     image_fetcher: Callable[[str], IngestedImage] = fetch_and_validate_image,
     failed_articles: list[dict] | None = None,
 ) -> dict[str, Any]:
-    """Synchronize normalized Hashnode records from any retrieval adapter."""
+    """Synchronize normalized records from any retrieval adapter."""
     started_at = _now().isoformat()
     article_results: list[dict] = list(failed_articles or [])
     counters = {
@@ -291,6 +310,7 @@ def _sync_remote_articles(
         try:
             result = _sync_article(
                 user_id=user_id,
+                platform=platform,
                 remote=remote,
                 started_at=started_at,
                 store=store,
@@ -304,7 +324,7 @@ def _sync_remote_articles(
                 "action": "failed",
                 "revisionCreated": False,
                 "imageStatus": "not_attempted",
-                "error": _safe_error_code(exc),
+                "error": _safe_error_code(exc, platform),
             }
         article_results.append(result)
         action_counter = {
@@ -369,7 +389,25 @@ def sync_hashnode_browser_records(
     image_fetcher: Callable[[str], IngestedImage] = fetch_and_validate_image,
 ) -> dict[str, Any]:
     """Synchronize records returned by the authenticated browser runner."""
-    remote_articles: list[HashnodeRemoteArticle] = []
+    return sync_browser_records(
+        user_id,
+        retrieval,
+        platform="hashnode",
+        store=store,
+        image_fetcher=image_fetcher,
+    )
+
+
+def sync_browser_records(
+    user_id: str,
+    retrieval: dict,
+    *,
+    platform: str,
+    store: HashnodeSyncStore = default_store,
+    image_fetcher: Callable[[str], IngestedImage] = fetch_and_validate_image,
+) -> dict[str, Any]:
+    """Synchronize normalized records returned by a browser extension."""
+    remote_articles: list[RemoteSyncArticle] = []
     source_errors: list[dict] = []
     failed_articles: list[dict] = []
     diagnostics = retrieval.get("diagnostics") or {}
@@ -400,7 +438,10 @@ def sync_hashnode_browser_records(
         try:
             metadata = record.get("metadata") or {}
             status = str(record.get("status") or "draft").lower()
-            remote_articles.append(HashnodeRemoteArticle(
+            record_platform = str(record.get("platform") or platform).lower()
+            if record_platform != platform:
+                raise ValueError("browser article platform mismatch")
+            remote_articles.append(RemoteSyncArticle(
                 article_id=str(record["remote_id"]),
                 title=str(record["title"]),
                 url=record.get("url") or metadata.get("url"),
@@ -424,6 +465,7 @@ def sync_hashnode_browser_records(
         user_id,
         remote_articles,
         source_errors,
+        platform=platform,
         store=store,
         image_fetcher=image_fetcher,
         failed_articles=failed_articles,

--- a/backend/services/medium_sync.py
+++ b/backend/services/medium_sync.py
@@ -1,0 +1,24 @@
+"""Medium browser retrieval to local-workspace synchronization."""
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import backend.store as default_store
+from backend.services.hashnode_sync import HashnodeSyncStore, sync_browser_records
+from backend.services.image_ingest import IngestedImage, fetch_and_validate_image
+
+
+def sync_medium_browser_records(
+    user_id: str,
+    retrieval: dict,
+    *,
+    store: HashnodeSyncStore = default_store,
+    image_fetcher: Callable[[str], IngestedImage] = fetch_and_validate_image,
+) -> dict[str, Any]:
+    return sync_browser_records(
+        user_id,
+        retrieval,
+        platform="medium",
+        store=store,
+        image_fetcher=image_fetcher,
+    )

--- a/screens/settings/v2.html
+++ b/screens/settings/v2.html
@@ -216,7 +216,10 @@ let _browserConnections = {
   hashnode: { platform: 'hashnode', status: 'disconnected' },
 };
 let _browserMethodMenus = { medium: false, hashnode: false };
-let _hashnodeSync = { status: 'idle', message: '' };
+const _platformSync = {
+  hashnode: { status: 'idle', message: '' },
+  medium: { status: 'idle', message: '' },
+};
 let _browserLoginTabs = {};
 let _browserLoginTabTimers = {};
 const _authTimers = new Map();
@@ -425,8 +428,10 @@ function browserPlatformCard(conn) {
   let actions = '';
   if (connected) {
     const connectedMethod = apiConnected && browserConnected ? 'both' : apiConnected ? 'api' : 'browser';
-    const syncAction = id === 'hashnode' ? `<button id="hashnode-sync" onclick="syncHashnodeArticles()" ${_hashnodeSync.status === 'running' ? 'disabled' : ''}
-      style="font-size:11px;padding:4px 10px;border-radius:4px;border:1px solid #252a38;background:transparent;color:#c9cfe0;cursor:${_hashnodeSync.status === 'running' ? 'wait' : 'pointer'};font-family:inherit;">${_hashnodeSync.status === 'running' ? 'Syncing…' : 'Sync articles'}</button>` : '';
+    const canSync = id === 'hashnode' ? connected : browserConnected;
+    const syncState = canSync ? _platformSync[id] : null;
+    const syncAction = syncState ? `<button id="${id}-sync" onclick="syncBrowserArticles('${id}')" ${syncState.status === 'running' ? 'disabled' : ''}
+      style="font-size:11px;padding:4px 10px;border-radius:4px;border:1px solid #252a38;background:transparent;color:#c9cfe0;cursor:${syncState.status === 'running' ? 'wait' : 'pointer'};font-family:inherit;">${syncState.status === 'running' ? 'Syncing…' : 'Sync articles'}</button>` : '';
     actions = `${syncAction}<button onclick="disconnectBrowserPlatformConnection('${id}', '${connectedMethod}')"
       style="font-size:11px;color:#f87171;background:transparent;border:none;cursor:pointer;font-family:inherit;">Disconnect</button>`;
   } else if (waiting) {
@@ -473,7 +478,7 @@ function browserPlatformCard(conn) {
             </div>
             ${method ? `<div style="font-size:11px;color:#c9cfe0;margin-top:3px;">${method}</div>` : ''}
             <div style="font-size:10px;color:#5a6080;margin-top:3px;">${helper}</div>
-            ${id === 'hashnode' && _hashnodeSync.message ? `<div role="status" style="font-size:10px;color:${_hashnodeSync.status === 'failed' ? '#f87171' : _hashnodeSync.status === 'partial' ? '#fbbf24' : '#71d892'};margin-top:3px;">${esc(_hashnodeSync.message)}</div>` : ''}
+            ${_platformSync[id]?.message ? `<div role="status" style="font-size:10px;color:${_platformSync[id].status === 'failed' ? '#f87171' : _platformSync[id].status === 'partial' ? '#fbbf24' : '#71d892'};margin-top:3px;">${esc(_platformSync[id].message)}</div>` : ''}
           </div>
         </div>
         <div style="display:flex;align-items:center;gap:8px;flex-shrink:0;">${actions}</div>
@@ -509,24 +514,25 @@ function chooseBrowserPlatformLogin(id) {
   startBrowserLogin(id);
 }
 
-async function syncHashnodeArticles() {
-  if (_hashnodeSync.status === 'running') return;
-  _hashnodeSync = { status: 'running', message: '' };
+async function syncBrowserArticles(id) {
+  const syncState = _platformSync[id];
+  if (!syncState || syncState.status === 'running') return;
+  _platformSync[id] = { status: 'running', message: '' };
   renderPlatforms(_connections.filter(c => c.type === 'blog'));
   try {
-    const res = await fetch('/api/connections/hashnode/sync', { method: 'POST' });
+    const res = await fetch(`/api/connections/${id}/sync`, { method: 'POST' });
     const data = await res.json();
     if (!res.ok) {
       const detail = data.detail;
       throw new Error(typeof detail === 'string' ? detail : detail?.message || detail?.error || `HTTP ${res.status}`);
     }
     const status = data.status === 'partial' ? 'partial' : 'succeeded';
-    _hashnodeSync = {
+    _platformSync[id] = {
       status,
       message: `${data.fetched} articles synced · ${data.imported} new · ${data.updated} updated`,
     };
   } catch (error) {
-    _hashnodeSync = { status: 'failed', message: error.message || 'Article sync failed' };
+    _platformSync[id] = { status: 'failed', message: error.message || 'Article sync failed' };
   }
   renderPlatforms(_connections.filter(c => c.type === 'blog'));
 }

--- a/tests/settings.spec.js
+++ b/tests/settings.spec.js
@@ -147,6 +147,39 @@ test.describe('Settings screen', () => {
     await expect(card.getByText('Test', { exact: true })).toHaveCount(0);
   });
 
+  test('[contract] connected Medium browser profile can sync articles', async ({ page }) => {
+    await page.route('**/api/connections/medium/browser-connection', route => route.fulfill({
+      json: {
+        platform: 'medium',
+        status: 'connected',
+        authorizationUrl: null,
+        verifiedAt: '2026-08-20T08:00:00Z',
+        error: null,
+      },
+    }));
+    await page.route('**/api/connections/medium/sync', route => route.fulfill({
+      json: {
+        status: 'succeeded',
+        fetched: 12,
+        imported: 10,
+        updated: 2,
+      },
+    }));
+    await page.reload();
+
+    const requestPromise = page.waitForRequest(
+      request => request.url().endsWith('/api/connections/medium/sync')
+        && request.method() === 'POST',
+    );
+    const card = page.locator('#plat-card-medium');
+    await card.getByRole('button', { name: 'Sync articles' }).click();
+    await requestPromise;
+
+    await expect(card.getByRole('status')).toHaveText(
+      '12 articles synced · 10 new · 2 updated',
+    );
+  });
+
   // ── 3. Browser login flow ────────────────────────────────────────────────────
 
   /**

--- a/tests/tests_backend/test_medium_sync.py
+++ b/tests/tests_backend/test_medium_sync.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import backend.store as global_store
+from backend.routers import connections
+from backend.services import cli_runner
+from backend.services.image_ingest import ImageIngestReason, IngestedImage
+from backend.services.medium_sync import sync_medium_browser_records
+from backend.store.backends.sqlite import SQLiteStore
+
+
+def _store(tmp_path) -> SQLiteStore:
+    return SQLiteStore(str(tmp_path / "bloghub.db"), str(tmp_path / "blobs"))
+
+
+def _retrieval(*, body: str = "# Medium story\n\nBody.\n", cover: str | None = None):
+    return {
+        "success": True,
+        "articles": [{
+            "platform": "medium",
+            "remote_id": "medium-story-1",
+            "title": "Medium story",
+            "body": body,
+            "status": "published",
+            "subtitle": "A synchronized subtitle",
+            "canonical_url": "https://example.com/medium-story",
+            "cover_url": cover,
+            "created_at": "2026-08-20T08:00:00Z",
+            "updated_at": "2026-08-21T09:00:00Z",
+            "metadata": {"url": "https://medium.com/@writer/medium-story-1"},
+        }],
+        "diagnostics": {"errors": []},
+    }
+
+
+def _valid_image(_url: str) -> IngestedImage:
+    return IngestedImage(
+        ok=True,
+        content_type="image/jpeg",
+        image_bytes=b"full-image",
+        thumbnail_bytes=b"thumbnail",
+        thumbnail_format="PNG",
+    )
+
+
+def test_medium_sync_is_idempotent_and_creates_revision_only_for_content_change(tmp_path):
+    store = _store(tmp_path)
+    try:
+        first = sync_medium_browser_records(
+            store.SEED_USER_ID, _retrieval(), store=store,
+        )
+        second = sync_medium_browser_records(
+            store.SEED_USER_ID, _retrieval(), store=store,
+        )
+        changed = sync_medium_browser_records(
+            store.SEED_USER_ID,
+            _retrieval(body="# Medium story\n\nChanged body.\n"),
+            store=store,
+        )
+
+        assert first["imported"] == 1
+        assert second["unchanged"] == 1
+        assert changed["updated"] == 1
+        article_id = first["articles"][0]["articleId"]
+        assert changed["articles"][0]["articleId"] == article_id
+        revisions = store.list_article_revisions(store.SEED_USER_ID, article_id)
+        assert len(revisions) == 2
+        assert all(item["source"] == "remote-sync" for item in revisions)
+        identity = store.get_remote_article_identity(
+            store.SEED_USER_ID, "medium", "medium-story-1",
+        )
+        assert identity["subtitle"] == "A synchronized subtitle"
+        assert identity["remote_content_fingerprint"].startswith("sha256:")
+        assert identity["last_sync_status"] == "succeeded"
+    finally:
+        store.close()
+
+
+def test_medium_cover_is_local_and_failure_preserves_text_sync(tmp_path):
+    store = _store(tmp_path)
+    try:
+        success = sync_medium_browser_records(
+            store.SEED_USER_ID,
+            _retrieval(cover="https://cdn.example/medium.jpg"),
+            store=store,
+            image_fetcher=_valid_image,
+        )
+        article_id = success["articles"][0]["articleId"]
+        article = store.get_article(store.SEED_USER_ID, article_id)
+        assert article["preview_image_url"].startswith(
+            f"/api/articles/{article_id}/assets/"
+        )
+
+        changed = _retrieval(cover="https://cdn.example/new-medium.jpg")
+        changed["articles"][0]["updated_at"] = "2026-08-22T09:00:00Z"
+        partial = sync_medium_browser_records(
+            store.SEED_USER_ID,
+            changed,
+            store=store,
+            image_fetcher=lambda _url: IngestedImage(
+                ok=False, reason=ImageIngestReason.HTTP_ERROR,
+            ),
+        )
+        assert partial["status"] == "partial"
+        assert partial["imagesFailed"] == 1
+        assert store.get_article(
+            store.SEED_USER_ID, article_id,
+        )["preview_image_url"] == article["preview_image_url"]
+    finally:
+        store.close()
+
+
+def test_medium_sync_reports_article_detail_failure_and_isolates_users(tmp_path):
+    store = _store(tmp_path)
+    try:
+        retrieval = _retrieval()
+        retrieval["diagnostics"]["errors"] = [{
+            "source": "article_detail",
+            "remote_id": "unreadable-story",
+            "error": "article_retrieval_failed",
+        }]
+        first = sync_medium_browser_records(
+            store.SEED_USER_ID, retrieval, store=store,
+        )
+        other = store.create_user("medium-sync@example.com", "hash")
+        second = sync_medium_browser_records(other["id"], _retrieval(), store=store)
+
+        assert first["status"] == "partial"
+        assert first["failed"] == 1
+        assert first["articles"][0]["remoteId"] == "unreadable-story"
+        first_identity = store.get_remote_article_identity(
+            store.SEED_USER_ID, "medium", "medium-story-1",
+        )
+        second_identity = store.get_remote_article_identity(
+            other["id"], "medium", "medium-story-1",
+        )
+        assert first_identity["article_id"] != second_identity["article_id"]
+    finally:
+        store.close()
+
+
+def test_medium_runner_hydrates_listings_and_keeps_partial_failures(monkeypatch):
+    calls = []
+
+    def operation(_platform, operation_name, **kwargs):
+        calls.append((operation_name, kwargs.get("remote_id")))
+        if operation_name == "list_articles":
+            return {
+                "success": True,
+                "articles": [
+                    {
+                        "platform": "medium",
+                        "remote_id": "one",
+                        "title": "One",
+                        "subtitle": "Listing excerpt",
+                        "cover_url": "https://cdn.example/listing.jpg",
+                    },
+                    {"platform": "medium", "remote_id": "two", "title": "Two"},
+                ],
+                "diagnostics": {"errors": []},
+            }
+        if kwargs["remote_id"] == "two":
+            return {"success": False, "error": "content_missing"}
+        return {"success": True, "article": {
+            "platform": "medium",
+            "remote_id": "one",
+            "title": "One",
+            "body": "Hydrated body",
+            "status": "draft",
+            "subtitle": None,
+            "cover_url": None,
+            "metadata": {"url": "https://medium.com/p/one/edit"},
+        }}
+
+    monkeypatch.setattr(cli_runner, "browser_operation", operation)
+    result = cli_runner.medium_browser_articles(
+        organization_id="org", profile_id="profile",
+    )
+
+    assert result["success"] is True
+    assert result["articles"][0]["body"] == "Hydrated body"
+    assert result["articles"][0]["subtitle"] == "Listing excerpt"
+    assert result["articles"][0]["cover_url"] == "https://cdn.example/listing.jpg"
+    assert result["diagnostics"]["errors"] == [{
+        "source": "article_detail",
+        "remote_id": "two",
+        "error": "content_missing",
+    }]
+    assert calls == [("list_articles", None), ("get_article", "one"), ("get_article", "two")]
+
+
+def test_medium_manual_sync_endpoint_imports_into_overview(client, monkeypatch):
+    user_id = global_store._backend.SEED_USER_ID
+    global_store.start_browser_connection(
+        user_id,
+        "medium",
+        session_id="medium_sync",
+        organization_id="org_medium",
+        app_url="http://localhost/browser",
+        profile_id="profile_medium",
+    )
+    global_store.update_browser_connection(
+        user_id, "medium", "connected", profile_id="profile_medium",
+    )
+    retrieval = _retrieval()
+    monkeypatch.setattr(
+        connections.runner, "medium_browser_articles", lambda **_kwargs: retrieval,
+    )
+    monkeypatch.setattr(
+        connections,
+        "sync_medium_browser_records",
+        lambda received_user_id, received: sync_medium_browser_records(
+            received_user_id, received, store=global_store,
+        ),
+    )
+
+    response = client.post("/api/connections/medium/sync")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["imported"] == 1
+    article_id = payload["articles"][0]["articleId"]
+    overview = client.get("/api/articles").json()["items"]
+    article = next(item for item in overview if item["id"] == article_id)
+    assert article["sourcePlatform"] == "medium"
+    assert article["destinations"]["medium"]["status"] == "published"
+
+
+def test_medium_manual_sync_requires_connected_browser(client):
+    response = client.post("/api/connections/medium/sync")
+    assert response.status_code == 409
+    assert response.json()["detail"]["error"] == "medium_browser_connection_required"


### PR DESCRIPTION
## Summary
- hydrate normalized Medium listings with browser article-detail operations
- reuse the existing identity, optimistic revision, image-ingestion, and local asset pipeline for Medium
- add a manual authenticated Medium sync endpoint and settings action
- render synchronized Medium records through the existing local overview API without request-time Medium calls
- preserve Hashnode behavior through the now platform-aware browser sync engine

## Verification
- 486 unit tests passed; 308 integration/browser tests deselected by the unit gate
- 56 focused retrieval/sync compatibility tests passed
- 11 Playwright tests passed; 1 live OAuth test skipped
- npm run check:contracts

Closes #66