### PR TITLE
feat: add deterministic live preview pipeline

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
-from backend.routers import agent, agent_sessions, articles, comments, connections, dev, jobs, patches, platforms, reconciliation
+from backend.routers import agent, agent_sessions, articles, comments, connections, dev, jobs, patches, platforms, previews, reconciliation
 from backend.routers import auth as auth_router
 from backend.middleware.auth import AuthMiddleware
 from backend.security import install_secret_redaction
@@ -55,6 +55,7 @@ app.include_router(auth_router.router)
 app.include_router(agent.router)
 app.include_router(agent_sessions.router)
 app.include_router(articles.router)
+app.include_router(previews.router)
 app.include_router(reconciliation.router)
 app.include_router(comments.router)
 app.include_router(patches.router)

--- a/backend/routers/articles.py
+++ b/backend/routers/articles.py
@@ -172,12 +172,7 @@ def _etag_matches(request: Request, etag: str) -> bool:
     return "*" in candidates or etag in candidates or f"W/{etag}" in candidates
 
 
-@router.get("/{article_id}/assets/{asset_id}", response_class=Response)
-def get_article_asset(request: Request, article_id: str, asset_id: int):
-    asset = store.read_article_asset(request.state.user_id, article_id, asset_id)
-    if asset is None:
-        raise HTTPException(status_code=404, detail="Asset not found")
-
+def _article_asset_response(request: Request, asset: dict) -> Response:
     etag = f'"{hashlib.sha256(asset["data"]).hexdigest()}"'
     media_type = _asset_media_type(asset["mime_type"])
     headers = {
@@ -185,17 +180,27 @@ def get_article_asset(request: Request, article_id: str, asset_id: int):
         "Cache-Control": "private, max-age=3600, must-revalidate",
         "Vary": "Cookie",
         "X-Content-Type-Options": "nosniff",
-        "Content-Disposition": _asset_content_disposition(
-            asset["filename"], media_type,
-        ),
+        "Content-Disposition": _asset_content_disposition(asset["filename"], media_type),
     }
     if _etag_matches(request, etag):
         return Response(status_code=304, headers=headers)
-    return Response(
-        content=asset["data"],
-        media_type=media_type,
-        headers=headers,
-    )
+    return Response(content=asset["data"], media_type=media_type, headers=headers)
+
+
+@router.get("/{article_id}/assets/by-filename/{filename:path}", response_class=Response)
+def get_article_asset_by_filename(request: Request, article_id: str, filename: str):
+    asset = store.get_article_asset_by_filename(request.state.user_id, article_id, filename)
+    if asset is None:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    return _article_asset_response(request, asset)
+
+
+@router.get("/{article_id}/assets/{asset_id}", response_class=Response)
+def get_article_asset(request: Request, article_id: str, asset_id: int):
+    asset = store.read_article_asset(request.state.user_id, article_id, asset_id)
+    if asset is None:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    return _article_asset_response(request, asset)
 
 
 @router.get("/{article_id}", response_model=ArticleDetailResponse)

--- a/backend/routers/previews.py
+++ b/backend/routers/previews.py
@@ -1,0 +1,57 @@
+"""Live article preview endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+import backend.store as store
+from backend.schemas.previews import (
+    PreviewArtifact,
+    PreviewCapabilities,
+    PreviewRenderRequest,
+    PreviewSource,
+)
+from backend.services.platform_previews.engine import preview_engine, working_copy_fingerprint
+
+
+router = APIRouter(prefix="/api/articles/{article_id}/previews", tags=["previews"])
+
+
+@router.get("/capabilities", response_model=list[PreviewCapabilities])
+def preview_capabilities(article_id: str, request: Request):
+    if store.get_article(request.state.user_id, article_id) is None:
+        raise HTTPException(status_code=404, detail="Article not found")
+    return preview_engine.capabilities()
+
+
+@router.post("/render", response_model=PreviewArtifact)
+def render_preview(article_id: str, body: PreviewRenderRequest, request: Request):
+    user_id = request.state.user_id
+    article = store.get_article(user_id, article_id)
+    if article is None:
+        raise HTTPException(status_code=404, detail="Article not found")
+    current = store.get_current_article_revision(user_id, article_id)
+    fingerprint = working_copy_fingerprint(body.title, body.content)
+    matches_current = bool(
+        current
+        and body.base_revision_id == current["id"]
+        and body.title == current["title"]
+        and body.content == current["content"]
+    )
+    source = PreviewSource(
+        article_id=article_id,
+        revision_id=current["id"] if matches_current else None,
+        revision_number=current["revision_number"] if matches_current else None,
+        working_copy_fingerprint=None if matches_current else fingerprint,
+    )
+    try:
+        return preview_engine.render(
+            body,
+            source=source,
+            asset_base_url=f"/api/articles/{article_id}/assets/by-filename",
+        )
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=501,
+            detail={"code": "preview_not_supported", "platform": str(exc.args[0])},
+        ) from exc
+

--- a/backend/services/platform_previews/engine.py
+++ b/backend/services/platform_previews/engine.py
@@ -23,7 +23,6 @@ from backend.schemas.previews import (
 )
 
 
-_LOCAL_IMAGE = re.compile(r"(!\[[^\]]*\]\()([^)\s]+)([^)]*\))")
 _RAW_HTML = re.compile(r"<\s*/?\s*[A-Za-z][^>]*>")
 
 
@@ -37,15 +36,11 @@ def working_copy_fingerprint(title: str, content: str) -> str:
     return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
-def rewrite_local_images(markdown: str, asset_base_url: str) -> str:
-    def replace(match: re.Match[str]) -> str:
-        target = match.group(2)
-        if target.startswith(("https://", "http://", "data:", "/")):
-            return match.group(0)
-        clean = target.lstrip("./").replace("\\", "/")
-        return f"{match.group(1)}{asset_base_url}/{quote(clean, safe='/')}{match.group(3)}"
-
-    return _LOCAL_IMAGE.sub(replace, markdown)
+def _rewrite_image_url(target: str, asset_base_url: str) -> str:
+    if target.startswith(("https://", "http://", "data:", "/")):
+        return target
+    clean = target.lstrip("./").replace("\\", "/")
+    return f"{asset_base_url}/{quote(clean, safe='/')}"
 
 
 def render_markdown_fragment(markdown: str, asset_base_url: str) -> tuple[str, list[PreviewWarning]]:
@@ -57,7 +52,15 @@ def render_markdown_fragment(markdown: str, asset_base_url: str) -> tuple[str, l
             severity="info",
         ))
     parser = MarkdownIt("commonmark", {"html": False, "linkify": True}).enable("table")
-    return parser.render(rewrite_local_images(markdown, asset_base_url)), warnings
+    tokens = parser.parse(markdown)
+    for token in tokens:
+        for child in token.children or ():
+            if child.type != "image":
+                continue
+            source = child.attrGet("src")
+            if source:
+                child.attrSet("src", _rewrite_image_url(source, asset_base_url))
+    return parser.renderer.render(tokens, parser.options, {}), warnings
 
 
 def preview_document(*, title: str, body: str, css: str, platform: str) -> str:
@@ -140,6 +143,8 @@ class PreviewEngine:
         if provider is None:
             raise KeyError(request.platform.value)
         cache_key = "|".join((
+            source.article_id,
+            asset_base_url,
             request.platform.value,
             request.viewport.value,
             source.working_copy_fingerprint or source.revision_id or "",
@@ -160,4 +165,3 @@ class PreviewEngine:
 
 
 preview_engine = PreviewEngine([MarkdownPreviewProvider()])
-

--- a/backend/services/platform_previews/engine.py
+++ b/backend/services/platform_previews/engine.py
@@ -1,0 +1,163 @@
+"""Deterministic live preview rendering and caching."""
+from __future__ import annotations
+
+import hashlib
+import html
+import json
+import re
+from collections import OrderedDict
+from threading import Lock
+from urllib.parse import quote
+
+from markdown_it import MarkdownIt
+
+from backend.schemas.previews import (
+    PreviewArtifact,
+    PreviewCapabilities,
+    PreviewPlatform,
+    PreviewRenderRequest,
+    PreviewSource,
+    PreviewState,
+    PreviewViewport,
+    PreviewWarning,
+)
+
+
+_LOCAL_IMAGE = re.compile(r"(!\[[^\]]*\]\()([^)\s]+)([^)]*\))")
+_RAW_HTML = re.compile(r"<\s*/?\s*[A-Za-z][^>]*>")
+
+
+def working_copy_fingerprint(title: str, content: str) -> str:
+    canonical = json.dumps(
+        {"title": title, "content": content.replace("\r\n", "\n")},
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def rewrite_local_images(markdown: str, asset_base_url: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        target = match.group(2)
+        if target.startswith(("https://", "http://", "data:", "/")):
+            return match.group(0)
+        clean = target.lstrip("./").replace("\\", "/")
+        return f"{match.group(1)}{asset_base_url}/{quote(clean, safe='/')}{match.group(3)}"
+
+    return _LOCAL_IMAGE.sub(replace, markdown)
+
+
+def render_markdown_fragment(markdown: str, asset_base_url: str) -> tuple[str, list[PreviewWarning]]:
+    warnings: list[PreviewWarning] = []
+    if _RAW_HTML.search(markdown):
+        warnings.append(PreviewWarning(
+            code="raw_html_escaped",
+            message="Raw HTML is shown as text in live previews.",
+            severity="info",
+        ))
+    parser = MarkdownIt("commonmark", {"html": False, "linkify": True}).enable("table")
+    return parser.render(rewrite_local_images(markdown, asset_base_url)), warnings
+
+
+def preview_document(*, title: str, body: str, css: str, platform: str) -> str:
+    return """<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{title}</title><style>{css}</style></head>
+<body data-preview-platform="{platform}">{body}</body></html>""".format(
+        title=html.escape(title), css=css, platform=platform, body=body,
+    )
+
+
+MARKDOWN_CSS = """
+:root{color-scheme:light}*{box-sizing:border-box}body{margin:0;background:#fff;color:#20242d;
+font:16px/1.7 Inter,ui-sans-serif,system-ui,sans-serif}main{width:min(760px,100%);margin:0 auto;
+padding:38px 32px 72px}h1,h2,h3{line-height:1.25;color:#111827;margin:1.6em 0 .55em}
+h1{font-size:2.25rem;margin-top:0}h2{font-size:1.55rem}h3{font-size:1.2rem}p,ul,ol,
+blockquote,pre,table{margin:0 0 1.2em}a{color:#4f46e5}img{display:block;max-width:100%;height:auto;
+margin:1.6em auto}blockquote{border-left:3px solid #a5b4fc;padding:.15em 0 .15em 1em;color:#4b5563}
+pre{overflow:auto;background:#111827;color:#e5e7eb;padding:16px;border-radius:6px}code{font-family:
+ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.9em}table{width:100%;border-collapse:collapse}
+th,td{border:1px solid #d1d5db;padding:8px 10px;text-align:left}@media(max-width:600px){main{padding:24px 18px 52px}
+h1{font-size:1.85rem}h2{font-size:1.35rem}}
+"""
+
+
+class MarkdownPreviewProvider:
+    capabilities = PreviewCapabilities(
+        platform=PreviewPlatform.markdown,
+        renderer_version="markdown-1",
+        viewports=[PreviewViewport.desktop, PreviewViewport.mobile],
+    )
+
+    def render(
+        self,
+        request: PreviewRenderRequest,
+        *,
+        source: PreviewSource,
+        asset_base_url: str,
+    ) -> PreviewArtifact:
+        body, warnings = render_markdown_fragment(request.content, asset_base_url)
+        document = preview_document(
+            title=request.title,
+            platform=self.capabilities.platform.value,
+            css=MARKDOWN_CSS,
+            body=f'<main><article>{body}</article></main>',
+        )
+        return PreviewArtifact(
+            state=PreviewState.current,
+            platform=self.capabilities.platform,
+            viewport=request.viewport,
+            renderer_version=self.capabilities.renderer_version,
+            source=source,
+            html=document,
+            warnings=warnings,
+        )
+
+
+class PreviewEngine:
+    def __init__(self, providers=(), *, max_cache_entries: int = 128):
+        self._providers = {p.capabilities.platform: p for p in providers}
+        self._cache: OrderedDict[str, PreviewArtifact] = OrderedDict()
+        self._max_cache_entries = max_cache_entries
+        self._lock = Lock()
+
+    def register(self, provider) -> None:
+        self._providers[provider.capabilities.platform] = provider
+
+    def capabilities(self) -> list[PreviewCapabilities]:
+        return [provider.capabilities for provider in self._providers.values()]
+
+    def render(
+        self,
+        request: PreviewRenderRequest,
+        *,
+        source: PreviewSource,
+        asset_base_url: str,
+    ) -> PreviewArtifact:
+        provider = self._providers.get(request.platform)
+        if provider is None:
+            raise KeyError(request.platform.value)
+        cache_key = "|".join((
+            request.platform.value,
+            request.viewport.value,
+            source.working_copy_fingerprint or source.revision_id or "",
+            provider.capabilities.renderer_version,
+        ))
+        with self._lock:
+            cached = self._cache.get(cache_key)
+            if cached is not None:
+                self._cache.move_to_end(cache_key)
+                return cached.model_copy(deep=True)
+        artifact = provider.render(request, source=source, asset_base_url=asset_base_url)
+        with self._lock:
+            self._cache[cache_key] = artifact.model_copy(deep=True)
+            self._cache.move_to_end(cache_key)
+            while len(self._cache) > self._max_cache_entries:
+                self._cache.popitem(last=False)
+        return artifact
+
+
+preview_engine = PreviewEngine([MarkdownPreviewProvider()])
+

--- a/backend/store/backends/sqlite.py
+++ b/backend/store/backends/sqlite.py
@@ -1199,14 +1199,37 @@ class SQLiteStore(
     def get_article_asset_by_filename(
         self, user_id: str, article_id: str, filename: str,
     ) -> dict | None:
-        row = self._con.execute(
-            """SELECT aa.id, aa.filename, aa.mime_type
-               FROM article_assets aa
-               JOIN articles a ON a.id=aa.article_id
-               WHERE aa.article_id=? AND aa.filename=? AND a.user_id=?""",
-            (article_id, filename, user_id),
-        ).fetchone()
-        return dict(row) if row else None
+        with self._workspace_lock.acquire():
+            row = self._con.execute(
+                """SELECT aa.id, aa.filename, aa.asset_path, aa.mime_type
+                   FROM article_assets aa
+                   JOIN articles a ON a.id=aa.article_id
+                   WHERE aa.article_id=? AND aa.filename=? AND a.user_id=?""",
+                (article_id, filename, user_id),
+            ).fetchone()
+            if row is None:
+                return None
+
+            assets_root = (
+                self._blobs_dir / "articles" / article_id / "assets"
+            ).resolve()
+            candidate = (self._blobs_dir / row["asset_path"]).resolve()
+            try:
+                candidate.relative_to(assets_root)
+            except ValueError:
+                return None
+            try:
+                if not candidate.is_file():
+                    return None
+                data = candidate.read_bytes()
+            except OSError:
+                return None
+            return {
+                "id": row["id"],
+                "filename": row["filename"],
+                "mime_type": row["mime_type"],
+                "data": data,
+            }
 
     def reset(self) -> None:
         """Drop all data and re-seed. Used by the /api/dev/reset endpoint in tests."""

--- a/tests/tests_backend/test_article_assets.py
+++ b/tests/tests_backend/test_article_assets.py
@@ -38,6 +38,10 @@ def _asset_url(article_id: str, asset_id: int) -> str:
     return f"/api/articles/{article_id}/assets/{asset_id}"
 
 
+def _filename_asset_url(article_id: str, filename: str) -> str:
+    return f"/api/articles/{article_id}/assets/by-filename/{filename}"
+
+
 def test_owner_can_read_registered_cover_with_safe_headers(client: TestClient):
     asset_id, _ = _add_cover()
     with store._backend._con:
@@ -58,6 +62,17 @@ def test_owner_can_read_registered_cover_with_safe_headers(client: TestClient):
     assert disposition.startswith("inline;")
     assert ".." not in disposition
     assert "\n" not in disposition and "\r" not in disposition
+
+
+def test_owner_can_read_registered_asset_by_filename(client: TestClient):
+    _add_cover(filename="preview image.png", content=b"preview-bytes")
+
+    response = client.get(_filename_asset_url("art_001", "preview image.png"))
+
+    assert response.status_code == 200
+    assert response.content == b"preview-bytes"
+    assert response.headers["content-type"] == "image/png"
+    assert response.headers["etag"].startswith('"')
 
 
 def test_asset_read_requires_authentication(anon_client: TestClient):

--- a/tests/tests_backend/test_live_previews.py
+++ b/tests/tests_backend/test_live_previews.py
@@ -46,6 +46,21 @@ def test_markdown_renderer_rewrites_local_images_only():
     assert "https://example.com/a.png" in artifact.html
 
 
+def test_markdown_renderer_does_not_rewrite_images_inside_fenced_code():
+    artifact = MarkdownPreviewProvider().render(
+        PreviewRenderRequest(
+            platform=PreviewPlatform.markdown,
+            title="Image syntax",
+            content="```markdown\n![literal](./logo.png)\n```\n\n![real](./logo.png)",
+        ),
+        source=PreviewSource(article_id="art_001", working_copy_fingerprint="sha256:x"),
+        asset_base_url="/api/articles/art_001/assets/by-filename",
+    )
+
+    assert "![literal](./logo.png)" in artifact.html
+    assert artifact.html.count("/api/articles/art_001/assets/by-filename/logo.png") == 1
+
+
 def test_engine_cache_is_keyed_by_fingerprint_and_returns_copies():
     class CountingProvider(MarkdownPreviewProvider):
         calls = 0
@@ -65,6 +80,39 @@ def test_engine_cache_is_keyed_by_fingerprint_and_returns_copies():
 
     assert provider.calls == 1
     assert first.html != second.html
+
+
+def test_engine_cache_is_isolated_by_article_and_asset_base_url():
+    class CountingProvider(MarkdownPreviewProvider):
+        calls = 0
+
+        def render(self, *args, **kwargs):
+            self.calls += 1
+            return super().render(*args, **kwargs)
+
+    provider = CountingProvider()
+    engine = PreviewEngine([provider])
+    request = PreviewRenderRequest(
+        platform=PreviewPlatform.markdown,
+        title="Same",
+        content="![cover](./cover.png)",
+    )
+    first = engine.render(
+        request,
+        source=PreviewSource(article_id="art_001", working_copy_fingerprint="sha256:same"),
+        asset_base_url="/api/articles/art_001/assets/by-filename",
+    )
+    second = engine.render(
+        request,
+        source=PreviewSource(article_id="art_002", working_copy_fingerprint="sha256:same"),
+        asset_base_url="/api/articles/art_002/assets/by-filename",
+    )
+
+    assert provider.calls == 2
+    assert first.source.article_id == "art_001"
+    assert second.source.article_id == "art_002"
+    assert "/art_001/assets/" in first.html
+    assert "/art_002/assets/" in second.html
 
 
 def test_render_api_uses_revision_for_saved_content(client):

--- a/tests/tests_backend/test_live_previews.py
+++ b/tests/tests_backend/test_live_previews.py
@@ -1,0 +1,115 @@
+from backend.schemas.previews import PreviewPlatform, PreviewRenderRequest, PreviewSource
+from backend.services.platform_previews.engine import (
+    MarkdownPreviewProvider,
+    PreviewEngine,
+    working_copy_fingerprint,
+)
+
+
+def test_fingerprint_is_deterministic_and_normalizes_line_endings():
+    assert working_copy_fingerprint("Title", "one\r\ntwo") == working_copy_fingerprint(
+        "Title", "one\ntwo"
+    )
+
+
+def test_markdown_renderer_escapes_raw_html_and_unsafe_links():
+    provider = MarkdownPreviewProvider()
+    artifact = provider.render(
+        PreviewRenderRequest(
+            platform=PreviewPlatform.markdown,
+            title="Safe",
+            content="<script>alert(1)</script>\n\n[x](javascript:alert(2))",
+        ),
+        source=PreviewSource(article_id="art_001", working_copy_fingerprint="sha256:x"),
+        asset_base_url="/assets",
+    )
+
+    assert "<script>" not in artifact.html
+    assert "&lt;script&gt;" in artifact.html
+    assert 'href="javascript:' not in artifact.html
+    assert artifact.warnings[0].code == "raw_html_escaped"
+
+
+def test_markdown_renderer_rewrites_local_images_only():
+    provider = MarkdownPreviewProvider()
+    artifact = provider.render(
+        PreviewRenderRequest(
+            platform=PreviewPlatform.markdown,
+            title="Images",
+            content="![local](./images/photo.png)\n\n![remote](https://example.com/a.png)",
+        ),
+        source=PreviewSource(article_id="art_001", working_copy_fingerprint="sha256:x"),
+        asset_base_url="/api/articles/art_001/assets/by-filename",
+    )
+
+    assert "/api/articles/art_001/assets/by-filename/images/photo.png" in artifact.html
+    assert "https://example.com/a.png" in artifact.html
+
+
+def test_engine_cache_is_keyed_by_fingerprint_and_returns_copies():
+    class CountingProvider(MarkdownPreviewProvider):
+        calls = 0
+
+        def render(self, *args, **kwargs):
+            self.calls += 1
+            return super().render(*args, **kwargs)
+
+    provider = CountingProvider()
+    engine = PreviewEngine([provider])
+    request = PreviewRenderRequest(platform=PreviewPlatform.markdown, title="A", content="B")
+    source = PreviewSource(article_id="art_001", working_copy_fingerprint="sha256:same")
+
+    first = engine.render(request, source=source, asset_base_url="/assets")
+    second = engine.render(request, source=source, asset_base_url="/assets")
+    second.html = "changed"
+
+    assert provider.calls == 1
+    assert first.html != second.html
+
+
+def test_render_api_uses_revision_for_saved_content(client):
+    article = client.get("/api/articles/art_001").json()
+    response = client.post(
+        "/api/articles/art_001/previews/render",
+        json={
+            "platform": "markdown",
+            "viewport": "desktop",
+            "title": article["title"],
+            "content": article["content"],
+            "base_revision_id": article["revision_id"],
+        },
+    )
+
+    assert response.status_code == 200
+    artifact = response.json()
+    assert artifact["state"] == "current"
+    assert artifact["source"]["revision_id"] == article["revision_id"]
+    assert artifact["source"]["working_copy_fingerprint"] is None
+
+
+def test_render_api_uses_fingerprint_for_unsaved_content(client):
+    article = client.get("/api/articles/art_001").json()
+    response = client.post(
+        "/api/articles/art_001/previews/render",
+        json={
+            "platform": "markdown",
+            "title": article["title"],
+            "content": article["content"] + "\nUnsaved",
+            "base_revision_id": article["revision_id"],
+        },
+    )
+
+    assert response.status_code == 200
+    source = response.json()["source"]
+    assert source["revision_id"] is None
+    assert source["working_copy_fingerprint"].startswith("sha256:")
+
+
+def test_unregistered_renderer_returns_typed_not_supported(client):
+    response = client.post(
+        "/api/articles/art_001/previews/render",
+        json={"platform": "hashnode", "title": "T", "content": "Body"},
+    )
+
+    assert response.status_code == 501
+    assert response.json()["detail"]["code"] == "preview_not_supported"


### PR DESCRIPTION
Adds the sanitized CommonMark renderer, working-copy fingerprints, revision-aware preview API, bounded renderer cache, and authenticated local image delivery.\n\nStacked on #80.\nCloses #81