### PR TITLE
feat: add Medium browser publishing

### DIFF
--- a/backend/services/browser_publish.py
+++ b/backend/services/browser_publish.py
@@ -28,13 +28,35 @@ def execute_run(*, user_id: str, run_id: str) -> None:
         )
         return
     try:
+        article = store.get_article(user_id, run["article_id"])
+        destination = (article or {}).get("destinations", {}).get(platform, {})
+        remote_id = destination.get("draft_id")
+        if not remote_id:
+            identities = store.list_article_remote_identities(
+                user_id, run["article_id"]
+            )
+            remote_id = next(
+                (
+                    identity["remote_id"]
+                    for identity in identities
+                    if identity["platform"] == platform
+                ),
+                None,
+            )
         operation = "publish" if run["mode"] == "publish" else "create_draft"
+        if platform == "medium" and remote_id and run["mode"] == "draft":
+            operation = "update_article"
         result = runner.browser_operation(
             platform,
             operation,
             organization_id=browser_connection["skyvern_organization_id"],
             profile_id=browser_connection["skyvern_profile_id"],
-            article={"title": revision["title"], "body": revision["content"]},
+            article={
+                "title": revision["title"],
+                "body": revision["content"],
+                "remote_id": remote_id,
+            },
+            remote_id=remote_id,
             approved=True,
         )
         if not result.get("success"):
@@ -50,9 +72,20 @@ def execute_run(*, user_id: str, run_id: str) -> None:
                 user_id, run_id, result=result, error=error
             )
             return
+        result_remote_id = result.get("draft_id") or result.get("remote_id")
+        if result_remote_id and not store.get_remote_article_identity(
+            user_id, platform, result_remote_id
+        ):
+            store.upsert_remote_article_identity(
+                user_id,
+                run["article_id"],
+                platform,
+                result_remote_id,
+            )
         store.apply_push_result(
             user_id, run["article_id"], platform, success=True,
-            url=result.get("url"), draft_id=result.get("draft_id"),
+            url=result.get("url"),
+            draft_id=result_remote_id,
             label="Published" if run["mode"] == "publish" else "Draft",
             status="published" if run["mode"] == "publish" else "draft",
         )

--- a/cli-runner/blog_extensions/builtin/medium.py
+++ b/cli-runner/blog_extensions/builtin/medium.py
@@ -6,6 +6,7 @@ from medium_browser import (
     check_medium_profile,
     get_medium_article,
     list_medium_articles,
+    write_medium_article,
 )
 
 from ..contracts import (
@@ -27,7 +28,13 @@ class MediumLoginAdapter(BrowserLoginAdapter):
 
 class MediumOperationsAdapter(BlogOperationsAdapter):
     platform = "medium"
-    capabilities = frozenset({Capability.LIST_ARTICLES, Capability.GET_ARTICLE})
+    capabilities = frozenset({
+        Capability.LIST_ARTICLES,
+        Capability.GET_ARTICLE,
+        Capability.CREATE_DRAFT,
+        Capability.UPDATE_ARTICLE,
+        Capability.PUBLISH,
+    })
 
     def execute(self, page, operation: Capability, request: OperationRequest) -> dict:
         if operation == Capability.LIST_ARTICLES:
@@ -36,4 +43,21 @@ class MediumOperationsAdapter(BlogOperationsAdapter):
             if not request.remote_id:
                 raise ValueError("Medium get_article requires a remote_id")
             return get_medium_article(page=page, article_id=request.remote_id)
+        if operation in {
+            Capability.CREATE_DRAFT,
+            Capability.UPDATE_ARTICLE,
+            Capability.PUBLISH,
+        }:
+            if request.article is None:
+                raise ValueError(f"Medium {operation.value} requires article content")
+            remote_id = request.remote_id or request.article.remote_id
+            if operation == Capability.UPDATE_ARTICLE and not remote_id:
+                raise ValueError("Medium update_article requires a remote_id")
+            return write_medium_article(
+                page=page,
+                title=request.article.title,
+                article_md=request.article.body,
+                remote_id=remote_id,
+                publish=operation == Capability.PUBLISH,
+            )
         raise OperationNotSupported(self.platform, operation.value)

--- a/cli-runner/blog_extensions/manifests/medium/bloghub_extension.toml
+++ b/cli-runner/blog_extensions/manifests/medium/bloghub_extension.toml
@@ -3,8 +3,8 @@ protocol_version = 1
 id = "bloghub.medium"
 platform = "medium"
 display_name = "Medium"
-version = "1.0.0"
-capabilities = ["list_articles", "get_article"]
+version = "1.1.0"
+capabilities = ["list_articles", "get_article", "create_draft", "update_article", "publish"]
 
 [entrypoints]
 login = "blog_extensions.builtin.medium:MediumLoginAdapter"

--- a/cli-runner/blog_extensions/runtime.py
+++ b/cli-runner/blog_extensions/runtime.py
@@ -23,6 +23,7 @@ def execute_operation(
             str(profile_dir),
             headless=True,
             viewport={"width": 1440, "height": 1000},
+            permissions=["clipboard-read", "clipboard-write"],
         )
         page = context.pages[0] if context.pages else context.new_page()
         try:

--- a/cli-runner/medium_browser.py
+++ b/cli-runner/medium_browser.py
@@ -1,14 +1,18 @@
 """Medium browser-profile checks for persistent Skyvern sessions."""
 from __future__ import annotations
 
+from html import unescape
 import json
 from pathlib import Path
 import re
 import sqlite3
 import time
 
+from markdown_it import MarkdownIt
+
 
 _CHROMIUM_EPOCH_OFFSET_SECONDS = 11_644_473_600
+_EDITOR_URL = "https://medium.com/new-story"
 _DRAFTS_URL = "https://medium.com/me/stories/drafts"
 _PUBLISHED_URL = "https://medium.com/me/stories/public"
 _ARTICLE_ID_RE = re.compile(r"[A-Za-z0-9_-]{6,64}")
@@ -21,6 +25,167 @@ class MediumBrowserError(RuntimeError):
 def _is_login_url(url: str) -> bool:
     lowered = url.lower()
     return any(part in lowered for part in ("/signin", "/m/signin", "/login"))
+
+
+def _story_id(url: str) -> str | None:
+    match = re.search(r"/p/([A-Za-z0-9_-]{6,64})/edit", url)
+    return match.group(1) if match else None
+
+
+def _article_html(article_md: str, title: str) -> str:
+    body = article_md.lstrip()
+    heading = re.match(r"^#\s+(.+?)(?:\n+|$)", body)
+    if heading and heading.group(1).strip() == title.strip():
+        body = body[heading.end():]
+    return MarkdownIt("commonmark", {"html": False, "linkify": False}).enable(
+        "table"
+    ).render(body)
+
+
+def _first_visible(page, selectors: tuple[str, ...]):
+    for selector in selectors:
+        candidate = page.locator(selector).first
+        try:
+            if candidate.is_visible(timeout=1_500):
+                return candidate
+        except Exception:
+            continue
+    return None
+
+
+def _paste_html(page, article_html: str) -> None:
+    staging = page.context.new_page()
+    try:
+        staging.set_content(f"<!doctype html><html><body>{article_html}</body></html>")
+        staging.locator("body").click()
+        staging.keyboard.press("Control+A")
+        staging.keyboard.press("Control+C")
+    finally:
+        staging.close()
+    page.bring_to_front()
+    page.keyboard.press("Control+V")
+
+
+def _replace_editor_content(page, *, title: str, article_html: str) -> None:
+    page.wait_for_selector('[contenteditable="true"]', timeout=30_000)
+    title_control = _first_visible(
+        page,
+        (
+            'h1[data-testid="storyTitle"]',
+            '[data-placeholder="Title"]',
+            '[placeholder*="Title"]',
+            'h1[contenteditable="true"]',
+            '[contenteditable="true"]',
+        ),
+    )
+    if title_control is None:
+        raise MediumBrowserError("Medium title editor was not found")
+
+    editables = page.locator('[contenteditable="true"]')
+    title_control.click()
+    page.keyboard.press("Control+A")
+    page.keyboard.insert_text(title)
+    if editables.count() > 1:
+        editables.last.click()
+        page.keyboard.press("Control+A")
+        page.keyboard.press("Backspace")
+    else:
+        page.keyboard.press("End")
+        page.keyboard.press("Enter")
+        page.keyboard.press("Enter")
+    _paste_html(page, article_html)
+
+
+def _text_tokens(value: str) -> list[str]:
+    return re.findall(r"[\w']+", unescape(re.sub(r"<[^>]+>", " ", value)).lower())
+
+
+def _verify_article(
+    *, page, remote_id: str, title: str, article_html: str,
+    expected_status: str,
+) -> dict:
+    page.wait_for_timeout(4_000)
+    article = get_medium_article(page=page, article_id=remote_id)["article"]
+    expected_tokens = _text_tokens(article_html)[:12]
+    actual_tokens = set(_text_tokens(str(article.get("body") or "")))
+    body_matches = not expected_tokens or all(
+        token in actual_tokens for token in expected_tokens
+    )
+    if article.get("title") != title or not body_matches:
+        raise MediumBrowserError("Medium article autosave could not be verified")
+    if expected_status == "published" and article.get("status") != "published":
+        raise MediumBrowserError("Medium public publish could not be verified")
+    return article
+
+
+def write_medium_article(
+    *, page, title: str, article_md: str, remote_id: str | None = None,
+    publish: bool = False,
+) -> dict:
+    """Create or update a Medium story and verify the resulting remote state."""
+    if remote_id and not _ARTICLE_ID_RE.fullmatch(remote_id):
+        raise ValueError("Invalid Medium article id")
+    target_url = (
+        f"https://medium.com/p/{remote_id}/edit" if remote_id else _EDITOR_URL
+    )
+    page.goto(target_url, wait_until="domcontentloaded", timeout=60_000)
+    if _is_login_url(page.url):
+        return {
+            "success": False,
+            "error": "Medium browser session is not authenticated",
+            "manual_handoff": {
+                "reason": "medium_login_required",
+                "url": "https://medium.com/m/signin",
+            },
+        }
+
+    html = _article_html(article_md, title)
+    _replace_editor_content(page, title=title, article_html=html)
+    deadline = time.monotonic() + 25
+    while remote_id is None and time.monotonic() < deadline:
+        remote_id = _story_id(page.url)
+        if remote_id is None:
+            page.wait_for_timeout(500)
+    if remote_id is None:
+        raise MediumBrowserError("Medium draft autosave did not return an article id")
+
+    status = "draft"
+    article = _verify_article(
+        page=page, remote_id=remote_id, title=title,
+        article_html=html, expected_status=status,
+    )
+    if publish:
+        publish_button = page.get_by_role(
+            "button", name=re.compile(r"^Publish$", re.I)
+        ).first
+        if not publish_button.is_visible(timeout=5_000):
+            publish_button = page.locator('[data-action*="publish"]').first
+        if not publish_button.is_visible(timeout=5_000):
+            raise MediumBrowserError("Medium publish action was not found")
+        publish_button.click()
+        page.wait_for_timeout(1_000)
+        confirmation = page.get_by_role(
+            "button", name=re.compile(r"^Publish", re.I)
+        ).last
+        if not confirmation.is_visible(timeout=10_000):
+            raise MediumBrowserError("Medium publish confirmation was not found")
+        confirmation.click()
+        article = _verify_article(
+            page=page, remote_id=remote_id, title=title,
+            article_html=html, expected_status="published",
+        )
+        status = "published"
+
+    return {
+        "success": True,
+        "method": "deterministic",
+        "status": status,
+        "remote_id": remote_id,
+        "draft_id": remote_id,
+        "url": article.get("canonical_url")
+        or f"https://medium.com/p/{remote_id}/edit",
+        "article": article,
+    }
 
 
 def _list_source(page, *, status: str, url: str, limit: int) -> list[dict]:

--- a/cli-runner/requirements.txt
+++ b/cli-runner/requirements.txt
@@ -3,3 +3,4 @@ httpx>=0.27.0
 uvicorn[standard]>=0.29.0
 pydantic>=2.7.0
 patchright==1.62.1
+markdown-it-py>=3.0.0

--- a/tests/tests_backend/test_blog_extension_runner.py
+++ b/tests/tests_backend/test_blog_extension_runner.py
@@ -28,7 +28,7 @@ def test_runner_discovers_builtin_extension_capabilities():
         "create_draft", "list_articles", "publish",
     ]
     assert by_platform["medium"]["capabilities"] == [
-        "get_article", "list_articles",
+        "create_draft", "get_article", "list_articles", "publish", "update_article",
     ]
 
 
@@ -62,7 +62,7 @@ def test_public_operation_requires_explicit_approval():
     assert "approval" in exc_info.value.detail
 
 
-def test_unsupported_operation_is_rejected_before_browser_launch():
+def test_medium_publish_requires_explicit_approval():
     request = runner_main.BrowserOperationRequest(
         organization_id="o_test", profile_id="bp_test"
     )
@@ -71,7 +71,7 @@ def test_unsupported_operation_is_rejected_before_browser_launch():
         runner_main.browser_operation("medium", "publish", request)
 
     assert exc_info.value.status_code == 409
-    assert "does not support" in exc_info.value.detail
+    assert "approval" in exc_info.value.detail
 
 
 def test_generic_operation_passes_normalized_article_to_runtime(tmp_path, monkeypatch):

--- a/tests/tests_backend/test_blog_extensions.py
+++ b/tests/tests_backend/test_blog_extensions.py
@@ -37,6 +37,7 @@ def test_builtin_extensions_satisfy_the_versioned_contract():
     })
     assert medium.manifest.capabilities == frozenset({
         Capability.LIST_ARTICLES, Capability.GET_ARTICLE,
+        Capability.CREATE_DRAFT, Capability.UPDATE_ARTICLE, Capability.PUBLISH,
     })
     assert [item["platform"] for item in registry.descriptors()] == [
         "hashnode", "medium",
@@ -51,13 +52,13 @@ def test_fixture_loader_builds_normalized_article_input():
     assert article.metadata == {"language": "en"}
 
 
-def test_medium_rejects_undeclared_operations():
+def test_medium_update_requires_a_remote_id():
     extension = ExtensionRegistry().get("medium")
 
-    with pytest.raises(OperationNotSupported):
+    with pytest.raises(ValueError, match="requires a remote_id"):
         extension.operations.execute(
             object(),
-            Capability.PUBLISH,
+            Capability.UPDATE_ARTICLE,
             OperationRequest(article=article_from_fixture(FIXTURE)),
         )
 

--- a/tests/tests_backend/test_browser_publish.py
+++ b/tests/tests_backend/test_browser_publish.py
@@ -4,13 +4,13 @@ import backend.services.browser_publish as browser_publish
 import backend.store as store
 
 
-def _connect() -> None:
+def _connect(platform: str = "hashnode") -> None:
     store.start_browser_connection(
-        "user_seed", "hashnode", session_id="pbs_test",
+        "user_seed", platform, session_id="pbs_test",
         organization_id="o_test", app_url="http://localhost/login",
     )
     store.update_browser_connection(
-        "user_seed", "hashnode", "connected", profile_id="bp_test"
+        "user_seed", platform, "connected", profile_id="bp_test"
     )
 
 
@@ -83,6 +83,57 @@ def test_public_publish_mode_is_durable_and_updates_destination(
     assert article["destinations"]["hashnode"]["url"] == (
         "https://example.hashnode.dev/test"
     )
+
+
+def test_medium_draft_updates_existing_remote_article(
+    client, monkeypatch, run_jobs,
+):
+    _connect("medium")
+    store.upsert_remote_article_identity(
+        "user_seed", "art_001", "medium", "medium123abc",
+    )
+    seen = {}
+    monkeypatch.setattr(
+        browser_publish.runner,
+        "browser_operation",
+        lambda platform, operation, **kwargs: seen.update(
+            kwargs, platform=platform, operation=operation
+        ) or {
+            "success": True,
+            "status": "draft",
+            "remote_id": "medium123abc",
+        },
+    )
+
+    run = client.post("/api/articles/art_001/browser-publish/medium").json()
+    client.post(f"/api/articles/art_001/browser-publish/{run['id']}/approve")
+    run_jobs()
+
+    assert seen["operation"] == "update_article"
+    assert seen["remote_id"] == "medium123abc"
+    assert seen["article"]["remote_id"] == "medium123abc"
+
+
+def test_first_browser_draft_records_remote_identity(client, monkeypatch, run_jobs):
+    _connect("medium")
+    monkeypatch.setattr(
+        browser_publish.runner,
+        "browser_operation",
+        lambda *_args, **_kwargs: {
+            "success": True,
+            "status": "draft",
+            "remote_id": "created123abc",
+        },
+    )
+
+    run = client.post("/api/articles/art_001/browser-publish/medium").json()
+    client.post(f"/api/articles/art_001/browser-publish/{run['id']}/approve")
+    run_jobs()
+
+    identity = store.get_remote_article_identity(
+        "user_seed", "medium", "created123abc"
+    )
+    assert identity["article_id"] == "art_001"
 
 
 def test_browser_publish_cannot_be_approved_twice(client, monkeypatch, run_jobs):

--- a/tests/tests_backend/test_medium_browser.py
+++ b/tests/tests_backend/test_medium_browser.py
@@ -219,3 +219,164 @@ def test_detail_rejects_invalid_remote_id_before_navigation():
         medium_browser.get_medium_article(page=page, article_id="../cookie")
 
     assert page.url == "about:blank"
+
+
+class _WritePage:
+    def __init__(self, *, login=False):
+        self.url = "about:blank"
+        self.login = login
+        self.waits = []
+
+    def goto(self, url, **_kwargs):
+        self.url = "https://medium.com/m/signin" if self.login else url
+
+    def wait_for_timeout(self, timeout):
+        self.waits.append(timeout)
+
+
+class _Button:
+    def __init__(self):
+        self.clicks = 0
+
+    @property
+    def first(self):
+        return self
+
+    @property
+    def last(self):
+        return self
+
+    def is_visible(self, **_kwargs):
+        return True
+
+    def click(self):
+        self.clicks += 1
+
+
+class _PublishingPage(_WritePage):
+    def __init__(self):
+        super().__init__()
+        self.publish = _Button()
+        self.confirm = _Button()
+        self.role_calls = 0
+
+    def get_by_role(self, *_args, **_kwargs):
+        self.role_calls += 1
+        return self.publish if self.role_calls == 1 else self.confirm
+
+
+def test_article_html_removes_matching_leading_title_and_renders_images():
+    rendered = medium_browser._article_html(
+        "# A Medium story\n\nBody copy.\n\n![Diagram](https://cdn.example/diagram.png)",
+        "A Medium story",
+    )
+
+    assert "<h1>" not in rendered
+    assert "<p>Body copy.</p>" in rendered
+    assert '<img src="https://cdn.example/diagram.png" alt="Diagram"' in rendered
+
+
+def test_create_draft_pastes_content_and_verifies_remote_article(monkeypatch):
+    page = _WritePage()
+    seen = {}
+
+    def replace(target, **kwargs):
+        seen.update(kwargs)
+        target.url = "https://medium.com/p/draft123abc/edit"
+
+    monkeypatch.setattr(medium_browser, "_replace_editor_content", replace)
+    monkeypatch.setattr(
+        medium_browser,
+        "_verify_article",
+        lambda **_kwargs: {
+            "title": "A Medium story",
+            "body": "Body copy.",
+            "status": "draft",
+            "canonical_url": None,
+        },
+    )
+
+    result = medium_browser.write_medium_article(
+        page=page,
+        title="A Medium story",
+        article_md="# A Medium story\n\nBody copy.",
+    )
+
+    assert result["success"] is True
+    assert result["remote_id"] == "draft123abc"
+    assert result["status"] == "draft"
+    assert "<h1>" not in seen["article_html"]
+
+
+def test_update_targets_existing_medium_story(monkeypatch):
+    page = _WritePage()
+    monkeypatch.setattr(
+        medium_browser, "_replace_editor_content", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        medium_browser,
+        "_verify_article",
+        lambda **_kwargs: {
+            "title": "Updated",
+            "body": "New body",
+            "status": "draft",
+            "canonical_url": None,
+        },
+    )
+
+    result = medium_browser.write_medium_article(
+        page=page, title="Updated", article_md="New body", remote_id="draft123abc",
+    )
+
+    assert page.url == "https://medium.com/p/draft123abc/edit"
+    assert result["draft_id"] == "draft123abc"
+
+
+def test_write_returns_manual_handoff_for_stale_login():
+    result = medium_browser.write_medium_article(
+        page=_WritePage(login=True), title="Title", article_md="Body",
+    )
+
+    assert result["success"] is False
+    assert result["manual_handoff"]["reason"] == "medium_login_required"
+
+
+def test_publish_confirms_action_and_verifies_published_state(monkeypatch):
+    page = _PublishingPage()
+    statuses = []
+    monkeypatch.setattr(
+        medium_browser, "_replace_editor_content", lambda *_args, **_kwargs: None
+    )
+
+    def verify(**kwargs):
+        statuses.append(kwargs["expected_status"])
+        return {
+            "title": "Published story",
+            "body": "Body",
+            "status": kwargs["expected_status"],
+            "canonical_url": "https://medium.com/@author/published-story-abc123def456",
+        }
+
+    monkeypatch.setattr(medium_browser, "_verify_article", verify)
+
+    result = medium_browser.write_medium_article(
+        page=page, title="Published story", article_md="Body",
+        remote_id="abc123def456", publish=True,
+    )
+
+    assert statuses == ["draft", "published"]
+    assert page.publish.clicks == 1
+    assert page.confirm.clicks == 1
+    assert result["status"] == "published"
+    assert result["url"].endswith("published-story-abc123def456")
+
+
+def test_write_rejects_invalid_existing_remote_id_before_navigation():
+    page = _WritePage()
+
+    with pytest.raises(ValueError, match="Invalid Medium article id"):
+        medium_browser.write_medium_article(
+            page=page, title="Title", article_md="Body", remote_id="../cookie",
+        )
+
+    assert page.url == "about:blank"


### PR DESCRIPTION
Closes #43

## Summary
- add deterministic Medium create, update, and publish operations to the blog extension
- render Markdown into Medium rich-editor clipboard HTML and verify autosaves by reading the remote article back
- reuse durable remote identities to update imported drafts without duplication
- persist newly created Medium remote identities in BlogHub

## Validation
- 528 passed, 1 skipped (unit gate)
- focused Medium and extension tests: 37 passed
- cli-runner Docker image build and extension discovery smoke test passed

## Live verification
The persisted local profiles currently contain no valid Medium session, so no live remote write was performed in this pass.