### PR TITLE
feat: define shared platform preview contracts

### DIFF
--- a/backend/schemas/previews.py
+++ b/backend/schemas/previews.py
@@ -1,0 +1,95 @@
+"""API contracts shared by local and remote article previews."""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class PreviewPlatform(str, Enum):
+    markdown = "markdown"
+    hashnode = "hashnode"
+    medium = "medium"
+
+
+class PreviewKind(str, Enum):
+    live = "live"
+    remote = "remote"
+
+
+class PreviewState(str, Enum):
+    missing = "missing"
+    rendering = "rendering"
+    current = "current"
+    stale = "stale"
+    failed = "failed"
+
+
+class PreviewViewport(str, Enum):
+    desktop = "desktop"
+    mobile = "mobile"
+
+
+class PreviewWarning(BaseModel):
+    code: str
+    message: str
+    severity: Literal["info", "warning"] = "warning"
+
+
+class PreviewFailure(BaseModel):
+    code: str
+    message: str
+    retryable: bool = False
+
+
+class PreviewSource(BaseModel):
+    article_id: str
+    revision_id: str | None = None
+    revision_number: int | None = Field(default=None, ge=1)
+    working_copy_fingerprint: str | None = None
+
+    @model_validator(mode="after")
+    def require_revision_or_working_copy(self) -> "PreviewSource":
+        if not self.revision_id and not self.working_copy_fingerprint:
+            raise ValueError("revision_id or working_copy_fingerprint is required")
+        return self
+
+
+class PreviewCapabilities(BaseModel):
+    platform: PreviewPlatform
+    renderer_version: str
+    viewports: list[PreviewViewport]
+    live: bool = True
+    remote_capture: bool = False
+
+
+class PreviewRenderRequest(BaseModel):
+    platform: PreviewPlatform
+    viewport: PreviewViewport = PreviewViewport.desktop
+    title: str = Field(max_length=500)
+    content: str = Field(max_length=2_000_000)
+    base_revision_id: str | None = None
+
+
+class PreviewArtifact(BaseModel):
+    kind: PreviewKind = PreviewKind.live
+    state: PreviewState
+    platform: PreviewPlatform
+    viewport: PreviewViewport
+    renderer_version: str
+    source: PreviewSource
+    html: str | None = None
+    warnings: list[PreviewWarning] = Field(default_factory=list)
+    failure: PreviewFailure | None = None
+    artifact_url: str | None = None
+    rendered_at: str | None = None
+
+    @model_validator(mode="after")
+    def validate_state_payload(self) -> "PreviewArtifact":
+        if self.state == PreviewState.current and self.html is None and self.artifact_url is None:
+            raise ValueError("a current preview requires html or artifact_url")
+        if self.state == PreviewState.failed and self.failure is None:
+            raise ValueError("a failed preview requires failure details")
+        return self
+

--- a/backend/schemas/previews.py
+++ b/backend/schemas/previews.py
@@ -1,6 +1,7 @@
 """API contracts shared by local and remote article previews."""
 from __future__ import annotations
 
+from datetime import datetime
 from enum import Enum
 from typing import Literal
 
@@ -83,13 +84,12 @@ class PreviewArtifact(BaseModel):
     warnings: list[PreviewWarning] = Field(default_factory=list)
     failure: PreviewFailure | None = None
     artifact_url: str | None = None
-    rendered_at: str | None = None
+    rendered_at: datetime | None = None
 
     @model_validator(mode="after")
     def validate_state_payload(self) -> "PreviewArtifact":
-        if self.state == PreviewState.current and self.html is None and self.artifact_url is None:
-            raise ValueError("a current preview requires html or artifact_url")
+        if self.state in {PreviewState.current, PreviewState.stale} and self.html is None and self.artifact_url is None:
+            raise ValueError(f"a {self.state.value} preview requires html or artifact_url")
         if self.state == PreviewState.failed and self.failure is None:
             raise ValueError("a failed preview requires failure details")
         return self
-

--- a/backend/services/platform_previews/__init__.py
+++ b/backend/services/platform_previews/__init__.py
@@ -1,0 +1,6 @@
+"""Platform preview rendering contracts and implementations."""
+
+from backend.services.platform_previews.contracts import PlatformPreviewProvider
+
+__all__ = ["PlatformPreviewProvider"]
+

--- a/backend/services/platform_previews/contracts.py
+++ b/backend/services/platform_previews/contracts.py
@@ -1,0 +1,29 @@
+"""Extension contract for deterministic and remote preview providers."""
+from __future__ import annotations
+
+from typing import Protocol
+
+from backend.schemas.previews import (
+    PreviewArtifact,
+    PreviewCapabilities,
+    PreviewRenderRequest,
+    PreviewSource,
+)
+
+
+class PlatformPreviewProvider(Protocol):
+    """Render one platform without coupling callers to its implementation."""
+
+    @property
+    def capabilities(self) -> PreviewCapabilities:
+        ...
+
+    def render(
+        self,
+        request: PreviewRenderRequest,
+        *,
+        source: PreviewSource,
+        asset_base_url: str,
+    ) -> PreviewArtifact:
+        ...
+

--- a/tests/tests_backend/test_preview_contracts.py
+++ b/tests/tests_backend/test_preview_contracts.py
@@ -51,3 +51,38 @@ def test_failed_artifact_carries_typed_failure():
     )
 
     assert artifact.failure.code == "renderer_failed"
+
+
+def test_failed_artifact_requires_failure_details():
+    with pytest.raises(ValidationError, match="requires failure details"):
+        PreviewArtifact(
+            state=PreviewState.failed,
+            platform=PreviewPlatform.medium,
+            viewport=PreviewViewport.desktop,
+            renderer_version="1",
+            source=PreviewSource(article_id="art_001", revision_id="rev_001"),
+        )
+
+
+def test_stale_artifact_requires_the_previous_render():
+    with pytest.raises(ValidationError, match="stale preview requires html or artifact_url"):
+        PreviewArtifact(
+            state=PreviewState.stale,
+            platform=PreviewPlatform.hashnode,
+            viewport=PreviewViewport.desktop,
+            renderer_version="1",
+            source=PreviewSource(article_id="art_001", revision_id="rev_001"),
+        )
+
+
+def test_rendered_at_requires_an_iso_timestamp():
+    with pytest.raises(ValidationError):
+        PreviewArtifact(
+            state=PreviewState.current,
+            platform=PreviewPlatform.markdown,
+            viewport=PreviewViewport.desktop,
+            renderer_version="1",
+            source=PreviewSource(article_id="art_001", revision_id="rev_001"),
+            html="<p>preview</p>",
+            rendered_at="not-a-timestamp",
+        )

--- a/tests/tests_backend/test_preview_contracts.py
+++ b/tests/tests_backend/test_preview_contracts.py
@@ -1,0 +1,53 @@
+import pytest
+from pydantic import ValidationError
+
+from backend.schemas.previews import (
+    PreviewArtifact,
+    PreviewFailure,
+    PreviewPlatform,
+    PreviewSource,
+    PreviewState,
+    PreviewViewport,
+)
+
+
+def test_preview_source_accepts_revision_identity():
+    source = PreviewSource(article_id="art_001", revision_id="rev_001", revision_number=3)
+
+    assert source.revision_id == "rev_001"
+    assert source.working_copy_fingerprint is None
+
+
+def test_preview_source_accepts_unsaved_working_copy():
+    source = PreviewSource(article_id="art_001", working_copy_fingerprint="sha256:abc")
+
+    assert source.working_copy_fingerprint == "sha256:abc"
+
+
+def test_preview_source_requires_stable_identity():
+    with pytest.raises(ValidationError, match="revision_id or working_copy_fingerprint"):
+        PreviewSource(article_id="art_001")
+
+
+def test_current_artifact_requires_rendered_content():
+    with pytest.raises(ValidationError, match="requires html or artifact_url"):
+        PreviewArtifact(
+            state=PreviewState.current,
+            platform=PreviewPlatform.hashnode,
+            viewport=PreviewViewport.desktop,
+            renderer_version="1",
+            source=PreviewSource(article_id="art_001", revision_id="rev_001"),
+        )
+
+
+def test_failed_artifact_carries_typed_failure():
+    artifact = PreviewArtifact(
+        state=PreviewState.failed,
+        platform=PreviewPlatform.medium,
+        viewport=PreviewViewport.mobile,
+        renderer_version="1",
+        source=PreviewSource(article_id="art_001", working_copy_fingerprint="sha256:abc"),
+        failure=PreviewFailure(code="renderer_failed", message="Could not render"),
+    )
+
+    assert artifact.failure.code == "renderer_failed"


### PR DESCRIPTION
Defines typed live/remote preview artifacts, source identity, lifecycle states, viewports, warnings, failures, capabilities, and the platform preview provider protocol.\n\nCloses #80