### PR TITLE
feat: add live Hashnode preview renderer

### DIFF
--- a/backend/routers/previews.py
+++ b/backend/routers/previews.py
@@ -10,7 +10,8 @@ from backend.schemas.previews import (
     PreviewRenderRequest,
     PreviewSource,
 )
-from backend.services.platform_previews.engine import preview_engine, working_copy_fingerprint
+from backend.services.platform_previews.engine import working_copy_fingerprint
+from backend.services.platform_previews.registry import preview_engine
 
 
 router = APIRouter(prefix="/api/articles/{article_id}/previews", tags=["previews"])
@@ -54,4 +55,3 @@ def render_preview(article_id: str, body: PreviewRenderRequest, request: Request
             status_code=501,
             detail={"code": "preview_not_supported", "platform": str(exc.args[0])},
         ) from exc
-

--- a/backend/services/platform_previews/engine.py
+++ b/backend/services/platform_previews/engine.py
@@ -162,6 +162,3 @@ class PreviewEngine:
             while len(self._cache) > self._max_cache_entries:
                 self._cache.popitem(last=False)
         return artifact
-
-
-preview_engine = PreviewEngine([MarkdownPreviewProvider()])

--- a/backend/services/platform_previews/hashnode.py
+++ b/backend/services/platform_previews/hashnode.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import html
 import re
 
-from blogs.hashnode.render import render_markdown
+from blogs.hashnode.render import PLANNING_MARKERS, render_markdown
 from backend.schemas.previews import (
     PreviewArtifact,
     PreviewCapabilities,
@@ -62,11 +62,14 @@ class HashnodePreviewProvider:
     ) -> PreviewArtifact:
         normalized = render_markdown(request.content)
         body, warnings = render_markdown_fragment(normalized.body_markdown, asset_base_url)
-        if normalized.body_markdown.strip() != request.content.strip():
+        if any(line.strip().startswith(PLANNING_MARKERS) for line in request.content.splitlines()):
             warnings.append(PreviewWarning(
-                code="hashnode_content_normalized",
-                message="Title or publishing notes were moved out of the Hashnode article body.",
-                severity="info",
+                code="hashnode_planning_tail_removed",
+                message=(
+                    "Hashnode omits the publishing marker and all content after it from the "
+                    "article body."
+                ),
+                severity="warning",
             ))
         words = len(re.findall(r"\w+", normalized.body_markdown))
         read_minutes = max(1, round(words / 220))
@@ -94,4 +97,3 @@ class HashnodePreviewProvider:
             ),
             warnings=warnings,
         )
-

--- a/backend/services/platform_previews/hashnode.py
+++ b/backend/services/platform_previews/hashnode.py
@@ -1,0 +1,97 @@
+"""Deterministic Hashnode-like live preview renderer."""
+from __future__ import annotations
+
+import html
+import re
+
+from blogs.hashnode.render import render_markdown
+from backend.schemas.previews import (
+    PreviewArtifact,
+    PreviewCapabilities,
+    PreviewPlatform,
+    PreviewRenderRequest,
+    PreviewSource,
+    PreviewState,
+    PreviewViewport,
+    PreviewWarning,
+)
+from backend.services.platform_previews.engine import preview_document, render_markdown_fragment
+
+
+HASHNODE_CSS = """
+:root{color-scheme:light}*{box-sizing:border-box}body{margin:0;background:#fff;color:#111827;
+font-family:Inter,ui-sans-serif,system-ui,-apple-system,sans-serif}.site-header{height:64px;border-bottom:1px solid #e5e7eb;
+display:flex;align-items:center;padding:0 24px;gap:12px;position:sticky;top:0;background:#fffffffa}.brand-mark{width:34px;
+height:34px;border-radius:7px;background:#2563eb;color:#fff;display:grid;place-items:center;font-weight:800}.brand{font-weight:700}
+.search{margin-left:auto;width:180px;height:34px;border:1px solid #d1d5db;border-radius:7px;color:#9ca3af;padding:7px 11px;
+font-size:13px}.page{width:min(1040px,100%);margin:0 auto;padding:48px 24px 80px}.article-head{width:min(800px,100%);
+margin:0 auto 30px}.eyebrow{font-size:13px;color:#2563eb;font-weight:600;margin-bottom:15px}.article-title{font-size:48px;
+line-height:1.12;letter-spacing:0;margin:0 0 15px;font-weight:800;color:#111827}.subtitle{font-size:20px;line-height:1.5;
+color:#4b5563;margin:0 0 24px}.byline{display:flex;align-items:center;gap:11px;color:#4b5563;font-size:13px}.avatar{width:38px;
+height:38px;border-radius:50%;background:#dbeafe;color:#1d4ed8;display:grid;place-items:center;font-weight:700}.author{color:#111827;
+font-weight:600}.layout{width:min(920px,100%);margin:0 auto;display:grid;grid-template-columns:52px minmax(0,800px);gap:24px}
+.rail{padding-top:8px;display:flex;flex-direction:column;align-items:center;gap:15px;color:#6b7280;font-size:12px}.rail-button{width:38px;
+height:38px;border:1px solid #e5e7eb;border-radius:50%;display:grid;place-items:center;background:#fff}.content{font-family:Georgia,
+'Times New Roman',serif;font-size:19px;line-height:1.82;color:#1f2937;min-width:0}.content h1,.content h2,.content h3{
+font-family:Inter,ui-sans-serif,system-ui,sans-serif;line-height:1.25;color:#111827;letter-spacing:0}.content h1{font-size:34px}
+.content h2{font-size:28px;margin:1.7em 0 .55em}.content h3{font-size:22px;margin:1.5em 0 .5em}.content p,.content ul,
+.content ol,.content blockquote,.content pre,.content table{margin:0 0 1.35em}.content a{color:#2563eb}.content img{display:block;
+max-width:100%;height:auto;border-radius:5px;margin:2em auto}.content blockquote{border-left:4px solid #2563eb;margin-left:0;padding:
+.2em 0 .2em 1.2em;color:#4b5563;font-style:italic}.content pre{overflow:auto;background:#111827;color:#e5e7eb;padding:18px;
+border-radius:7px}.content code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.86em}.content table{width:100%;
+border-collapse:collapse;font-family:Inter,ui-sans-serif,system-ui,sans-serif;font-size:14px}.content th,.content td{border:1px solid #d1d5db;
+padding:9px 11px;text-align:left}.content th{background:#f9fafb}@media(max-width:640px){.site-header{height:56px;padding:0 14px}
+.search{display:none}.page{padding:28px 18px 56px}.article-title{font-size:34px}.subtitle{font-size:17px}.layout{display:block}
+.rail{display:none}.content{font-size:17px;line-height:1.75}.content h2{font-size:24px}}
+"""
+
+
+class HashnodePreviewProvider:
+    capabilities = PreviewCapabilities(
+        platform=PreviewPlatform.hashnode,
+        renderer_version="hashnode-1",
+        viewports=[PreviewViewport.desktop, PreviewViewport.mobile],
+    )
+
+    def render(
+        self,
+        request: PreviewRenderRequest,
+        *,
+        source: PreviewSource,
+        asset_base_url: str,
+    ) -> PreviewArtifact:
+        normalized = render_markdown(request.content)
+        body, warnings = render_markdown_fragment(normalized.body_markdown, asset_base_url)
+        if normalized.body_markdown.strip() != request.content.strip():
+            warnings.append(PreviewWarning(
+                code="hashnode_content_normalized",
+                message="Title or publishing notes were moved out of the Hashnode article body.",
+                severity="info",
+            ))
+        words = len(re.findall(r"\w+", normalized.body_markdown))
+        read_minutes = max(1, round(words / 220))
+        subtitle = normalized.subtitle or "Live preview of the article as it will appear on Hashnode."
+        shell = f"""
+<header class="site-header"><div class="brand-mark">H</div><div class="brand">Publication</div>
+<div class="search">Search articles</div></header>
+<main class="page"><header class="article-head"><div class="eyebrow">Publication</div>
+<h1 class="article-title">{html.escape(request.title)}</h1>
+<p class="subtitle">{html.escape(subtitle)}</p><div class="byline"><div class="avatar">B</div>
+<div><div class="author">BlogHub author</div><div>{read_minutes} min read</div></div></div></header>
+<div class="layout"><aside class="rail" aria-hidden="true"><div class="rail-button">♡</div><span>0</span>
+<div class="rail-button">↗</div></aside><article class="content">{body}</article></div></main>"""
+        return PreviewArtifact(
+            state=PreviewState.current,
+            platform=self.capabilities.platform,
+            viewport=request.viewport,
+            renderer_version=self.capabilities.renderer_version,
+            source=source,
+            html=preview_document(
+                title=request.title,
+                platform=self.capabilities.platform.value,
+                css=HASHNODE_CSS,
+                body=shell,
+            ),
+            warnings=warnings,
+        )
+

--- a/backend/services/platform_previews/registry.py
+++ b/backend/services/platform_previews/registry.py
@@ -1,0 +1,7 @@
+"""Configured live preview providers."""
+
+from backend.services.platform_previews.engine import MarkdownPreviewProvider, PreviewEngine
+from backend.services.platform_previews.hashnode import HashnodePreviewProvider
+
+
+preview_engine = PreviewEngine([MarkdownPreviewProvider(), HashnodePreviewProvider()])

--- a/tests/tests_backend/test_hashnode_live_preview.py
+++ b/tests/tests_backend/test_hashnode_live_preview.py
@@ -1,0 +1,57 @@
+from backend.schemas.previews import PreviewPlatform, PreviewRenderRequest, PreviewSource
+from backend.services.platform_previews.hashnode import HashnodePreviewProvider
+
+
+SOURCE = PreviewSource(article_id="art_001", working_copy_fingerprint="sha256:test")
+
+
+def test_hashnode_preview_has_platform_shell_and_normalized_content():
+    artifact = HashnodePreviewProvider().render(
+        PreviewRenderRequest(
+            platform=PreviewPlatform.hashnode,
+            title="A practical guide",
+            content="# A practical guide\n\nA useful introduction.\n\n## First step\n\nDo this.",
+        ),
+        source=SOURCE,
+        asset_base_url="/assets",
+    )
+
+    assert artifact.renderer_version == "hashnode-1"
+    assert 'data-preview-platform="hashnode"' in artifact.html
+    assert '<h1 class="article-title">A practical guide</h1>' in artifact.html
+    assert artifact.html.count("A practical guide") == 2  # document title + visible title
+    assert "A useful introduction." in artifact.html
+    assert any(w.code == "hashnode_content_normalized" for w in artifact.warnings)
+
+
+def test_hashnode_preview_uses_authenticated_asset_urls():
+    artifact = HashnodePreviewProvider().render(
+        PreviewRenderRequest(
+            platform=PreviewPlatform.hashnode,
+            title="Images",
+            content="![diagram](./diagram.png)",
+            viewport="mobile",
+        ),
+        source=SOURCE,
+        asset_base_url="/api/articles/art_001/assets/by-filename",
+    )
+
+    assert artifact.viewport.value == "mobile"
+    assert "/api/articles/art_001/assets/by-filename/diagram.png" in artifact.html
+    assert "@media(max-width:640px)" in artifact.html
+
+
+def test_hashnode_renderer_is_available_through_api(client):
+    response = client.post(
+        "/api/articles/art_001/previews/render",
+        json={
+            "platform": "hashnode",
+            "viewport": "desktop",
+            "title": "Preview title",
+            "content": "Intro paragraph.",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["platform"] == "hashnode"
+    assert "Preview title" in response.json()["html"]

--- a/tests/tests_backend/test_hashnode_live_preview.py
+++ b/tests/tests_backend/test_hashnode_live_preview.py
@@ -21,7 +21,24 @@ def test_hashnode_preview_has_platform_shell_and_normalized_content():
     assert '<h1 class="article-title">A practical guide</h1>' in artifact.html
     assert artifact.html.count("A practical guide") == 2  # document title + visible title
     assert "A useful introduction." in artifact.html
-    assert any(w.code == "hashnode_content_normalized" for w in artifact.warnings)
+    assert not artifact.warnings
+
+
+def test_hashnode_preview_warns_when_the_planning_tail_is_removed():
+    artifact = HashnodePreviewProvider().render(
+        PreviewRenderRequest(
+            platform=PreviewPlatform.hashnode,
+            title="Notes",
+            content="# Notes\r\n\r\nBody.\r\n\r\n**Tags:** Python\r\n\r\n## Hidden section",
+        ),
+        source=SOURCE,
+        asset_base_url="/assets",
+    )
+
+    warning = next(w for w in artifact.warnings if w.code == "hashnode_planning_tail_removed")
+    assert warning.severity == "warning"
+    assert "all content after it" in warning.message
+    assert "Hidden section" not in artifact.html
 
 
 def test_hashnode_preview_uses_authenticated_asset_urls():

--- a/tests/tests_backend/test_live_previews.py
+++ b/tests/tests_backend/test_live_previews.py
@@ -1,3 +1,5 @@
+import pytest
+
 from backend.schemas.previews import PreviewPlatform, PreviewRenderRequest, PreviewSource
 from backend.services.platform_previews.engine import (
     MarkdownPreviewProvider,
@@ -153,11 +155,10 @@ def test_render_api_uses_fingerprint_for_unsaved_content(client):
     assert source["working_copy_fingerprint"].startswith("sha256:")
 
 
-def test_unregistered_renderer_returns_typed_not_supported(client):
-    response = client.post(
-        "/api/articles/art_001/previews/render",
-        json={"platform": "hashnode", "title": "T", "content": "Body"},
-    )
+def test_engine_rejects_an_unregistered_renderer():
+    engine = PreviewEngine([])
+    request = PreviewRenderRequest(platform=PreviewPlatform.hashnode, title="T", content="Body")
+    source = PreviewSource(article_id="art_001", working_copy_fingerprint="sha256:none")
 
-    assert response.status_code == 501
-    assert response.json()["detail"]["code"] == "preview_not_supported"
+    with pytest.raises(KeyError, match="hashnode"):
+        engine.render(request, source=source, asset_base_url="/assets")

--- a/tests/tests_backend/test_live_previews.py
+++ b/tests/tests_backend/test_live_previews.py
@@ -1,5 +1,3 @@
-import pytest
-
 from backend.schemas.previews import PreviewPlatform, PreviewRenderRequest, PreviewSource
 from backend.services.platform_previews.engine import (
     MarkdownPreviewProvider,
@@ -155,10 +153,14 @@ def test_render_api_uses_fingerprint_for_unsaved_content(client):
     assert source["working_copy_fingerprint"].startswith("sha256:")
 
 
-def test_engine_rejects_an_unregistered_renderer():
-    engine = PreviewEngine([])
-    request = PreviewRenderRequest(platform=PreviewPlatform.hashnode, title="T", content="Body")
-    source = PreviewSource(article_id="art_001", working_copy_fingerprint="sha256:none")
+def test_unregistered_renderer_returns_typed_not_supported(client):
+    response = client.post(
+        "/api/articles/art_001/previews/render",
+        json={"platform": "medium", "title": "T", "content": "Body"},
+    )
 
-    with pytest.raises(KeyError, match="hashnode"):
-        engine.render(request, source=source, asset_base_url="/assets")
+    assert response.status_code == 501
+    assert response.json()["detail"] == {
+        "code": "preview_not_supported",
+        "platform": "medium",
+    }


### PR DESCRIPTION
Adds a versioned Hashnode simulation using the existing Hashnode publish normalization, responsive platform styling, authenticated assets, and focused tests.\n\nStacked on #81.\nCloses #82