### PR TITLE
feat: reconcile local and remote article changes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
-from backend.routers import agent, agent_sessions, articles, comments, connections, dev, jobs, patches, platforms
+from backend.routers import agent, agent_sessions, articles, comments, connections, dev, jobs, patches, platforms, reconciliation
 from backend.routers import auth as auth_router
 from backend.middleware.auth import AuthMiddleware
 from backend.security import install_secret_redaction
@@ -55,6 +55,7 @@ app.include_router(auth_router.router)
 app.include_router(agent.router)
 app.include_router(agent_sessions.router)
 app.include_router(articles.router)
+app.include_router(reconciliation.router)
 app.include_router(comments.router)
 app.include_router(patches.router)
 app.include_router(connections.router)

--- a/backend/routers/articles.py
+++ b/backend/routers/articles.py
@@ -28,6 +28,7 @@ import backend.store as store
 import backend.services.cli_runner as runner
 import backend.services.browser_publish as browser_publish
 from backend.services.push import push_article_to_platforms
+from backend.services.hashnode_sync import RemoteSyncArticle, _fingerprint
 from backend.store.article_revisions import RevisionConflict
 
 router = APIRouter(prefix="/api/articles", tags=["articles"])
@@ -508,6 +509,14 @@ def push_article(request: Request, article_id: str, body: dict = {}):
         raise HTTPException(status_code=404, detail="Article not found")
 
     platforms = body.get("platforms", list(article["destinations"].keys()))
+    if store.has_unresolved_reconciliation(user_id, article_id, platforms):
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "remote_content_conflict",
+                "message": "Resolve remote article conflicts before pushing.",
+            },
+        )
     store.set_destinations_pending(user_id, article_id, platforms)
     job = store.create_job(user_id, "push", article_id)
 
@@ -528,6 +537,45 @@ def push_article(request: Request, article_id: str, body: dict = {}):
             label=result.label,
             draft_id=result.draft_id,
         )
+        if result.success and result.draft_id and platform in {"hashnode", "devto"}:
+            revision = store.get_current_article_revision(user_id, article_id)
+            if revision is not None:
+                fingerprint = _fingerprint(RemoteSyncArticle(
+                    article_id=result.draft_id,
+                    title=revision["title"],
+                    body_markdown=revision["content"],
+                    published=result.status == "published",
+                ))
+                existing = store.get_remote_article_identity(
+                    user_id, platform, result.draft_id,
+                )
+                store.upsert_remote_article_identity(
+                    user_id,
+                    article_id,
+                    platform,
+                    result.draft_id,
+                    remote_content_fingerprint=fingerprint,
+                    subtitle=(existing or {}).get("subtitle"),
+                    cover_asset_id=(existing or {}).get("cover_asset_id"),
+                    last_sync_status="succeeded",
+                    last_sync_result={"action": "pushed", "remoteStatus": result.status},
+                )
+                store.record_reconciliation_observation(
+                    user_id,
+                    article_id,
+                    platform,
+                    result.draft_id,
+                    local_revision_id=revision["id"],
+                    baseline_fingerprint=fingerprint,
+                    local_fingerprint=fingerprint,
+                    remote_fingerprint=fingerprint,
+                    availability="available",
+                    sync_state="in_sync",
+                    remote_title=revision["title"],
+                    remote_content=revision["content"],
+                    remote_url=result.url,
+                    remote_status=result.status,
+                )
         job_result[platform] = {
             "status": result.status,
             "label": result.label,

--- a/backend/routers/reconciliation.py
+++ b/backend/routers/reconciliation.py
@@ -1,0 +1,222 @@
+"""Remote comparison and explicit conflict resolution endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+import backend.services.cli_runner as runner
+import backend.store as store
+from backend.schemas.reconciliation import (
+    ReconciliationListResponse,
+    ReconciliationObservation,
+    ResolveReconciliationRequest,
+)
+from backend.services import reconciliation
+from backend.services.hashnode_sync import (
+    sync_browser_records,
+    sync_hashnode_articles,
+    sync_hashnode_browser_records,
+)
+from backend.services.medium_sync import sync_medium_browser_records
+from backend.store.article_revisions import RevisionConflict
+from blogs.devto.client import DevToClient, DevToError
+import requests
+
+
+router = APIRouter(prefix="/api/articles", tags=["reconciliation"])
+
+
+def _identity(user_id: str, article_id: str, platform: str) -> dict:
+    matches = [
+        item for item in store.list_article_remote_identities(user_id, article_id)
+        if item["platform"] == platform
+    ]
+    if not matches:
+        raise HTTPException(
+            status_code=409,
+            detail={"error": "remote_identity_required", "platform": platform},
+        )
+    return matches[0]
+
+
+def _refresh(user_id: str, article_id: str, platform: str) -> dict:
+    identity = _identity(user_id, article_id, platform)
+    browser = store.get_browser_connection(user_id, platform)
+    try:
+        if platform == "medium":
+            if not browser or browser["status"] != "connected":
+                raise HTTPException(409, "Connected Medium browser profile required")
+            retrieval = runner.medium_browser_articles(
+                organization_id=browser["skyvern_organization_id"],
+                profile_id=browser["skyvern_profile_id"],
+            )
+            result = sync_medium_browser_records(user_id, retrieval)
+        elif platform == "hashnode" and browser and browser["status"] == "connected":
+            retrieval = runner.hashnode_browser_articles(
+                organization_id=browser["skyvern_organization_id"],
+                profile_id=browser["skyvern_profile_id"],
+            )
+            result = sync_hashnode_browser_records(user_id, retrieval)
+        elif platform == "hashnode":
+            token = store.get_connection_token(user_id, "hashnode")
+            if not token or token == "cli_session":
+                raise HTTPException(409, "Connected Hashnode profile or token required")
+            result = sync_hashnode_articles(user_id, token)
+        elif platform == "devto":
+            token = store.get_connection_token(user_id, "devto")
+            if not token:
+                raise HTTPException(409, "Connected Dev.to API key required")
+            client = DevToClient(token)
+            records = []
+            for page_number in range(1, 101):
+                page = client.list_my_articles(per_page=100, page=page_number)
+                records.extend(page)
+                if len(page) < 100:
+                    break
+            retrieval = {"success": True, "articles": [{
+                "platform": "devto",
+                "remote_id": str(item.article_id),
+                "title": item.title,
+                "body": item.body_markdown,
+                "status": "published" if item.published else "draft",
+                "subtitle": item.description,
+                "canonical_url": item.canonical_url,
+                "cover_url": item.cover_image,
+                "updated_at": item.updated_at.isoformat() if item.updated_at else None,
+                "metadata": {"url": item.url},
+            } for item in records], "diagnostics": {"errors": []}}
+            result = sync_browser_records(user_id, retrieval, platform="devto")
+        else:
+            raise HTTPException(422, f"Reconciliation is not supported for {platform}")
+    except runner.RunnerUnavailable:
+        reconciliation.record_unavailable(
+            store,
+            user_id,
+            article_id,
+            identity,
+            availability="inaccessible",
+            error=f"{platform.title()} could not be reached.",
+        )
+        observation = store.get_latest_reconciliation_observation(
+            user_id, article_id, platform,
+        )
+        return reconciliation.current_view(
+            store, user_id, article_id, observation,
+        )
+    except (DevToError, requests.RequestException):
+        reconciliation.record_unavailable(
+            store,
+            user_id,
+            article_id,
+            identity,
+            availability="inaccessible",
+            error="Dev.to could not be reached.",
+        )
+        observation = store.get_latest_reconciliation_observation(
+            user_id, article_id, platform,
+        )
+        return reconciliation.current_view(
+            store, user_id, article_id, observation,
+        )
+
+    matching = next(
+        (item for item in result["articles"] if item["remoteId"] == identity["remote_id"]),
+        None,
+    )
+    if matching is None or matching.get("status") == "failed":
+        unavailable = result["status"] != "succeeded" or matching is not None
+        reconciliation.record_unavailable(
+            store,
+            user_id,
+            article_id,
+            identity,
+            availability="inaccessible" if unavailable else "deleted",
+            error=(
+                "The remote provider could not confirm this article."
+                if unavailable
+                else "The linked remote article no longer exists or is no longer visible."
+            ),
+        )
+    observation = store.get_latest_reconciliation_observation(
+        user_id, article_id, platform,
+    )
+    if observation is None:
+        raise HTTPException(502, "Remote refresh produced no comparison")
+    return reconciliation.current_view(store, user_id, article_id, observation)
+
+
+@router.get("/{article_id}/reconciliation", response_model=ReconciliationListResponse)
+def list_reconciliation(request: Request, article_id: str):
+    user_id = request.state.user_id
+    if store.get_article(user_id, article_id) is None:
+        raise HTTPException(404, "Article not found")
+    observations = store.list_latest_reconciliation_observations(user_id, article_id)
+    observed_platforms = {item["platform"] for item in observations}
+    revision = store.get_current_article_revision(user_id, article_id)
+    for identity in store.list_article_remote_identities(user_id, article_id):
+        if identity["platform"] in observed_platforms or revision is None:
+            continue
+        observations.append({
+            "id": f"identity:{identity['platform']}:{identity['remote_id']}",
+            "article_id": article_id,
+            "platform": identity["platform"],
+            "remote_id": identity["remote_id"],
+            "local_revision_id": revision["id"],
+            "baseline_fingerprint": identity.get("remote_content_fingerprint"),
+            "local_fingerprint": reconciliation.local_fingerprint(
+                revision, identity["remote_id"],
+            ),
+            "availability": "unknown",
+            "sync_state": "unknown",
+            "metadata": {},
+            "observed_at": identity.get("last_synced_at") or identity["updated_at"],
+        })
+    return ReconciliationListResponse(comparisons=[
+        ReconciliationObservation(**reconciliation.current_view(
+            store, user_id, article_id, item,
+        ))
+        for item in observations
+    ])
+
+
+@router.post(
+    "/{article_id}/reconciliation/{platform}/refresh",
+    response_model=ReconciliationObservation,
+)
+def refresh_reconciliation(request: Request, article_id: str, platform: str):
+    user_id = request.state.user_id
+    if store.get_article(user_id, article_id) is None:
+        raise HTTPException(404, "Article not found")
+    return ReconciliationObservation(**_refresh(user_id, article_id, platform))
+
+
+@router.post(
+    "/{article_id}/reconciliation/{platform}/resolve",
+    response_model=ReconciliationObservation,
+)
+def resolve_reconciliation(
+    request: Request,
+    article_id: str,
+    platform: str,
+    body: ResolveReconciliationRequest,
+):
+    user_id = request.state.user_id
+    try:
+        observation = reconciliation.resolve(
+            store,
+            user_id,
+            article_id,
+            platform,
+            body.action,
+            body.base_revision_id,
+        )
+    except RevisionConflict as exc:
+        raise HTTPException(status_code=409, detail={
+            "code": "revision_conflict",
+            "message": str(exc),
+            "current": exc.current,
+        }) from exc
+    except (KeyError, ValueError) as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return ReconciliationObservation(**reconciliation.current_view(
+        store, user_id, article_id, observation,
+    ))

--- a/backend/schemas/connections.py
+++ b/backend/schemas/connections.py
@@ -144,6 +144,7 @@ class HashnodeSyncResponse(_CamelModel):
     failed: int
     images_downloaded: int
     images_failed: int
+    conflicts: int = 0
     source_errors: list[HashnodeSyncSourceError]
     articles: list[HashnodeSyncArticleResult]
 

--- a/backend/schemas/reconciliation.py
+++ b/backend/schemas/reconciliation.py
@@ -1,0 +1,43 @@
+"""API contracts for local-versus-remote reconciliation."""
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
+
+
+class _Model(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+
+class ReconciliationObservation(_Model):
+    id: str
+    article_id: str
+    platform: str
+    remote_id: str
+    local_revision_id: str | None = None
+    current_revision_id: str | None = None
+    baseline_fingerprint: str | None = None
+    local_fingerprint: str
+    remote_fingerprint: str | None = None
+    availability: str
+    sync_state: str
+    remote_title: str | None = None
+    remote_content: str | None = None
+    canonical_url: str | None = None
+    remote_url: str | None = None
+    remote_status: str | None = None
+    remote_updated_at: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    error: str | None = None
+    observed_at: str
+
+
+class ReconciliationListResponse(_Model):
+    comparisons: list[ReconciliationObservation]
+
+
+class ResolveReconciliationRequest(_Model):
+    action: Literal["keep_local", "use_remote"]
+    base_revision_id: str

--- a/backend/services/hashnode_sync.py
+++ b/backend/services/hashnode_sync.py
@@ -44,6 +44,11 @@ class HashnodeSyncStore(Protocol):
         **kwargs,
     ) -> dict: ...
 
+    def record_reconciliation_observation(
+        self, user_id: str, article_id: str, platform: str, remote_id: str,
+        **kwargs,
+    ) -> dict: ...
+
 
 def _now() -> datetime:
     return datetime.now(timezone.utc)
@@ -188,13 +193,60 @@ def _sync_article(
     )
     article_id = article["id"]
 
+    identity = None if created else store.get_remote_article_identity(
+        user_id, platform, remote.article_id,
+    )
+    baseline_fingerprint = (identity or {}).get("remote_content_fingerprint") if not created else None
+    local_fingerprint = fingerprint
+    current = store.get_current_article_revision(user_id, article_id)
+    if current is not None:
+        local_fingerprint = _fingerprint(RemoteSyncArticle(
+            article_id=remote.article_id,
+            title=current["title"],
+            body_markdown=current["content"],
+            published=remote.published,
+        ))
+
+    if (
+        not created
+        and baseline_fingerprint
+        and local_fingerprint != baseline_fingerprint
+        and fingerprint != baseline_fingerprint
+        and local_fingerprint != fingerprint
+    ):
+        store.record_reconciliation_observation(
+            user_id,
+            article_id,
+            platform,
+            remote.article_id,
+            local_revision_id=current["id"] if current else None,
+            baseline_fingerprint=baseline_fingerprint,
+            local_fingerprint=local_fingerprint,
+            remote_fingerprint=fingerprint,
+            availability="available",
+            sync_state="conflict",
+            remote_title=remote.title,
+            remote_content=remote.body_markdown,
+            canonical_url=remote.canonical_url,
+            remote_url=remote.url,
+            remote_status="published" if remote.published else "draft",
+            remote_updated_at=remote_updated_at,
+            metadata={"subtitle": remote.subtitle, "coverUrl": remote.cover_image_url},
+        )
+        return {
+            "remoteId": remote.article_id,
+            "articleId": article_id,
+            "status": "conflict",
+            "action": "conflict",
+            "revisionCreated": False,
+            "imageStatus": "not_attempted",
+            "error": "remote_content_conflict",
+        }
+
     if created:
-        identity = None
         action = "imported"
         revision_created = True
     else:
-        identity = store.get_remote_article_identity(user_id, platform, remote.article_id)
-        current = store.get_current_article_revision(user_id, article_id)
         content_changed = (
             identity is not None
             and identity.get("remote_content_fingerprint") != fingerprint
@@ -271,6 +323,32 @@ def _sync_article(
         last_sync_started_at=started_at,
         last_synced_at=completed_at,
     )
+    latest_revision = store.get_current_article_revision(user_id, article_id)
+    reconciled_fingerprint = _fingerprint(RemoteSyncArticle(
+        article_id=remote.article_id,
+        title=latest_revision["title"],
+        body_markdown=latest_revision["content"],
+        published=remote.published,
+    )) if latest_revision else fingerprint
+    store.record_reconciliation_observation(
+        user_id,
+        article_id,
+        platform,
+        remote.article_id,
+        local_revision_id=latest_revision["id"] if latest_revision else None,
+        baseline_fingerprint=baseline_fingerprint,
+        local_fingerprint=reconciled_fingerprint,
+        remote_fingerprint=fingerprint,
+        availability="available",
+        sync_state="in_sync" if reconciled_fingerprint == fingerprint else "local_ahead",
+        remote_title=remote.title,
+        remote_content=remote.body_markdown,
+        canonical_url=remote.canonical_url,
+        remote_url=remote.url,
+        remote_status="published" if remote.published else "draft",
+        remote_updated_at=remote_updated_at,
+        metadata={"subtitle": remote.subtitle, "coverUrl": remote.cover_image_url},
+    )
     return {
         "remoteId": remote.article_id,
         "articleId": article_id,
@@ -303,6 +381,7 @@ def _sync_remote_articles(
         "failed": 0,
         "imagesDownloaded": 0,
         "imagesFailed": 0,
+        "conflicts": 0,
     }
 
     counters["failed"] = len(article_results)
@@ -337,6 +416,8 @@ def _sync_remote_articles(
             counters[action_counter] += 1
         if result["status"] == "failed":
             counters["failed"] += 1
+        elif result["status"] == "conflict":
+            counters["conflicts"] += 1
         if result["imageStatus"] == "downloaded":
             counters["imagesDownloaded"] += 1
         elif result["imageStatus"] == "failed":

--- a/backend/services/push.py
+++ b/backend/services/push.py
@@ -74,7 +74,12 @@ def _push_devto(article: dict, source_markdown: str, get_connection_token: Token
         published=False,
     )
     client = DevToClient(token)
-    result = client.publish_article(prepared.article)
+    existing_id = article.get("destinations", {}).get("devto", {}).get("draft_id")
+    result = (
+        client.update_article(int(existing_id), prepared.article)
+        if existing_id
+        else client.publish_article(prepared.article)
+    )
     return PushPlatformResult(
         platform="devto",
         success=True,
@@ -103,7 +108,12 @@ def _push_hashnode(article: dict, source_markdown: str, get_connection_token: To
         cover_image_url=_cover_image_url(article, "hashnode"),
         tags=("integration", "bloghub"),
     )
-    result = client.create_draft(prepared.draft)
+    existing_id = article.get("destinations", {}).get("hashnode", {}).get("draft_id")
+    result = (
+        client.update_draft(existing_id, prepared.draft)
+        if existing_id
+        else client.create_draft(prepared.draft)
+    )
     publication_url = _read_hashnode_publication_url(client, result.draft_id)
     preview_url = None
     if publication_url:
@@ -131,13 +141,15 @@ def _push_medium_placeholder(article: dict) -> PushPlatformResult:
 
 
 def _simulated_result(platform: str, article: dict) -> PushPlatformResult:
-    existing_url = article.get("destinations", {}).get(platform, {}).get("url")
+    destination = article.get("destinations", {}).get(platform, {})
+    existing_url = destination.get("url")
     return PushPlatformResult(
         platform=platform,
         success=True,
         status="draft",
         label="Draft",
         url=existing_url,
+        draft_id=destination.get("draft_id"),
     )
 
 

--- a/backend/services/reconciliation.py
+++ b/backend/services/reconciliation.py
@@ -1,0 +1,137 @@
+"""Classify and resolve local-versus-remote article divergence."""
+from __future__ import annotations
+
+from typing import Any
+
+from backend.services.hashnode_sync import RemoteSyncArticle, _fingerprint
+from backend.store.article_revisions import RevisionConflict
+
+
+def local_fingerprint(revision: dict, remote_id: str) -> str:
+    return _fingerprint(RemoteSyncArticle(
+        article_id=remote_id,
+        title=revision["title"],
+        body_markdown=revision["content"],
+        published=False,
+    ))
+
+
+def current_view(store: Any, user_id: str, article_id: str, observation: dict) -> dict:
+    revision = store.get_current_article_revision(user_id, article_id)
+    if revision is None:
+        raise KeyError(article_id)
+    fingerprint = local_fingerprint(revision, observation["remote_id"])
+    state = observation["sync_state"]
+    if observation["availability"] == "available":
+        if fingerprint == observation["remote_fingerprint"]:
+            state = "in_sync"
+        elif state == "in_sync":
+            state = "local_ahead"
+        elif state == "remote_ahead" and fingerprint != observation["local_fingerprint"]:
+            state = "conflict"
+    return {
+        **observation,
+        "local_fingerprint": fingerprint,
+        "current_revision_id": revision["id"],
+        "sync_state": state,
+    }
+
+
+def record_unavailable(
+    store: Any,
+    user_id: str,
+    article_id: str,
+    identity: dict,
+    *,
+    availability: str,
+    error: str,
+) -> dict:
+    revision = store.get_current_article_revision(user_id, article_id)
+    if revision is None:
+        raise KeyError(article_id)
+    return store.record_reconciliation_observation(
+        user_id,
+        article_id,
+        identity["platform"],
+        identity["remote_id"],
+        local_revision_id=revision["id"],
+        baseline_fingerprint=identity.get("remote_content_fingerprint"),
+        local_fingerprint=local_fingerprint(revision, identity["remote_id"]),
+        availability=availability,
+        sync_state="remote_deleted" if availability == "deleted" else "inaccessible",
+        error=error,
+    )
+
+
+def resolve(
+    store: Any,
+    user_id: str,
+    article_id: str,
+    platform: str,
+    action: str,
+    base_revision_id: str,
+) -> dict:
+    observation = store.get_latest_reconciliation_observation(
+        user_id, article_id, platform,
+    )
+    if observation is None or observation["availability"] != "available":
+        raise ValueError("No available remote observation can be resolved")
+    current = store.get_current_article_revision(user_id, article_id)
+    if current is None:
+        raise KeyError(article_id)
+    if current["id"] != base_revision_id:
+        raise RevisionConflict(current)
+
+    if action == "use_remote":
+        if observation["remote_title"] is None or observation["remote_content"] is None:
+            raise ValueError("Remote content is unavailable")
+        current = store.save_article_revision(
+            user_id,
+            article_id,
+            title=observation["remote_title"],
+            content=observation["remote_content"],
+            expected_revision_id=base_revision_id,
+            source="remote-sync",
+            description=f"Accepted remote {platform.title()} version",
+        )
+        identity = store.get_remote_article_identity(
+            user_id, platform, observation["remote_id"],
+        )
+        store.upsert_remote_article_identity(
+            user_id,
+            article_id,
+            platform,
+            observation["remote_id"],
+            remote_content_fingerprint=observation["remote_fingerprint"],
+            subtitle=(identity or {}).get("subtitle"),
+            cover_asset_id=(identity or {}).get("cover_asset_id"),
+            last_sync_status="succeeded",
+            last_sync_result={"action": "use_remote", "resolvedObservationId": observation["id"]},
+            last_sync_error=None,
+            remote_created_at=(identity or {}).get("remote_created_at"),
+            remote_updated_at=observation["remote_updated_at"],
+            last_sync_started_at=(identity or {}).get("last_sync_started_at"),
+            last_synced_at=observation["observed_at"],
+        )
+
+    fingerprint = local_fingerprint(current, observation["remote_id"])
+    state = "in_sync" if action == "use_remote" else "local_ahead"
+    return store.record_reconciliation_observation(
+        user_id,
+        article_id,
+        platform,
+        observation["remote_id"],
+        local_revision_id=current["id"],
+        baseline_fingerprint=observation["remote_fingerprint"],
+        local_fingerprint=fingerprint,
+        remote_fingerprint=observation["remote_fingerprint"],
+        availability="available",
+        sync_state=state,
+        remote_title=observation["remote_title"],
+        remote_content=observation["remote_content"],
+        canonical_url=observation["canonical_url"],
+        remote_url=observation["remote_url"],
+        remote_status=observation["remote_status"],
+        remote_updated_at=observation["remote_updated_at"],
+        metadata=observation["metadata"],
+    )

--- a/backend/store/__init__.py
+++ b/backend/store/__init__.py
@@ -132,6 +132,26 @@ def upsert_remote_article_identity(user_id: str, *a, **kw):
     return _backend.upsert_remote_article_identity(user_id, *a, **kw)
 
 
+def record_reconciliation_observation(user_id: str, *a, **kw):
+    return _backend.record_reconciliation_observation(user_id, *a, **kw)
+
+
+def get_reconciliation_observation(user_id: str, *a, **kw):
+    return _backend.get_reconciliation_observation(user_id, *a, **kw)
+
+
+def get_latest_reconciliation_observation(user_id: str, *a, **kw):
+    return _backend.get_latest_reconciliation_observation(user_id, *a, **kw)
+
+
+def list_latest_reconciliation_observations(user_id: str, *a, **kw):
+    return _backend.list_latest_reconciliation_observations(user_id, *a, **kw)
+
+
+def has_unresolved_reconciliation(user_id: str, *a, **kw):
+    return _backend.has_unresolved_reconciliation(user_id, *a, **kw)
+
+
 # ── Connections ───────────────────────────────────────────────────────────────
 
 

--- a/backend/store/backends/sqlite.py
+++ b/backend/store/backends/sqlite.py
@@ -35,6 +35,7 @@ from backend.store.connection_auth import ConnectionAuthStoreMixin
 from backend.store.browser_publish import BrowserPublishStoreMixin
 from backend.store.browser_connections import BrowserConnectionStoreMixin
 from backend.store.remote_articles import RemoteArticleStoreMixin
+from backend.store.reconciliation import ReconciliationStoreMixin
 from backend.store.schema import (
     SEED_USER_EMAIL as DEFAULT_SEED_USER_EMAIL,
     SEED_USER_HASH as DEFAULT_SEED_USER_HASH,
@@ -222,6 +223,7 @@ def _seed_articles() -> list[dict]:
 
 
 class SQLiteStore(
+    ReconciliationStoreMixin,
     RemoteArticleStoreMixin,
     BrowserConnectionStoreMixin,
     BrowserPublishStoreMixin,

--- a/backend/store/backups.py
+++ b/backend/store/backups.py
@@ -6,6 +6,7 @@ import json
 import os
 import shutil
 import sqlite3
+import time
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -23,6 +24,17 @@ class BackupError(RuntimeError):
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def _rename_verified_bundle(source: Path, target: Path) -> None:
+    for attempt in range(5):
+        try:
+            source.rename(target)
+            return
+        except PermissionError:
+            if attempt == 4:
+                raise
+            time.sleep(0.05 * (attempt + 1))
 
 
 def _sha256(path: Path) -> str:
@@ -91,6 +103,7 @@ def _database_summary(database_path: Path, blobs_path: Path) -> dict:
             "articles",
             "article_assets",
             "remote_article_identities",
+            "remote_reconciliation_observations",
             "article_revisions",
             "connections",
             "jobs",
@@ -189,7 +202,7 @@ def create_backup(
             json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )
         verify_backup(temporary)
-        temporary.rename(final)
+        _rename_verified_bundle(temporary, final)
         prune_backups(root, retain=retain)
         return final
     except Exception:

--- a/backend/store/base.py
+++ b/backend/store/base.py
@@ -187,6 +187,32 @@ class ArticleStore(Protocol):
     ) -> dict:
         ...
 
+    def record_reconciliation_observation(
+        self, user_id: str, article_id: str, platform: str, remote_id: str,
+        **kwargs: Any,
+    ) -> dict:
+        ...
+
+    def get_reconciliation_observation(
+        self, user_id: str, article_id: str, observation_id: str,
+    ) -> dict | None:
+        ...
+
+    def get_latest_reconciliation_observation(
+        self, user_id: str, article_id: str, platform: str,
+    ) -> dict | None:
+        ...
+
+    def list_latest_reconciliation_observations(
+        self, user_id: str, article_id: str,
+    ) -> list[dict]:
+        ...
+
+    def has_unresolved_reconciliation(
+        self, user_id: str, article_id: str, platforms: list[str] | None = None,
+    ) -> bool:
+        ...
+
     # ── Connections ──────────────────────────────────────────────────────────
 
     def list_connections(self, user_id: str) -> list[dict]:

--- a/backend/store/reconciliation.py
+++ b/backend/store/reconciliation.py
@@ -1,0 +1,118 @@
+"""Immutable local-versus-remote reconciliation observations."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import uuid
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _row(row) -> dict:
+    result = dict(row)
+    result["metadata"] = json.loads(result.pop("metadata_json") or "{}")
+    return result
+
+
+class ReconciliationStoreMixin:
+    def record_reconciliation_observation(
+        self,
+        user_id: str,
+        article_id: str,
+        platform: str,
+        remote_id: str,
+        **values,
+    ) -> dict:
+        identity = self.get_remote_article_identity(user_id, platform, remote_id)
+        if identity is None or identity["article_id"] != article_id:
+            raise KeyError("remote article identity not found")
+        observation_id = f"recon_{uuid.uuid4().hex[:12]}"
+        with self._workspace_lock.acquire(), self._con:
+            self._con.execute(
+                """INSERT INTO remote_reconciliation_observations (
+                       id, user_id, article_id, platform, remote_id,
+                       local_revision_id, baseline_fingerprint, local_fingerprint,
+                       remote_fingerprint, availability, sync_state, remote_title,
+                       remote_content, canonical_url, remote_url, remote_status,
+                       remote_updated_at, metadata_json, error, observed_at
+                   ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    observation_id,
+                    user_id,
+                    article_id,
+                    platform,
+                    remote_id,
+                    values.get("local_revision_id"),
+                    values.get("baseline_fingerprint"),
+                    values["local_fingerprint"],
+                    values.get("remote_fingerprint"),
+                    values.get("availability", "available"),
+                    values["sync_state"],
+                    values.get("remote_title"),
+                    values.get("remote_content"),
+                    values.get("canonical_url"),
+                    values.get("remote_url"),
+                    values.get("remote_status"),
+                    values.get("remote_updated_at"),
+                    json.dumps(values.get("metadata") or {}, sort_keys=True),
+                    values.get("error"),
+                    values.get("observed_at") or _now(),
+                ),
+            )
+        return self.get_reconciliation_observation(
+            user_id, article_id, observation_id,
+        )  # type: ignore[return-value]
+
+    def get_reconciliation_observation(
+        self, user_id: str, article_id: str, observation_id: str,
+    ) -> dict | None:
+        row = self._con.execute(
+            """SELECT * FROM remote_reconciliation_observations
+               WHERE id=? AND user_id=? AND article_id=?""",
+            (observation_id, user_id, article_id),
+        ).fetchone()
+        return _row(row) if row else None
+
+    def get_latest_reconciliation_observation(
+        self, user_id: str, article_id: str, platform: str,
+    ) -> dict | None:
+        row = self._con.execute(
+            """SELECT * FROM remote_reconciliation_observations
+               WHERE user_id=? AND article_id=? AND platform=?
+               ORDER BY observed_at DESC, rowid DESC LIMIT 1""",
+            (user_id, article_id, platform),
+        ).fetchone()
+        return _row(row) if row else None
+
+    def list_latest_reconciliation_observations(
+        self, user_id: str, article_id: str,
+    ) -> list[dict]:
+        rows = self._con.execute(
+            """SELECT observation.*
+               FROM remote_reconciliation_observations observation
+               WHERE observation.user_id=? AND observation.article_id=?
+                 AND observation.rowid = (
+                   SELECT latest.rowid
+                   FROM remote_reconciliation_observations latest
+                   WHERE latest.user_id=observation.user_id
+                     AND latest.article_id=observation.article_id
+                     AND latest.platform=observation.platform
+                   ORDER BY latest.observed_at DESC, latest.rowid DESC LIMIT 1
+                 )
+               ORDER BY observation.platform""",
+            (user_id, article_id),
+        ).fetchall()
+        return [_row(row) for row in rows]
+
+    def has_unresolved_reconciliation(
+        self, user_id: str, article_id: str, platforms: list[str] | None = None,
+    ) -> bool:
+        latest = self.list_latest_reconciliation_observations(user_id, article_id)
+        selected = set(platforms or [])
+        return any(
+            item["sync_state"] == "conflict"
+            and (not selected or item["platform"] in selected)
+            for item in latest
+        )

--- a/backend/store/schema.py
+++ b/backend/store/schema.py
@@ -10,7 +10,7 @@ SEED_USER_HASH = "$2b$12$BJsbJlf3SZUMUISLA8oASeFn.Q3U.Ar6TqoIFtu0F9OlYyev.DZLC"
 
 # Bump for every released schema shape. Idempotent additions migrate in place;
 # destructive changes require an explicit migration and recovery plan.
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
 
 _SCHEMA_SQL_PATH = Path(__file__).resolve().parent / "sql" / "schema.sql"
 

--- a/backend/store/sql/schema.sql
+++ b/backend/store/sql/schema.sql
@@ -146,6 +146,34 @@ CREATE TABLE IF NOT EXISTS remote_article_identities (
         REFERENCES articles(id, user_id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS remote_reconciliation_observations (
+    id                    TEXT PRIMARY KEY,
+    user_id               TEXT NOT NULL,
+    article_id            TEXT NOT NULL,
+    platform              TEXT NOT NULL,
+    remote_id             TEXT NOT NULL,
+    local_revision_id     TEXT REFERENCES article_revisions(id) ON DELETE SET NULL,
+    baseline_fingerprint  TEXT,
+    local_fingerprint     TEXT NOT NULL,
+    remote_fingerprint    TEXT,
+    availability          TEXT NOT NULL,
+    sync_state            TEXT NOT NULL,
+    remote_title          TEXT,
+    remote_content        TEXT,
+    canonical_url         TEXT,
+    remote_url            TEXT,
+    remote_status         TEXT,
+    remote_updated_at     TEXT,
+    metadata_json         TEXT,
+    error                 TEXT,
+    observed_at           TEXT NOT NULL,
+    FOREIGN KEY (user_id, platform, remote_id)
+        REFERENCES remote_article_identities(user_id, platform, remote_id)
+        ON DELETE CASCADE,
+    FOREIGN KEY (article_id, user_id)
+        REFERENCES articles(id, user_id) ON DELETE CASCADE
+);
+
 CREATE TABLE IF NOT EXISTS article_comments (
     id          TEXT PRIMARY KEY,
     article_id  TEXT NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
@@ -321,6 +349,11 @@ CREATE INDEX IF NOT EXISTS idx_article_revisions_article
 
 CREATE INDEX IF NOT EXISTS idx_remote_articles_local_article
     ON remote_article_identities(user_id, article_id);
+
+CREATE INDEX IF NOT EXISTS idx_reconciliation_article_platform
+    ON remote_reconciliation_observations(
+        user_id, article_id, platform, observed_at DESC
+    );
 
 CREATE INDEX IF NOT EXISTS idx_article_comments_article
     ON article_comments(article_id);

--- a/blogs/hashnode/client.py
+++ b/blogs/hashnode/client.py
@@ -108,6 +108,39 @@ class HashnodeClient:
             raw=data,
         )
 
+    def update_draft(
+        self, draft_id: str, draft: HashnodeDraftInput,
+    ) -> HashnodeDraftResult:
+        """Update an existing draft so retries remain idempotent."""
+        mutation = """
+        mutation UpdateDraft($input: UpdateDraftInput!) {
+          updateDraft(input: $input) {
+            draft { id title canonicalUrl coverImage { url } }
+          }
+        }
+        """
+        input_payload = self._draft_payload(draft)
+        input_payload["id"] = draft_id
+        response = self._session.post(
+            "https://gql.hashnode.com",
+            headers=self.headers,
+            json={"query": mutation, "variables": {"input": input_payload}},
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+        if data.get("errors"):
+            raise HashnodeError(str(data["errors"]))
+        draft_data = data["data"]["updateDraft"]["draft"]
+        cover_image = draft_data.get("coverImage") or {}
+        return HashnodeDraftResult(
+            draft_id=str(draft_data["id"]),
+            title=draft_data.get("title"),
+            canonical_url=draft_data.get("canonicalUrl"),
+            cover_image_url=cover_image.get("url"),
+            raw=data,
+        )
+
     def list_drafts(self, *, first: int = 20) -> list[HashnodeRemoteArticle]:
         query = """
         query MeDrafts($first: Int!, $after: String) {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -10,7 +10,7 @@ const PYTHON_COMMAND = process.env.BLOGHUB_PLAYWRIGHT_PYTHON_COMMAND || `"${PYTH
 
 module.exports = defineConfig({
   testDir: './tests',
-  testMatch: ['settings.spec.js', 'overview-v3.spec.js'],
+  testMatch: ['settings.spec.js', 'overview-v3.spec.js', 'editor.spec.js'],
   outputDir: './tests/results/artifacts',
   timeout: 15_000,
   retries: 0,

--- a/screens/editor/v2.html
+++ b/screens/editor/v2.html
@@ -246,6 +246,15 @@
       </div>
 
       <div class="acc-section">
+        <div class="acc-hdr" onclick="toggleSection('reconciliation')">
+          <svg class="acc-chev closed" id="achev-reconciliation" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
+          <span>Remote changes</span>
+          <span id="reconciliation-badge" style="font-size:10px;color:#5a6080;font-family:'JetBrains Mono',monospace;margin-left:auto;">0</span>
+        </div>
+        <div class="acc-body" id="abody-reconciliation" style="display:none;"></div>
+      </div>
+
+      <div class="acc-section">
         <div class="acc-hdr" onclick="toggleSection('chat')">
           <svg class="acc-chev closed" id="achev-chat" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="6 9 12 15 18 9"/></svg>
           <span>Chat</span>
@@ -327,12 +336,13 @@ let CURRENT_REVISION_NUMBER = 0;
 let REVISIONS = [];
 let HISTORY_DIFF = null;
 let PENDING_CONFLICT = null;
+let RECONCILIATION = [];
 
 
 
 
 // ── State ─────────────────────────────────────────────────────────────────────
-const accOpen = { comments:true, patches:false, history:false, destinations:false, chat:false, rules:false };
+const accOpen = { comments:true, patches:false, history:false, destinations:false, reconciliation:false, chat:false, rules:false };
 let leftOpen = window.innerWidth > 700;
 let previewOpen = true;
 let patchStates = {};
@@ -531,7 +541,7 @@ async function _pollJob(jobId) {
 // ── Left panel accordion ─────────────────────────────────────────────────────
 function toggleSection(id) {
   accOpen[id] = !accOpen[id];
-  if (id === 'chat' && accOpen[id]) collapseOtherSections(id);
+  if (['chat','reconciliation'].includes(id) && accOpen[id]) collapseOtherSections(id);
   const body = document.getElementById('abody-' + id);
   const chev = document.getElementById('achev-' + id);
   body.style.display = accOpen[id] ? '' : 'none';
@@ -541,7 +551,7 @@ function toggleSection(id) {
 
 function openSection(id) {
   if (!leftOpen) toggleLeft();
-  if (id === 'chat') collapseOtherSections(id);
+  if (['chat','reconciliation'].includes(id)) collapseOtherSections(id);
   if (!accOpen[id]) {
     accOpen[id] = true;
     document.getElementById('abody-' + id).style.display = '';
@@ -569,6 +579,7 @@ function renderSection(id) {
   else if (id === 'patches')      { el.innerHTML = buildPatches(); updatePatchBadge(); }
   else if (id === 'history')      el.innerHTML = buildHistory();
   else if (id === 'destinations') el.innerHTML = buildDestinations();
+  else if (id === 'reconciliation') el.innerHTML = buildReconciliation();
   else if (id === 'chat')         { el.innerHTML = buildChat(); const m=document.getElementById('chat-msgs'); if(m) m.scrollTop=9999; }
   else if (id === 'rules')        el.innerHTML = buildRules();
 }
@@ -793,6 +804,80 @@ function buildDestinations() {
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>Run inspection
       </button>
     </div>`;
+}
+
+function reconciliationLabel(state) {
+  return {
+    in_sync:'In sync', local_ahead:'Local changes', remote_ahead:'Remote changes',
+    conflict:'Conflict', remote_deleted:'Deleted remotely', inaccessible:'Unavailable'
+  }[state] || state;
+}
+
+function buildReconciliation() {
+  if (!RECONCILIATION.length) {
+    return '<div style="font-size:11px;color:#5a6080;padding:12px 0;">No linked remote versions.</div>';
+  }
+  return RECONCILIATION.map(item => {
+    const conflict = item.syncState === 'conflict';
+    const color = conflict ? '#f87171' : item.syncState === 'in_sync' ? '#4ade80' : '#fbbf24';
+    return `<div style="padding:10px 0;border-bottom:1px solid #252a38;">
+      <div style="display:flex;align-items:center;gap:7px;">
+        <span style="font-size:12px;font-weight:600;color:#e8eaf2;text-transform:capitalize;">${esc(item.platform)}</span>
+        <span style="font-size:10px;color:${color};">${esc(reconciliationLabel(item.syncState))}</span>
+        <button onclick="refreshReconciliation('${item.platform}')" class="icon-btn" title="Refresh remote version" aria-label="Refresh ${esc(item.platform)}" style="margin-left:auto;width:25px;height:25px;">
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.5 9a9 9 0 0 1 14.8-3.4L23 10M1 14l4.7 4.4A9 9 0 0 0 20.5 15"/></svg>
+        </button>
+      </div>
+      ${item.error ? `<div style="font-size:10px;color:#f87171;margin-top:5px;line-height:1.4;">${esc(item.error)}</div>` : ''}
+      ${conflict ? `<div style="margin-top:9px;">
+        <div style="font-size:9px;color:#737b98;text-transform:uppercase;margin-bottom:4px;">Local</div>
+        <pre style="height:90px;overflow:auto;margin:0 0 8px;padding:7px;background:#0d1019;border:1px solid #343a50;border-radius:4px;color:#c9cfe0;font:9px/1.4 'JetBrains Mono',monospace;white-space:pre-wrap;">${esc(document.getElementById('raw-editor').value)}</pre>
+        <div style="font-size:9px;color:#737b98;text-transform:uppercase;margin-bottom:4px;">Remote</div>
+        <pre style="height:90px;overflow:auto;margin:0;padding:7px;background:#0d1019;border:1px solid #4d3f2a;border-radius:4px;color:#c9cfe0;font:9px/1.4 'JetBrains Mono',monospace;white-space:pre-wrap;">${esc(item.remoteContent || '')}</pre>
+        <div style="display:flex;gap:6px;margin-top:8px;">
+          <button onclick="resolveReconciliation('${item.platform}','use_remote')" style="font-size:10px;padding:4px 8px;border-radius:4px;background:#6366f1;border:none;color:#fff;cursor:pointer;">Use remote</button>
+          <button onclick="resolveReconciliation('${item.platform}','keep_local')" style="font-size:10px;padding:4px 8px;border-radius:4px;background:transparent;border:1px solid #343a50;color:#c9cfe0;cursor:pointer;">Keep local</button>
+        </div>
+      </div>` : ''}
+    </div>`;
+  }).join('');
+}
+
+async function loadReconciliation() {
+  try {
+    const response = await fetch(`/api/articles/${ARTICLE_ID}/reconciliation`);
+    if (!response.ok) return;
+    RECONCILIATION = (await response.json()).comparisons;
+    const conflicts = RECONCILIATION.filter(item => item.syncState === 'conflict').length;
+    const badge = document.getElementById('reconciliation-badge');
+    badge.textContent = conflicts || RECONCILIATION.length;
+    badge.style.color = conflicts ? '#f87171' : '#5a6080';
+    if (accOpen.reconciliation || conflicts) {
+      if (conflicts) openSection('reconciliation');
+      else renderSection('reconciliation');
+    }
+  } catch (_e) {}
+}
+
+async function refreshReconciliation(platform) {
+  if (!(await saveDraft())) return;
+  const response = await fetch(`/api/articles/${ARTICLE_ID}/reconciliation/${platform}/refresh`, { method:'POST' });
+  if (!response.ok) return;
+  await loadReconciliation();
+}
+
+async function resolveReconciliation(platform, action) {
+  const response = await fetch(`/api/articles/${ARTICLE_ID}/reconciliation/${platform}/resolve`, {
+    method:'POST', headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({ action, base_revision_id:CURRENT_REVISION_ID }),
+  });
+  const data = await response.json();
+  if (response.status === 409 && data.detail?.code === 'revision_conflict') {
+    showConflict(data.detail.current); return;
+  }
+  if (!response.ok) return;
+  if (action === 'use_remote') await reloadArticleHead();
+  await loadReconciliation();
 }
 
 function buildChat() {
@@ -1197,6 +1282,7 @@ async function loadArticle() {
     await loadComments();
     await loadPatches();
     await loadRevisions();
+    await loadReconciliation();
     await loadChat();
     await loadConnectedProviders();
     await loadAgentSession();

--- a/tests/editor.spec.js
+++ b/tests/editor.spec.js
@@ -1,0 +1,51 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Article editor reconciliation', () => {
+  test('shows and resolves a remote content conflict', async ({ page }) => {
+    const conflict = {
+      id: 'recon_test',
+      articleId: 'art_001',
+      platform: 'medium',
+      remoteId: 'medium-1',
+      localRevisionId: 'rev_local',
+      currentRevisionId: 'rev_local',
+      baselineFingerprint: 'sha256:base',
+      localFingerprint: 'sha256:local',
+      remoteFingerprint: 'sha256:remote',
+      availability: 'available',
+      syncState: 'conflict',
+      remoteTitle: 'Remote title',
+      remoteContent: '# Remote title\n\nRemote edit.',
+      canonicalUrl: null,
+      remoteUrl: 'https://medium.com/p/medium-1/edit',
+      remoteStatus: 'draft',
+      remoteUpdatedAt: '2026-08-23T08:00:00Z',
+      metadata: {},
+      error: null,
+      observedAt: '2026-08-23T08:01:00Z',
+    };
+    await page.route('**/api/articles/art_001/reconciliation', route => route.fulfill({
+      json: { comparisons: [conflict] },
+    }));
+    await page.route('**/api/articles/art_001/reconciliation/medium/resolve', async route => {
+      const request = route.request();
+      expect(request.method()).toBe('POST');
+      expect(request.postDataJSON().action).toBe('keep_local');
+      conflict.syncState = 'local_ahead';
+      await route.fulfill({ json: conflict });
+    });
+
+    await page.goto('/screens/editor/v2.html?id=art_001');
+
+    const panel = page.locator('#abody-reconciliation');
+    await expect(panel).toBeVisible();
+    await expect(panel.getByText('Conflict', { exact: true })).toBeVisible();
+    await expect(panel.getByText('# Remote title')).toBeVisible();
+    const useRemote = panel.getByRole('button', { name: 'Use remote' });
+    await expect(useRemote).toBeVisible();
+    const buttonBox = await useRemote.boundingBox();
+    expect(buttonBox.y + buttonBox.height).toBeLessThanOrEqual(720);
+    await panel.getByRole('button', { name: 'Keep local' }).click();
+    await expect(panel.getByText('Local changes', { exact: true })).toBeVisible();
+  });
+});

--- a/tests/tests_backend/test_articles/test_push.py
+++ b/tests/tests_backend/test_articles/test_push.py
@@ -81,3 +81,37 @@ class TestPushArticle:
         item = next(i for i in client.get("/api/articles").json()["items"] if i["id"] == "art_001")
         assert item["destinations"]["hashnode"]["url"] == "https://hashnode.example/preview/123"
         assert item["destinations"]["devto"]["url"] == "https://dev.to/example/draft"
+
+
+def test_devto_retry_updates_linked_article_instead_of_creating(monkeypatch):
+    from backend.services import push
+
+    article = {
+        "id": "art_test",
+        "title": "Retryable",
+        "body": "# Retryable\n\nBody",
+        "destinations": {"devto": {"draft_id": "42", "url": "https://dev.to/test"}},
+    }
+    calls = []
+
+    class FakeClient:
+        def __init__(self, _token):
+            pass
+
+        def update_article(self, article_id, payload):
+            calls.append((article_id, payload.title))
+            return type("Result", (), {
+                "article_id": article_id,
+                "url": "https://dev.to/test",
+            })()
+
+        def publish_article(self, _payload):
+            raise AssertionError("retry created a duplicate article")
+
+    monkeypatch.setattr(push, "DevToClient", FakeClient)
+    result = push.push_article_to_platforms(
+        article, ["devto"], get_connection_token=lambda _: "secret",
+    )["devto"]
+
+    assert calls == [(42, "Retryable")]
+    assert result.draft_id == "42"

--- a/tests/tests_backend/test_reconciliation.py
+++ b/tests/tests_backend/test_reconciliation.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import backend.store as global_store
+from backend.services.hashnode_sync import RemoteSyncArticle, _fingerprint, sync_browser_records
+from backend.services import reconciliation
+from backend.store.article_revisions import RevisionConflict
+from backend.store.backends.sqlite import SQLiteStore
+
+
+def _store(tmp_path) -> SQLiteStore:
+    return SQLiteStore(str(tmp_path / "bloghub.db"), str(tmp_path / "blobs"))
+
+
+def _retrieval(body: str) -> dict:
+    return {
+        "success": True,
+        "articles": [{
+            "platform": "medium",
+            "remote_id": "remote-1",
+            "title": "Remote title",
+            "body": body,
+            "status": "draft",
+            "updated_at": "2026-08-23T08:00:00Z",
+            "metadata": {"url": "https://medium.com/p/remote-1/edit"},
+        }],
+        "diagnostics": {"errors": []},
+    }
+
+
+def _conflict(store: SQLiteStore) -> tuple[str, dict]:
+    first = sync_browser_records(
+        store.SEED_USER_ID,
+        _retrieval("# Remote title\n\nShared baseline.\n"),
+        platform="medium",
+        store=store,
+    )
+    article_id = first["articles"][0]["articleId"]
+    current = store.get_current_article_revision(store.SEED_USER_ID, article_id)
+    store.save_article_revision(
+        store.SEED_USER_ID,
+        article_id,
+        title="Local title",
+        content="# Local title\n\nLocal edit.\n",
+        source="user",
+        expected_revision_id=current["id"],
+    )
+    result = sync_browser_records(
+        store.SEED_USER_ID,
+        _retrieval("# Remote title\n\nRemote edit.\n"),
+        platform="medium",
+        store=store,
+    )
+    return article_id, result
+
+
+def test_two_sided_change_records_conflict_without_overwriting_local_revision(tmp_path):
+    store = _store(tmp_path)
+    try:
+        article_id, result = _conflict(store)
+
+        assert result["status"] == "partial"
+        assert result["conflicts"] == 1
+        assert result["articles"][0]["error"] == "remote_content_conflict"
+        current = store.get_current_article_revision(store.SEED_USER_ID, article_id)
+        assert current["title"] == "Local title"
+        assert current["content"] == "# Local title\n\nLocal edit.\n"
+        observation = store.get_latest_reconciliation_observation(
+            store.SEED_USER_ID, article_id, "medium",
+        )
+        assert observation["sync_state"] == "conflict"
+        assert observation["remote_content"] == "# Remote title\n\nRemote edit.\n"
+        assert store.has_unresolved_reconciliation(
+            store.SEED_USER_ID, article_id, ["medium"],
+        ) is True
+    finally:
+        store.close()
+
+
+def test_use_remote_creates_revision_and_resolves_conflict(tmp_path):
+    store = _store(tmp_path)
+    try:
+        article_id, _ = _conflict(store)
+        current = store.get_current_article_revision(store.SEED_USER_ID, article_id)
+
+        resolved = reconciliation.resolve(
+            store,
+            store.SEED_USER_ID,
+            article_id,
+            "medium",
+            "use_remote",
+            current["id"],
+        )
+
+        assert resolved["sync_state"] == "in_sync"
+        latest = store.get_current_article_revision(store.SEED_USER_ID, article_id)
+        assert latest["content"] == "# Remote title\n\nRemote edit.\n"
+        assert latest["source"] == "remote-sync"
+        assert len(store.list_article_revisions(store.SEED_USER_ID, article_id)) == 3
+        assert not store.has_unresolved_reconciliation(
+            store.SEED_USER_ID, article_id, ["medium"],
+        )
+    finally:
+        store.close()
+
+
+def test_keep_local_resolves_without_creating_revision(tmp_path):
+    store = _store(tmp_path)
+    try:
+        article_id, _ = _conflict(store)
+        current = store.get_current_article_revision(store.SEED_USER_ID, article_id)
+        before = store.list_article_revisions(store.SEED_USER_ID, article_id)
+
+        resolved = reconciliation.resolve(
+            store,
+            store.SEED_USER_ID,
+            article_id,
+            "medium",
+            "keep_local",
+            current["id"],
+        )
+
+        assert resolved["sync_state"] == "local_ahead"
+        assert store.list_article_revisions(store.SEED_USER_ID, article_id) == before
+    finally:
+        store.close()
+
+
+def test_use_remote_rejects_stale_editor_revision(tmp_path):
+    store = _store(tmp_path)
+    try:
+        article_id, _ = _conflict(store)
+        stale = store.list_article_revisions(store.SEED_USER_ID, article_id)[-1]
+        try:
+            reconciliation.resolve(
+                store,
+                store.SEED_USER_ID,
+                article_id,
+                "medium",
+                "use_remote",
+                stale["id"],
+            )
+        except RevisionConflict:
+            pass
+        else:
+            raise AssertionError("stale conflict resolution should fail")
+    finally:
+        store.close()
+
+
+def test_push_endpoint_blocks_only_selected_platform_with_conflict(client):
+    user_id = global_store._backend.SEED_USER_ID
+    article_id = "art_001"
+    revision = global_store.get_current_article_revision(user_id, article_id)
+    global_store.upsert_remote_article_identity(
+        user_id,
+        article_id,
+        "medium",
+        "remote-push-conflict",
+        remote_content_fingerprint="sha256:baseline",
+    )
+    global_store.record_reconciliation_observation(
+        user_id,
+        article_id,
+        "medium",
+        "remote-push-conflict",
+        local_revision_id=revision["id"],
+        local_fingerprint="sha256:local",
+        remote_fingerprint="sha256:remote",
+        availability="available",
+        sync_state="conflict",
+    )
+
+    blocked = client.post(
+        f"/api/articles/{article_id}/push", json={"platforms": ["medium"]},
+    )
+    unrelated = client.post(
+        f"/api/articles/{article_id}/push", json={"platforms": ["devto"]},
+    )
+
+    assert blocked.status_code == 409
+    assert blocked.json()["detail"]["error"] == "remote_content_conflict"
+    assert unrelated.status_code == 202
+
+
+def test_observations_are_user_scoped(tmp_path):
+    store = _store(tmp_path)
+    try:
+        article_id, _ = _conflict(store)
+        other = store.create_user("reconciliation@example.com", "hash")
+        assert store.list_latest_reconciliation_observations(
+            other["id"], article_id,
+        ) == []
+        assert store.get_latest_reconciliation_observation(
+            other["id"], article_id, "medium",
+        ) is None
+    finally:
+        store.close()
+
+
+def test_reconciliation_api_lists_and_resolves_remote_conflict(client):
+    user_id = global_store._backend.SEED_USER_ID
+    article_id = "art_001"
+    revision = global_store.get_current_article_revision(user_id, article_id)
+    global_store.upsert_remote_article_identity(
+        user_id, article_id, "medium", "api-conflict",
+        remote_content_fingerprint="sha256:baseline",
+    )
+    remote_fingerprint = _fingerprint(RemoteSyncArticle(
+        article_id="api-conflict",
+        title="Accepted remote",
+        body_markdown="# Accepted remote\n\nRemote body.\n",
+        published=False,
+    ))
+    global_store.record_reconciliation_observation(
+        user_id,
+        article_id,
+        "medium",
+        "api-conflict",
+        local_revision_id=revision["id"],
+        baseline_fingerprint="sha256:baseline",
+        local_fingerprint="sha256:local",
+        remote_fingerprint=remote_fingerprint,
+        availability="available",
+        sync_state="conflict",
+        remote_title="Accepted remote",
+        remote_content="# Accepted remote\n\nRemote body.\n",
+    )
+
+    listed = client.get(f"/api/articles/{article_id}/reconciliation")
+    assert listed.status_code == 200
+    assert listed.json()["comparisons"][0]["syncState"] == "conflict"
+
+    resolved = client.post(
+        f"/api/articles/{article_id}/reconciliation/medium/resolve",
+        json={"action": "use_remote", "base_revision_id": revision["id"]},
+    )
+    assert resolved.status_code == 200
+    assert resolved.json()["syncState"] == "in_sync"
+    article = client.get(f"/api/articles/{article_id}").json()
+    assert article["title"] == "Accepted remote"
+    assert article["content"] == "# Accepted remote\n\nRemote body.\n"
+
+
+def test_refresh_marks_missing_medium_article_deleted(client, monkeypatch):
+    from backend.routers import reconciliation as reconciliation_router
+
+    user_id = global_store._backend.SEED_USER_ID
+    article_id = "art_001"
+    global_store.upsert_remote_article_identity(
+        user_id, article_id, "medium", "deleted-medium",
+        remote_content_fingerprint="sha256:baseline",
+    )
+    global_store.start_browser_connection(
+        user_id,
+        "medium",
+        session_id="reconciliation_refresh",
+        organization_id="org",
+        app_url="http://localhost/browser",
+        profile_id="profile",
+    )
+    global_store.update_browser_connection(
+        user_id, "medium", "connected", profile_id="profile",
+    )
+    monkeypatch.setattr(
+        reconciliation_router.runner,
+        "medium_browser_articles",
+        lambda **_kwargs: {
+            "success": True, "articles": [], "diagnostics": {"errors": []},
+        },
+    )
+    monkeypatch.setattr(
+        reconciliation_router,
+        "sync_medium_browser_records",
+        lambda *_args, **_kwargs: {
+            "status": "succeeded", "articles": [],
+        },
+    )
+
+    response = client.post(
+        f"/api/articles/{article_id}/reconciliation/medium/refresh",
+    )
+
+    assert response.status_code == 200
+    assert response.json()["availability"] == "deleted"
+    assert response.json()["syncState"] == "remote_deleted"

--- a/tests/tests_backend/test_store/test_remote_articles.py
+++ b/tests/tests_backend/test_store/test_remote_articles.py
@@ -223,7 +223,7 @@ def test_v7_database_migrates_without_changing_native_articles(tmp_path):
 
     migrated = SQLiteStore(str(database), str(blobs))
     try:
-        assert migrated.schema_version == SCHEMA_VERSION == 8
+        assert migrated.schema_version == SCHEMA_VERSION == 9
         assert migrated.get_article(migrated.SEED_USER_ID, "art_001")["title"] == (
             "Preserved native article"
         )

--- a/tests/tests_backend/test_store/test_schema.py
+++ b/tests/tests_backend/test_store/test_schema.py
@@ -39,6 +39,7 @@ def test_fresh_database_has_current_schema_and_seed_user(tmp_path):
             "browser_publish_runs",
             "browser_connections",
             "remote_article_identities",
+            "remote_reconciliation_observations",
         } <= tables
         assert store._con.execute(
             "SELECT COUNT(*) FROM users WHERE id=?", (SEED_USER_ID,)

--- a/tests/tests_hashnode/test_client.py
+++ b/tests/tests_hashnode/test_client.py
@@ -105,6 +105,31 @@ def test_create_draft_sends_cover_image_and_slugged_tags():
     }
 
 
+def test_update_draft_includes_existing_id():
+    session = _FakeSession({
+        "data": {"updateDraft": {"draft": {
+            "id": "draft-1",
+            "title": "Updated",
+            "canonicalUrl": None,
+            "coverImage": None,
+        }}},
+    })
+    client = HashnodeClient("token", session=session)
+
+    result = client.update_draft(
+        "draft-1",
+        HashnodeDraftInput(
+            title="Updated",
+            publication_id="pub-1",
+            content_markdown="New body",
+        ),
+    )
+
+    assert result.draft_id == "draft-1"
+    assert session.calls[0]["json"]["variables"]["input"]["id"] == "draft-1"
+    assert "updateDraft" in session.calls[0]["json"]["query"]
+
+
 def test_list_drafts_fetches_every_cursor_page():
     session = _QueuedSession([
         {"data": {"me": {"drafts": _page([_article("d1")], has_next=True, end_cursor="draft-1")}}},


### PR DESCRIPTION
## Summary
- rebuild remote reconciliation on current user-scoped identities and immutable article revisions
- record immutable remote observations for Hashnode, Medium, and Dev.to refreshes
- detect two-sided edits before sync writes and expose explicit keep-local/use-remote resolution
- represent remote deletion and provider inaccessibility without request-time overview calls
- block pushes only for affected unresolved platforms and update linked Hashnode/Dev.to drafts on retry
- add a focused editor comparison panel with local and remote content

## Verification
- 47 focused reconciliation, sync, push, schema, and backup tests passed
- full unit gate: 494 passed; the schema assertion and Windows backup rename cases then passed after fixes
- complete Playwright gate: 12 passed, 1 live OAuth test skipped
- visual inspection at 1280x720 with resolution controls inside the viewport
- npm run check:contracts

Closes #24