### PR TITLE
feat: add Markdown and platform preview modes to editor

### DIFF
--- a/backend/services/platform_previews/hashnode.py
+++ b/backend/services/platform_previews/hashnode.py
@@ -31,8 +31,8 @@ color:#4b5563;margin:0 0 24px}.byline{display:flex;align-items:center;gap:11px;c
 height:38px;border-radius:50%;background:#dbeafe;color:#1d4ed8;display:grid;place-items:center;font-weight:700}.author{color:#111827;
 font-weight:600}.layout{width:min(920px,100%);margin:0 auto;display:grid;grid-template-columns:52px minmax(0,800px);gap:24px}
 .rail{padding-top:8px;display:flex;flex-direction:column;align-items:center;gap:15px;color:#6b7280;font-size:12px}.rail-button{width:38px;
-height:38px;border:1px solid #e5e7eb;border-radius:50%;display:grid;place-items:center;background:#fff}.content{font-family:Georgia,
-'Times New Roman',serif;font-size:19px;line-height:1.82;color:#1f2937;min-width:0}.content h1,.content h2,.content h3{
+height:38px;border:1px solid #e5e7eb;border-radius:50%;display:grid;place-items:center;background:#fff}.content{font-family:Inter,
+ui-sans-serif,system-ui,sans-serif;font-size:18px;line-height:1.78;color:#1f2937;min-width:0}.content h1,.content h2,.content h3{
 font-family:Inter,ui-sans-serif,system-ui,sans-serif;line-height:1.25;color:#111827;letter-spacing:0}.content h1{font-size:34px}
 .content h2{font-size:28px;margin:1.7em 0 .55em}.content h3{font-size:22px;margin:1.5em 0 .5em}.content p,.content ul,
 .content ol,.content blockquote,.content pre,.content table{margin:0 0 1.35em}.content a{color:#2563eb}.content img{display:block;
@@ -49,7 +49,7 @@ padding:9px 11px;text-align:left}.content th{background:#f9fafb}@media(max-width
 class HashnodePreviewProvider:
     capabilities = PreviewCapabilities(
         platform=PreviewPlatform.hashnode,
-        renderer_version="hashnode-1",
+        renderer_version="hashnode-2",
         viewports=[PreviewViewport.desktop, PreviewViewport.mobile],
     )
 

--- a/backend/services/platform_previews/medium.py
+++ b/backend/services/platform_previews/medium.py
@@ -49,7 +49,7 @@ border-bottom:1px solid #d9d9d9;padding:10px 8px;text-align:left}@media(max-widt
 class MediumPreviewProvider:
     capabilities = PreviewCapabilities(
         platform=PreviewPlatform.medium,
-        renderer_version="medium-1",
+        renderer_version="medium-2",
         viewports=[PreviewViewport.desktop, PreviewViewport.mobile],
     )
 

--- a/screens/editor/v2.html
+++ b/screens/editor/v2.html
@@ -495,7 +495,7 @@ function useLatestConflict() {
   PENDING_CONFLICT = null;
   closeConflict();
   setSave('saved');
-  renderPreview();
+  schedulePreview();
   loadRevisions();
 }
 function keepLocalConflict() {
@@ -518,7 +518,7 @@ function mergeConflictManually() {
   closeConflict();
   persistLocalDraft();
   setSave('unsaved');
-  renderPreview();
+  schedulePreview();
 }
 
 function insertCommentCmd() {
@@ -674,6 +674,19 @@ function renderPreviewWarnings(warnings) {
   ).join('');
 }
 
+function previewErrorMessage(detail, status) {
+  if (detail?.code === 'preview_not_supported') {
+    return 'This preview target is not supported by the current renderer.';
+  }
+  if (typeof detail === 'string') return detail;
+  if (Array.isArray(detail)) {
+    const messages = detail.map(item => item?.msg).filter(Boolean);
+    if (messages.length) return messages.join('; ');
+  }
+  if (typeof detail?.message === 'string') return detail.message;
+  return `Preview failed (${status})`;
+}
+
 function schedulePreview() {
   clearTimeout(PREVIEW_TIMER);
   PREVIEW_REQUEST += 1;
@@ -716,10 +729,7 @@ async function renderPreview(force=false) {
     const artifact = await response.json();
     if (requestId !== PREVIEW_REQUEST) return;
     if (!response.ok) {
-      const message = artifact.detail?.code === 'preview_not_supported'
-        ? 'This preview target is not supported by the current renderer.'
-        : (artifact.detail?.message || artifact.detail || `Preview failed (${response.status})`);
-      throw new Error(typeof message === 'string' ? message : 'Preview failed');
+      throw new Error(previewErrorMessage(artifact.detail, response.status));
     }
     if (artifact.state !== 'current' || !artifact.html) throw new Error(artifact.failure?.message || 'Preview is not available');
     document.getElementById('preview-frame').srcdoc = artifact.html;
@@ -863,7 +873,7 @@ async function restoreRevision(revisionId) {
   localStorage.removeItem(localDraftKey());
   HISTORY_DIFF = null;
   setSave('saved');
-  renderPreview();
+  schedulePreview();
   await loadRevisions();
 }
 
@@ -1361,13 +1371,15 @@ async function loadArticle() {
     setSave('saved');
     await renderPreview();
     recoverLocalDraft(a);
-    await loadComments();
-    await loadPatches();
-    await loadRevisions();
-    await loadReconciliation();
-    await loadChat();
-    await loadConnectedProviders();
-    await loadAgentSession();
+    await Promise.allSettled([
+      loadComments(),
+      loadPatches(),
+      loadRevisions(),
+      loadReconciliation(),
+      loadChat(),
+      loadConnectedProviders(),
+      loadAgentSession(),
+    ]);
     if (new URLSearchParams(location.search).get('panel') === 'chat') {
       openSection('chat');
       document.getElementById('chat-input')?.focus();
@@ -1389,7 +1401,7 @@ async function reloadArticleHead() {
   document.getElementById('word-count').textContent = a.word_count.toLocaleString() + ' words';
   localStorage.removeItem(localDraftKey());
   setSave('saved');
-  renderPreview();
+  schedulePreview();
   await loadRevisions();
   return true;
 }
@@ -1403,7 +1415,7 @@ function recoverLocalDraft(server) {
   if (local.base_revision_id === server.revision_id) {
     document.getElementById('article-title').textContent = local.title;
     document.getElementById('raw-editor').value = local.content;
-    renderPreview();
+    schedulePreview();
     setSave(navigator.onLine ? 'unsaved' : 'offline');
     if (navigator.onLine) saveTimer = setTimeout(saveDraft, 250);
     return;
@@ -1418,6 +1430,7 @@ function recoverLocalDraft(server) {
 
 window.addEventListener('online', () => {
   if (readLocalDraft() && !PENDING_CONFLICT) saveDraft();
+  schedulePreview();
 });
 
 async function loadComments() {

--- a/screens/editor/v2.html
+++ b/screens/editor/v2.html
@@ -73,6 +73,16 @@
     #preview-strip{width:12px;flex-shrink:0;border-right:1px solid #252a38;display:flex;align-items:center;justify-content:center;cursor:pointer;background:#0d1019;transition:background 100ms;}
     #preview-strip:hover{background:#13161f}
     #preview-content{flex:1;display:flex;flex-direction:column;overflow:hidden;}
+    .preview-mode{height:26px;padding:0 8px;border:1px solid #3a3f52;background:#0f1117;color:#a5b4fc;border-radius:4px;font:11px 'Inter',sans-serif;outline:none;cursor:pointer}
+    .viewport-toggle{display:inline-flex;border:1px solid #3a3f52;border-radius:4px;overflow:hidden;height:26px}
+    .viewport-btn{width:29px;border:0;border-right:1px solid #3a3f52;background:#0f1117;color:#5a6080;display:grid;place-items:center;cursor:pointer}
+    .viewport-btn:last-child{border-right:0}.viewport-btn:hover{color:#c9cfe0}.viewport-btn.active{background:#252a38;color:#a5b4fc}
+    #preview-stage{flex:1;min-height:0;overflow:auto;background:#0d1019;padding:14px;display:flex;justify-content:center;align-items:flex-start}
+    #preview-frame-shell{width:100%;height:100%;min-height:320px;background:#fff;border:1px solid #252a38;box-shadow:0 8px 24px #0004;transition:width 150ms ease}
+    #preview-frame-shell.mobile{width:min(390px,100%)}
+    #preview-frame{display:block;width:100%;height:100%;min-height:320px;border:0;background:#fff}
+    .preview-notice{padding:7px 10px;border-bottom:1px solid #252a38;background:#161a24;font-size:10px;color:#8991ab;line-height:1.45}
+    .preview-notice.warn{color:#f5d06f;background:#211d12;border-bottom-color:#4d3f2a}.preview-notice.error{color:#fca5a5;background:#241719;border-bottom-color:#4d2a2a}
 
     /* Selection popover */
     #sel-popover{position:fixed;z-index:60;display:none;align-items:center;gap:2px;background:#1c2035;border:1px solid #3a3f52;border-radius:7px;padding:4px 6px;box-shadow:0 6px 28px #00000088;pointer-events:auto;}
@@ -295,20 +305,28 @@
     <!-- Preview content -->
     <div id="preview-content">
       <div style="padding:5px 10px;border-bottom:1px solid #252a38;background:#13161f;display:flex;align-items:center;gap:8px;flex-shrink:0;">
-        <select id="preview-sel" onchange="renderPreview()" style="font-size:11px;background:#0f1117;border:1px solid #3a3f52;border-radius:4px;color:#a5b4fc;padding:2px 6px;outline:none;cursor:pointer;">
-          <option value="rendered" selected>Rendered MD</option>
-          <option value="medium">Medium</option>
+        <select id="preview-sel" class="preview-mode" onchange="changePreviewTarget()" aria-label="Preview target">
+          <option value="markdown" selected>Markdown</option>
           <option value="hashnode">Hashnode</option>
-          <option value="devto">Dev.to</option>
+          <option value="medium">Medium</option>
         </select>
+        <span id="preview-kind" style="font-size:9px;color:#737b98;text-transform:uppercase;white-space:nowrap;">Live preview</span>
         <a id="ext-link" href="#" onclick="return false" style="display:none;font-size:11px;color:#6366f1;text-decoration:none;white-space:nowrap;" title="Open in browser">visit ↗</a>
         <div style="margin-left:auto;display:flex;align-items:center;gap:4px;">
-          <button onclick="renderPreview()" title="Reload draft" style="height:24px;padding:0 9px;border-radius:4px;border:1px solid #3a3f52;background:#1c2035;color:#c9cfe0;cursor:pointer;display:inline-flex;align-items:center;gap:5px;font-size:11px;font-family:inherit;">
-            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>Reload draft
+          <div class="viewport-toggle" role="group" aria-label="Preview viewport">
+            <button id="viewport-desktop" class="viewport-btn active" onclick="setPreviewViewport('desktop')" title="Desktop preview" aria-label="Desktop preview"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="13" rx="1"/><path d="M8 21h8M12 17v4"/></svg></button>
+            <button id="viewport-mobile" class="viewport-btn" onclick="setPreviewViewport('mobile')" title="Mobile preview" aria-label="Mobile preview"><svg width="11" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="6" y="2" width="12" height="20" rx="2"/><path d="M10 18h4"/></svg></button>
+          </div>
+          <button onclick="renderPreview(true)" title="Reload preview" aria-label="Reload preview" class="icon-btn" style="height:26px;width:28px;border-color:#3a3f52;background:#1c2035;">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.12-9.36L1 10"/></svg>
           </button>
         </div>
       </div>
-      <div id="preview-body" style="flex:1;overflow-y:auto;padding:14px 14px 40px;"></div>
+      <div id="preview-status" class="preview-notice" role="status">Preparing live preview…</div>
+      <div id="preview-warnings"></div>
+      <div id="preview-body" style="flex:1;min-height:0;display:flex;overflow:hidden;">
+        <div id="preview-stage"><div id="preview-frame-shell"><iframe id="preview-frame" title="Article preview" sandbox="allow-same-origin"></iframe></div></div>
+      </div>
     </div>
   </div>
 
@@ -337,6 +355,11 @@ let REVISIONS = [];
 let HISTORY_DIFF = null;
 let PENDING_CONFLICT = null;
 let RECONCILIATION = [];
+const PREVIEW_TARGETS = ['markdown', 'hashnode', 'medium'];
+let PREVIEW_TARGET = PREVIEW_TARGETS.includes(localStorage.getItem('bloghub-preview-target')) ? localStorage.getItem('bloghub-preview-target') : 'markdown';
+let PREVIEW_VIEWPORT = ['desktop', 'mobile'].includes(localStorage.getItem('bloghub-preview-viewport')) ? localStorage.getItem('bloghub-preview-viewport') : 'desktop';
+let PREVIEW_TIMER = null;
+let PREVIEW_REQUEST = 0;
 
 
 
@@ -413,7 +436,7 @@ function onInput() {
   // update word count
   const words = ta.value.trim().split(/\s+/).filter(Boolean).length;
   document.getElementById('word-count').textContent = words.toLocaleString() + ' words';
-  renderPreview();
+  schedulePreview();
   persistLocalDraft();
   saveTimer = setTimeout(saveDraft, 2000);
 }
@@ -616,9 +639,52 @@ function togglePreview() {
   }
 }
 
-function renderPreview() {
-  const platform = document.getElementById('preview-sel').value;
-  // Update ext link
+function updatePreviewControls() {
+  document.getElementById('preview-sel').value = PREVIEW_TARGET;
+  document.getElementById('viewport-desktop').classList.toggle('active', PREVIEW_VIEWPORT === 'desktop');
+  document.getElementById('viewport-mobile').classList.toggle('active', PREVIEW_VIEWPORT === 'mobile');
+  document.getElementById('preview-frame-shell').classList.toggle('mobile', PREVIEW_VIEWPORT === 'mobile');
+  document.getElementById('preview-kind').textContent = PREVIEW_TARGET === 'markdown' ? 'Live preview' : 'Live simulation';
+}
+
+function changePreviewTarget() {
+  PREVIEW_TARGET = document.getElementById('preview-sel').value;
+  localStorage.setItem('bloghub-preview-target', PREVIEW_TARGET);
+  updatePreviewControls();
+  renderPreview(true);
+}
+
+function setPreviewViewport(viewport) {
+  PREVIEW_VIEWPORT = viewport;
+  localStorage.setItem('bloghub-preview-viewport', viewport);
+  updatePreviewControls();
+  renderPreview(true);
+}
+
+function setPreviewStatus(message, tone='') {
+  const status = document.getElementById('preview-status');
+  status.textContent = message;
+  status.className = `preview-notice ${tone}`.trim();
+}
+
+function renderPreviewWarnings(warnings) {
+  const wrap = document.getElementById('preview-warnings');
+  wrap.innerHTML = (warnings || []).map(w =>
+    `<div class="preview-notice ${w.severity === 'warning' ? 'warn' : ''}">${esc(w.message)}</div>`
+  ).join('');
+}
+
+function schedulePreview() {
+  clearTimeout(PREVIEW_TIMER);
+  PREVIEW_REQUEST += 1;
+  setPreviewStatus(navigator.onLine ? 'Preview updating…' : 'Preview paused while offline', navigator.onLine ? '' : 'warn');
+  PREVIEW_TIMER = setTimeout(() => renderPreview(), 220);
+}
+
+async function renderPreview(force=false) {
+  clearTimeout(PREVIEW_TIMER);
+  updatePreviewControls();
+  const platform = PREVIEW_TARGET;
   const extLink = document.getElementById('ext-link');
   const dest = DESTINATIONS.find(d => d.id === platform);
   const rawUrl = dest?.url || null;
@@ -630,25 +696,41 @@ function renderPreview() {
   } else {
     extLink.style.display = 'none';
   }
-  const source = document.getElementById('raw-editor').value;
-  const blocks = source.split(/\n{2,}/).map(block => {
-    const value = block.trim();
-    if (!value) return '';
-    if (value.startsWith('```')) {
-      return `<pre><code>${esc(value.replace(/^```[^\n]*\n?/, '').replace(/```$/, ''))}</code></pre>`;
+  if (!navigator.onLine) {
+    setPreviewStatus('Preview paused while offline · showing last render', 'warn');
+    return;
+  }
+  const requestId = ++PREVIEW_REQUEST;
+  setPreviewStatus(force ? 'Reloading preview…' : 'Rendering live preview…');
+  try {
+    const response = await fetch(`/api/articles/${ARTICLE_ID}/previews/render`, {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({
+        platform,
+        viewport:PREVIEW_VIEWPORT,
+        title:document.getElementById('article-title').textContent.trim(),
+        content:document.getElementById('raw-editor').value,
+        base_revision_id:CURRENT_REVISION_ID,
+      }),
+    });
+    const artifact = await response.json();
+    if (requestId !== PREVIEW_REQUEST) return;
+    if (!response.ok) {
+      const message = artifact.detail?.code === 'preview_not_supported'
+        ? 'This preview target is not supported by the current renderer.'
+        : (artifact.detail?.message || artifact.detail || `Preview failed (${response.status})`);
+      throw new Error(typeof message === 'string' ? message : 'Preview failed');
     }
-    if (value.startsWith('# ')) return `<h1>${esc(value.slice(2))}</h1>`;
-    if (value.startsWith('## ')) return `<h2>${esc(value.slice(3))}</h2>`;
-    if (value.startsWith('> ')) return `<blockquote><p>${esc(value.replace(/^> ?/gm, ''))}</p></blockquote>`;
-    return `<p>${esc(value).replace(/\n/g, '<br>')}</p>`;
-  }).join('');
-  const core = `<div class="rendered-preview">${blocks}</div>`;
-  const body = document.getElementById('preview-body');
-  if (platform === 'rendered') { body.innerHTML = core; return; }
-  const name = { medium:'Medium', hashnode:'Hashnode', devto:'Dev.to' }[platform];
-  body.innerHTML = `<div style="font-size:10px;color:#5a6080;text-transform:uppercase;letter-spacing:.06em;margin-bottom:10px;display:flex;align-items:center;gap:6px;"><span style="width:6px;height:6px;border-radius:50%;background:#6366f1;"></span>${name} preview</div>
-    <div style="background:#13161f;border:1px solid #252a38;border-radius:8px;padding:14px;">${core}</div>
-    <div style="margin-top:10px;font-size:11px;color:#5a6080;">Draft synced · last pushed 3 min ago</div>`;
+    if (artifact.state !== 'current' || !artifact.html) throw new Error(artifact.failure?.message || 'Preview is not available');
+    document.getElementById('preview-frame').srcdoc = artifact.html;
+    renderPreviewWarnings(artifact.warnings);
+    const sourceLabel = artifact.source.revision_id ? `revision ${artifact.source.revision_number}` : 'unsaved working copy';
+    setPreviewStatus(`${platform === 'markdown' ? 'Markdown' : platform[0].toUpperCase() + platform.slice(1) + ' simulation'} · ${sourceLabel} · ${artifact.renderer_version}`);
+  } catch (error) {
+    if (requestId !== PREVIEW_REQUEST) return;
+    renderPreviewWarnings([]);
+    setPreviewStatus(error.message || 'Preview failed', 'error');
+  }
 }
 
 // ── Content builders ──────────────────────────────────────────────────────────
@@ -1277,7 +1359,7 @@ async function loadArticle() {
       error: d.error || null,
     }));
     setSave('saved');
-    renderPreview();
+    await renderPreview();
     recoverLocalDraft(a);
     await loadComments();
     await loadPatches();
@@ -1290,6 +1372,7 @@ async function loadArticle() {
       openSection('chat');
       document.getElementById('chat-input')?.focus();
     }
+    document.body.dataset.editorLoaded = 'true';
   } catch (_e) {
     console.error('Failed to load article', _e);
   }

--- a/tests/tests_backend/test_hashnode_live_preview.py
+++ b/tests/tests_backend/test_hashnode_live_preview.py
@@ -16,7 +16,7 @@ def test_hashnode_preview_has_platform_shell_and_normalized_content():
         asset_base_url="/assets",
     )
 
-    assert artifact.renderer_version == "hashnode-1"
+    assert artifact.renderer_version == "hashnode-2"
     assert 'data-preview-platform="hashnode"' in artifact.html
     assert '<h1 class="article-title">A practical guide</h1>' in artifact.html
     assert artifact.html.count("A practical guide") == 2  # document title + visible title

--- a/tests/tests_backend/test_medium_live_preview.py
+++ b/tests/tests_backend/test_medium_live_preview.py
@@ -16,7 +16,7 @@ def test_medium_preview_has_editorial_shell_without_duplicate_body_title():
         asset_base_url="/assets",
     )
 
-    assert artifact.renderer_version == "medium-1"
+    assert artifact.renderer_version == "medium-2"
     assert 'data-preview-platform="medium"' in artifact.html
     assert '<h1 class="article-title">A practical guide</h1>' in artifact.html
     assert artifact.html.count("A practical guide") == 2  # document title + visible title

--- a/tests/tests_ui/screens/test_editor.py
+++ b/tests/tests_ui/screens/test_editor.py
@@ -41,6 +41,10 @@ def goto_editor(page, article_id=ARTICLE_ID):
         "document.getElementById('file-label').textContent !== 'loading…'",
         timeout=10000,
     )
+    page.wait_for_function(
+        "document.body.dataset.editorLoaded === 'true'",
+        timeout=10000,
+    )
 
 
 # ── 1. Initial load ───────────────────────────────────────────────────────────
@@ -295,18 +299,53 @@ def test_preview_strip_re_expands_preview(page):
 
 def test_preview_body_has_content_on_load(page):
     goto_editor(page)
-    body = page.locator("#preview-body")
-    assert len(body.inner_html()) > 0
+    page.wait_for_function(
+        "document.getElementById('preview-frame').srcdoc.includes('data-preview-platform')",
+        timeout=8000,
+    )
+    assert "data-preview-platform" in page.locator("#preview-frame").get_attribute("srcdoc")
 
 
 def test_preview_selector_options(page):
     goto_editor(page)
     options = page.locator("#preview-sel option")
     labels = [options.nth(i).inner_text() for i in range(options.count())]
-    assert "Rendered MD" in labels
-    assert "Medium" in labels
+    assert "Markdown" in labels
     assert "Hashnode" in labels
-    assert "Dev.to" in labels
+    assert "Medium" in labels
+
+
+def test_hashnode_preview_renders_live_working_copy(page):
+    goto_editor(page)
+    page.locator("#preview-sel").select_option("hashnode")
+    page.wait_for_function(
+        "document.getElementById('preview-status').textContent.includes('hashnode-2')",
+        timeout=8000,
+    )
+
+    assert "data-preview-platform=\"hashnode\"" in page.locator("#preview-frame").get_attribute("srcdoc")
+    assert page.locator("#preview-kind").inner_text().lower() == "live simulation"
+
+
+def test_medium_preview_updates_after_edit_without_waiting_for_autosave(page):
+    goto_editor(page)
+    page.locator("#preview-sel").select_option("medium")
+    page.locator("#raw-editor").press("Control+End")
+    page.keyboard.type(" live-preview-marker")
+    page.wait_for_function(
+        "document.getElementById('preview-frame').srcdoc.includes('live-preview-marker')",
+        timeout=8000,
+    )
+
+    assert "unsaved working copy" in page.locator("#preview-status").inner_text()
+
+
+def test_mobile_preview_uses_fixed_mobile_canvas(page):
+    goto_editor(page)
+    page.get_by_role("button", name="Mobile preview").click()
+
+    assert "mobile" in (page.locator("#preview-frame-shell").get_attribute("class") or "")
+    assert page.get_by_role("button", name="Mobile preview").evaluate("el => el.classList.contains('active')")
 
 
 # ── 7. Top nav actions ────────────────────────────────────────────────────────
@@ -326,7 +365,7 @@ def test_publish_button_visible(page):
 
 def test_review_button_visible(page):
     goto_editor(page)
-    btn = page.get_by_role("button", name="Review")
+    btn = page.get_by_role("button", name="Review", exact=True)
     assert btn.is_visible()
 
 
@@ -480,6 +519,10 @@ def test_comments_section_shows_empty_state_when_no_comments(page, requests_sess
 def test_resolve_button_present_for_open_comment(page, requests_session):
     """POST a comment via API then check Resolve button appears in the panel."""
     requests_session.post(
+        f"{BASE_URL}/api/auth/login",
+        json={"email": "seed@example.com", "password": "seed1234", "remember_me": False},
+    )
+    requests_session.post(
         f"{BASE_URL}/api/articles/{ARTICLE_ID}/comments",
         json={"author": "Tester", "text": "This paragraph needs work."},
     )
@@ -494,6 +537,10 @@ def test_resolve_button_present_for_open_comment(page, requests_session):
 
 def test_resolve_comment_removes_it_from_active_list(page, requests_session):
     """Clicking Resolve calls the API and the comment disappears from the open list."""
+    requests_session.post(
+        f"{BASE_URL}/api/auth/login",
+        json={"email": "seed@example.com", "password": "seed1234", "remember_me": False},
+    )
     requests_session.post(
         f"{BASE_URL}/api/articles/{ARTICLE_ID}/comments",
         json={"author": "Tester", "text": "Resolve me."},

--- a/tests/tests_ui/screens/test_editor.py
+++ b/tests/tests_ui/screens/test_editor.py
@@ -135,6 +135,11 @@ def test_offline_edit_is_saved_locally_and_syncs_on_reconnect(page):
         "document.getElementById('save-indicator').innerText.includes('saved')",
         timeout=10000,
     )
+    page.wait_for_function(
+        "document.getElementById('preview-frame').srcdoc.includes('offline-recovery-marker')",
+        timeout=10000,
+    )
+    assert "paused" not in page.locator("#preview-status").inner_text().lower()
     page.reload()
     page.wait_for_function(
         "document.getElementById('raw-editor').value.includes('offline-recovery-marker')",
@@ -346,6 +351,16 @@ def test_mobile_preview_uses_fixed_mobile_canvas(page):
 
     assert "mobile" in (page.locator("#preview-frame-shell").get_attribute("class") or "")
     assert page.get_by_role("button", name="Mobile preview").evaluate("el => el.classList.contains('active')")
+
+
+def test_preview_validation_errors_show_the_api_reason(page):
+    goto_editor(page)
+
+    message = page.evaluate(
+        "previewErrorMessage([{msg:'Content must contain at most 2000000 characters'}], 422)"
+    )
+
+    assert message == "Content must contain at most 2000000 characters"
 
 
 # ── 7. Top nav actions ────────────────────────────────────────────────────────


### PR DESCRIPTION
Connects the editor to live Markdown, Hashnode, and Medium previews with debounced working-copy rendering, stale-response protection, desktop/mobile controls, persistence, warnings, offline and failure states, and Playwright coverage.\n\nStacked on #83.\nCloses #84