### PR TITLE
feat: add live Medium preview renderer

### DIFF
--- a/backend/services/platform_previews/medium.py
+++ b/backend/services/platform_previews/medium.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 import html
 import re
 
-from blogs.medium.render import render_markdown
+from blogs.hashnode.client import HashnodeClient
+from blogs.hashnode.render import _derive_summary_from_markdown
+from blogs.medium._render import PLANNING_MARKERS, render_medium_markdown
 from backend.schemas.previews import (
     PreviewArtifact,
     PreviewCapabilities,
@@ -44,11 +46,6 @@ border-bottom:1px solid #d9d9d9;padding:10px 8px;text-align:left}@media(max-widt
 .content{font-size:18px;line-height:1.68}.content h2{font-size:26px}.content blockquote{margin-left:0}.actions{margin-top:24px}}
 """
 
-
-def _without_first_title(markdown: str) -> str:
-    return re.sub(r"(?m)^#\s+[^\n]+\n?", "", markdown, count=1).lstrip()
-
-
 class MediumPreviewProvider:
     capabilities = PreviewCapabilities(
         platform=PreviewPlatform.medium,
@@ -63,24 +60,24 @@ class MediumPreviewProvider:
         source: PreviewSource,
         asset_base_url: str,
     ) -> PreviewArtifact:
-        normalized = render_markdown(request.content, image_base_url=asset_base_url)
-        body_markdown = _without_first_title(normalized.body_markdown)
+        normalized = render_medium_markdown(request.content, image_base_url=None)
+        body_markdown = HashnodeClient.strip_leading_h1(normalized.body_markdown)
         body, warnings = render_markdown_fragment(body_markdown, asset_base_url)
-        if body_markdown.strip() != request.content.strip():
+        if any(line.strip().startswith(PLANNING_MARKERS) for line in request.content.splitlines()):
             warnings.append(PreviewWarning(
-                code="medium_content_normalized",
-                message="Title or publishing notes were moved out of the Medium article body.",
-                severity="info",
+                code="medium_planning_tail_removed",
+                message=(
+                    "Medium omits the publishing marker and all content after it from the "
+                    "article body."
+                ),
+                severity="warning",
             ))
         if re.search(r"(?m)^\s*\|.+\|\s*$", body_markdown):
             warnings.append(PreviewWarning(
                 code="medium_table_approximation",
                 message="Medium may transform table layout when the article is published.",
             ))
-        description = body_markdown
-        description = re.sub(r"[#>*_`\[\]()]", "", description)
-        description = re.sub(r"\s+", " ", description).strip()
-        subtitle = (description[:157].rstrip() + "...") if len(description) > 160 else description
+        subtitle = _derive_summary_from_markdown(body_markdown)
         subtitle = subtitle or "Live preview of the article as it will appear on Medium."
         words = len(re.findall(r"\w+", body_markdown))
         read_minutes = max(1, round(words / 240))

--- a/backend/services/platform_previews/medium.py
+++ b/backend/services/platform_previews/medium.py
@@ -1,0 +1,108 @@
+"""Deterministic Medium-like live preview renderer."""
+from __future__ import annotations
+
+import html
+import re
+
+from blogs.medium.render import render_markdown
+from backend.schemas.previews import (
+    PreviewArtifact,
+    PreviewCapabilities,
+    PreviewPlatform,
+    PreviewRenderRequest,
+    PreviewSource,
+    PreviewState,
+    PreviewViewport,
+    PreviewWarning,
+)
+from backend.services.platform_previews.engine import preview_document, render_markdown_fragment
+
+
+MEDIUM_CSS = """
+:root{color-scheme:light}*{box-sizing:border-box}body{margin:0;background:#fff;color:#242424;
+font-family:sohne,Inter,ui-sans-serif,system-ui,sans-serif}.site-header{height:57px;border-bottom:1px solid #e6e6e6;
+display:flex;align-items:center;padding:0 max(24px,calc((100% - 1192px)/2));gap:22px;background:#fff}.wordmark{font-family:
+Georgia,'Times New Roman',serif;font-size:30px;font-weight:700;line-height:1}.search{height:38px;width:220px;border-radius:20px;
+background:#f2f2f2;color:#6b6b6b;padding:10px 16px;font-size:13px}.header-actions{margin-left:auto;display:flex;align-items:center;
+gap:18px;color:#6b6b6b;font-size:13px}.write{color:#242424}.page{width:min(740px,100%);margin:0 auto;padding:54px 30px 90px}
+.article-title{font-family:Georgia,'Times New Roman',serif;font-size:46px;line-height:1.12;letter-spacing:0;font-weight:700;
+margin:0 0 14px;color:#242424}.subtitle{font-family:Georgia,'Times New Roman',serif;font-size:22px;line-height:1.4;
+color:#6b6b6b;margin:0 0 28px}.byline{display:flex;align-items:center;gap:12px;font-size:13px;color:#6b6b6b}.avatar{width:42px;
+height:42px;border-radius:50%;background:#1a8917;color:#fff;display:grid;place-items:center;font-weight:600}.author{color:#242424;
+margin-bottom:3px}.actions{height:52px;border-top:1px solid #e6e6e6;border-bottom:1px solid #e6e6e6;margin:30px 0 36px;
+display:flex;align-items:center;gap:24px;color:#6b6b6b;font-size:13px}.actions .right{margin-left:auto}.content{font-family:
+Georgia,'Times New Roman',serif;font-size:20px;line-height:1.65;color:#242424}.content h1,.content h2,.content h3{
+font-family:Georgia,'Times New Roman',serif;line-height:1.18;color:#242424;letter-spacing:0}.content h1{font-size:34px}
+.content h2{font-size:30px;margin:1.7em 0 .55em}.content h3{font-size:24px;margin:1.5em 0 .5em}.content p,
+.content ul,.content ol,.content blockquote,.content pre,.content table{margin:0 0 1.45em}.content a{color:inherit;text-decoration:underline}
+.content img{display:block;width:auto;max-width:min(100%,900px);height:auto;margin:2.2em auto}.content blockquote{border-left:3px solid #242424;
+margin-left:-20px;padding:.1em 0 .1em 20px;font-size:22px;font-style:italic}.content pre{overflow:auto;background:#f2f2f2;
+padding:17px 20px}.content code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.82em}.content table{width:100%;
+border-collapse:collapse;font-family:sohne,Inter,ui-sans-serif,system-ui,sans-serif;font-size:14px}.content th,.content td{
+border-bottom:1px solid #d9d9d9;padding:10px 8px;text-align:left}@media(max-width:640px){.site-header{height:52px;padding:0 16px}
+.search,.write{display:none}.wordmark{font-size:26px}.page{padding:34px 20px 60px}.article-title{font-size:36px}.subtitle{font-size:19px}
+.content{font-size:18px;line-height:1.68}.content h2{font-size:26px}.content blockquote{margin-left:0}.actions{margin-top:24px}}
+"""
+
+
+def _without_first_title(markdown: str) -> str:
+    return re.sub(r"(?m)^#\s+[^\n]+\n?", "", markdown, count=1).lstrip()
+
+
+class MediumPreviewProvider:
+    capabilities = PreviewCapabilities(
+        platform=PreviewPlatform.medium,
+        renderer_version="medium-1",
+        viewports=[PreviewViewport.desktop, PreviewViewport.mobile],
+    )
+
+    def render(
+        self,
+        request: PreviewRenderRequest,
+        *,
+        source: PreviewSource,
+        asset_base_url: str,
+    ) -> PreviewArtifact:
+        normalized = render_markdown(request.content, image_base_url=asset_base_url)
+        body_markdown = _without_first_title(normalized.body_markdown)
+        body, warnings = render_markdown_fragment(body_markdown, asset_base_url)
+        if body_markdown.strip() != request.content.strip():
+            warnings.append(PreviewWarning(
+                code="medium_content_normalized",
+                message="Title or publishing notes were moved out of the Medium article body.",
+                severity="info",
+            ))
+        if re.search(r"(?m)^\s*\|.+\|\s*$", body_markdown):
+            warnings.append(PreviewWarning(
+                code="medium_table_approximation",
+                message="Medium may transform table layout when the article is published.",
+            ))
+        description = body_markdown
+        description = re.sub(r"[#>*_`\[\]()]", "", description)
+        description = re.sub(r"\s+", " ", description).strip()
+        subtitle = (description[:157].rstrip() + "...") if len(description) > 160 else description
+        subtitle = subtitle or "Live preview of the article as it will appear on Medium."
+        words = len(re.findall(r"\w+", body_markdown))
+        read_minutes = max(1, round(words / 240))
+        shell = f"""
+<header class="site-header"><div class="wordmark">Medium</div><div class="search">Search</div>
+<div class="header-actions"><span class="write">Write</span><span>Sign up</span></div></header>
+<main class="page"><header><h1 class="article-title">{html.escape(request.title)}</h1>
+<p class="subtitle">{html.escape(subtitle)}</p><div class="byline"><div class="avatar">B</div>
+<div><div class="author">BlogHub author</div><div>{read_minutes} min read</div></div></div></header>
+<div class="actions" aria-hidden="true"><span>♡ 0</span><span>◯ 0</span><span class="right">⌑</span><span>↗</span></div>
+<article class="content">{body}</article></main>"""
+        return PreviewArtifact(
+            state=PreviewState.current,
+            platform=self.capabilities.platform,
+            viewport=request.viewport,
+            renderer_version=self.capabilities.renderer_version,
+            source=source,
+            html=preview_document(
+                title=request.title,
+                platform=self.capabilities.platform.value,
+                css=MEDIUM_CSS,
+                body=shell,
+            ),
+            warnings=warnings,
+        )

--- a/backend/services/platform_previews/registry.py
+++ b/backend/services/platform_previews/registry.py
@@ -2,6 +2,11 @@
 
 from backend.services.platform_previews.engine import MarkdownPreviewProvider, PreviewEngine
 from backend.services.platform_previews.hashnode import HashnodePreviewProvider
+from backend.services.platform_previews.medium import MediumPreviewProvider
 
 
-preview_engine = PreviewEngine([MarkdownPreviewProvider(), HashnodePreviewProvider()])
+preview_engine = PreviewEngine([
+    MarkdownPreviewProvider(),
+    HashnodePreviewProvider(),
+    MediumPreviewProvider(),
+])

--- a/blogs/hashnode/render.py
+++ b/blogs/hashnode/render.py
@@ -113,6 +113,9 @@ def _derive_summary_from_markdown(markdown_text: str, *, max_length: int = 160) 
         stripped = block.strip()
         if not stripped or stripped.startswith("#") or stripped == "---" or stripped.startswith("!["):
             continue
+        lines = [line.strip() for line in stripped.splitlines() if line.strip()]
+        if len(lines) >= 2 and all(line.startswith("|") and line.endswith("|") for line in lines):
+            continue
         if stripped.startswith("*") and stripped.endswith("*") and "\n" not in stripped:
             continue
         plain = stripped

--- a/tests/tests_backend/test_live_previews.py
+++ b/tests/tests_backend/test_live_previews.py
@@ -153,7 +153,14 @@ def test_render_api_uses_fingerprint_for_unsaved_content(client):
     assert source["working_copy_fingerprint"].startswith("sha256:")
 
 
-def test_unregistered_renderer_returns_typed_not_supported(client):
+def test_unregistered_renderer_returns_typed_not_supported(client, monkeypatch):
+    from backend.routers import previews as previews_router
+
+    class MissingProviderEngine:
+        def render(self, request, **kwargs):
+            raise KeyError(request.platform.value)
+
+    monkeypatch.setattr(previews_router, "preview_engine", MissingProviderEngine())
     response = client.post(
         "/api/articles/art_001/previews/render",
         json={"platform": "medium", "title": "T", "content": "Body"},

--- a/tests/tests_backend/test_medium_live_preview.py
+++ b/tests/tests_backend/test_medium_live_preview.py
@@ -1,0 +1,57 @@
+from backend.schemas.previews import PreviewPlatform, PreviewRenderRequest, PreviewSource
+from backend.services.platform_previews.medium import MediumPreviewProvider
+
+
+SOURCE = PreviewSource(article_id="art_001", working_copy_fingerprint="sha256:test")
+
+
+def test_medium_preview_has_editorial_shell_without_duplicate_body_title():
+    artifact = MediumPreviewProvider().render(
+        PreviewRenderRequest(
+            platform=PreviewPlatform.medium,
+            title="A practical guide",
+            content="# A practical guide\n\nA useful introduction.\n\n## First step\n\nDo this.",
+        ),
+        source=SOURCE,
+        asset_base_url="/assets",
+    )
+
+    assert artifact.renderer_version == "medium-1"
+    assert 'data-preview-platform="medium"' in artifact.html
+    assert '<h1 class="article-title">A practical guide</h1>' in artifact.html
+    assert artifact.html.count("A practical guide") == 2  # document title + visible title
+    assert "font-family:Georgia" in artifact.html
+    assert any(w.code == "medium_content_normalized" for w in artifact.warnings)
+
+
+def test_medium_preview_warns_about_table_approximation():
+    artifact = MediumPreviewProvider().render(
+        PreviewRenderRequest(
+            platform=PreviewPlatform.medium,
+            title="Table",
+            content="| A | B |\n| - | - |\n| 1 | 2 |",
+            viewport="mobile",
+        ),
+        source=SOURCE,
+        asset_base_url="/assets",
+    )
+
+    assert artifact.viewport.value == "mobile"
+    assert any(w.code == "medium_table_approximation" for w in artifact.warnings)
+    assert "<table>" in artifact.html
+
+
+def test_medium_renderer_is_available_through_api(client):
+    response = client.post(
+        "/api/articles/art_001/previews/render",
+        json={
+            "platform": "medium",
+            "viewport": "desktop",
+            "title": "Preview title",
+            "content": "Intro paragraph.",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["platform"] == "medium"
+    assert "Preview title" in response.json()["html"]

--- a/tests/tests_backend/test_medium_live_preview.py
+++ b/tests/tests_backend/test_medium_live_preview.py
@@ -21,7 +21,69 @@ def test_medium_preview_has_editorial_shell_without_duplicate_body_title():
     assert '<h1 class="article-title">A practical guide</h1>' in artifact.html
     assert artifact.html.count("A practical guide") == 2  # document title + visible title
     assert "font-family:Georgia" in artifact.html
-    assert any(w.code == "medium_content_normalized" for w in artifact.warnings)
+    assert not any(w.code == "medium_planning_tail_removed" for w in artifact.warnings)
+
+
+def test_medium_preview_only_strips_a_leading_title():
+    artifact = MediumPreviewProvider().render(
+        PreviewRenderRequest(
+            platform=PreviewPlatform.medium,
+            title="A practical guide",
+            content="Intro before the section.\n\n# A real section\n\nKeep this heading.",
+        ),
+        source=SOURCE,
+        asset_base_url="/assets",
+    )
+
+    assert "A real section" in artifact.html
+
+
+def test_medium_preview_rewrites_local_images_once():
+    artifact = MediumPreviewProvider().render(
+        PreviewRenderRequest(
+            platform=PreviewPlatform.medium,
+            title="Images",
+            content="![diagram](./img/diagram.png)",
+        ),
+        source=SOURCE,
+        asset_base_url="assets",
+    )
+
+    assert 'src="assets/img/diagram.png"' in artifact.html
+    assert "assets/assets/" not in artifact.html
+
+
+def test_medium_preview_derives_subtitle_from_prose_not_a_table():
+    artifact = MediumPreviewProvider().render(
+        PreviewRenderRequest(
+            platform=PreviewPlatform.medium,
+            title="Table",
+            content=(
+                "| A | B |\n| - | - |\n| 1 | 2 |\n\n"
+                "This is the useful prose summary that follows the table."
+            ),
+        ),
+        source=SOURCE,
+        asset_base_url="/assets",
+    )
+
+    assert '<p class="subtitle">This is the useful prose summary that follows the table.</p>' in artifact.html
+
+
+def test_medium_preview_warns_when_planning_tail_is_removed():
+    artifact = MediumPreviewProvider().render(
+        PreviewRenderRequest(
+            platform=PreviewPlatform.medium,
+            title="Plan",
+            content="Visible.\r\n\r\n**Tags:** preview\r\n\r\n## Hidden section",
+        ),
+        source=SOURCE,
+        asset_base_url="/assets",
+    )
+
+    warning = next(w for w in artifact.warnings if w.code == "medium_planning_tail_removed")
+    assert warning.severity == "warning"
+    assert "Hidden section" not in artifact.html
 
 
 def test_medium_preview_warns_about_table_approximation():


### PR DESCRIPTION
Adds a versioned Medium simulation using the existing Medium publish normalization, responsive editorial styling, transformation warnings, and focused tests.\n\nStacked on #82.\nCloses #83