### PR TITLE
feat: wire Overview navigation and editor actions

### DIFF
--- a/screens/overview/v3.html
+++ b/screens/overview/v3.html
@@ -424,10 +424,10 @@
   </div>
   <!-- Nav tabs — center, no grow so logo and actions stay in their own lanes -->
   <div style="display:flex;align-items:stretch;height:48px;flex-shrink:0;">
-    <button onclick="setView('articles')"  id="nav-articles"  class="nav-tab" style="padding:0 14px;font-size:13px;border:none;cursor:pointer;font-family:inherit;background:transparent;border-bottom:2px solid #6366f1;color:#e8eaf2;font-weight:500;">Articles</button>
-    <button onclick="setView('queue')"     id="nav-queue"     class="nav-tab" style="padding:0 14px;font-size:13px;border:none;cursor:pointer;font-family:inherit;background:transparent;border-bottom:2px solid transparent;color:#5a6080;">Queue</button>
-    <button onclick="setView('platforms')" id="nav-platforms" class="nav-tab" style="padding:0 14px;font-size:13px;border:none;cursor:pointer;font-family:inherit;background:transparent;border-bottom:2px solid transparent;color:#5a6080;">Platforms</button>
-    <button onclick="setView('settings')"  id="nav-settings"  class="nav-tab" style="padding:0 14px;font-size:13px;border:none;cursor:pointer;font-family:inherit;background:transparent;border-bottom:2px solid transparent;color:#5a6080;">Settings</button>
+    <button onclick="navigateOverview('articles')"  id="nav-articles"  class="nav-tab" style="padding:0 14px;font-size:13px;border:none;cursor:pointer;font-family:inherit;background:transparent;border-bottom:2px solid #6366f1;color:#e8eaf2;font-weight:500;">Articles</button>
+    <button id="nav-queue" class="nav-tab" style="padding:0 14px;font-size:13px;border:none;cursor:pointer;font-family:inherit;background:transparent;border-bottom:2px solid transparent;color:#5a6080;">Queue</button>
+    <button onclick="navigateOverview('platforms')" id="nav-platforms" class="nav-tab" style="padding:0 14px;font-size:13px;border:none;cursor:pointer;font-family:inherit;background:transparent;border-bottom:2px solid transparent;color:#5a6080;">Platforms</button>
+    <button onclick="navigateOverview('settings')"  id="nav-settings"  class="nav-tab" style="padding:0 14px;font-size:13px;border:none;cursor:pointer;font-family:inherit;background:transparent;border-bottom:2px solid transparent;color:#5a6080;">Settings</button>
   </div>
   <!-- Right actions — flex:1 justify-end keeps it in its own lane -->
   <div style="flex:1;display:flex;align-items:center;gap:14px;justify-content:flex-end;min-width:0;">
@@ -558,9 +558,9 @@
       <div style="padding:12px 16px;border-top:1px solid #252a38;display:flex;flex-direction:column;gap:6px;">
         <button id="panel-primary-btn" style="font-size:12px;font-weight:500;padding:8px;border-radius:6px;background:#6366f1;color:#fff;border:none;cursor:pointer;font-family:inherit;width:100%;">—</button>
         <div style="display:flex;gap:6px;">
-          <button style="flex:1;font-size:12px;padding:6px;border-radius:6px;background:transparent;color:#c9cfe0;border:1px solid #252a38;cursor:pointer;font-family:inherit;">Edit</button>
+          <button id="panel-edit-btn" style="flex:1;font-size:12px;padding:6px;border-radius:6px;background:transparent;color:#c9cfe0;border:1px solid #252a38;cursor:pointer;font-family:inherit;">Edit</button>
           <button id="panel-inspect-btn" style="flex:1;font-size:12px;padding:6px;border-radius:6px;background:transparent;color:#c9cfe0;border:1px solid #252a38;cursor:pointer;font-family:inherit;">Inspect</button>
-          <button style="flex:1;font-size:12px;padding:6px;border-radius:6px;background:transparent;color:#c9cfe0;border:1px solid #252a38;cursor:pointer;font-family:inherit;">Schedule</button>
+          <button id="panel-schedule-btn" style="flex:1;font-size:12px;padding:6px;border-radius:6px;background:transparent;color:#c9cfe0;border:1px solid #252a38;cursor:pointer;font-family:inherit;">Schedule</button>
         </div>
       </div>
     </div>
@@ -643,6 +643,22 @@ const DOT_COLOR = {
 const GATE_COLOR = { pass: '#4ade80', warn: '#fbbf24', fail: '#f87171', pending: '#5a6080' };
 const GATE_LABEL = { pass: '✓ Pass', warn: '⚠ Warn', fail: '✗ Fail', pending: '—' };
 const activeJobs = new Map();
+const OVERVIEW_DESTINATIONS = Object.freeze({
+  platforms: '../settings/v2.html?section=platforms',
+  settings: '../settings/v2.html',
+});
+
+function articleEditorUrl(articleId) {
+  const url = new URL('../editor/v2.html', window.location.href);
+  url.searchParams.set('id', articleId);
+  return `${url.pathname}${url.search}`;
+}
+
+function navigateOverview(view) {
+  if (view === 'articles') return;
+  const destination = OVERVIEW_DESTINATIONS[view];
+  if (destination) window.location.assign(destination);
+}
 
 function formatRelative(isoValue) {
   const date = new Date(isoValue);
@@ -868,7 +884,6 @@ async function runArticleAction(article, overrideKind = null) {
     return;
   }
   if (action.kind === 'schedule') {
-    alert('Schedule is not wired yet.');
     return;
   }
   const endpoint = action.kind === 'inspect' ? 'inspect' : 'push';
@@ -1132,7 +1147,7 @@ function renderCard(a) {
   };
   copy.querySelector('.card-edit').onclick = event => {
     event.stopPropagation();
-    window.location.href = `../editor/v2.html?id=${encodeURIComponent(a.id)}`;
+    window.location.assign(articleEditorUrl(a.id));
   };
   card.appendChild(copy);
   return card;
@@ -1342,6 +1357,9 @@ function selectCard(id) {
   pb.style.color = a.action.color;
   pb.style.border = `1px solid ${a.action.border}`;
   pb.onclick = async () => { await runArticleAction(a); };
+  document.getElementById('panel-edit-btn').onclick = () => {
+    window.location.assign(articleEditorUrl(a.id));
+  };
   document.getElementById('panel-inspect-btn').onclick = async () => { await runArticleAction(a, 'inspect'); };
 }
 
@@ -1400,16 +1418,6 @@ function toggleImportMenu(e) {
     const close = () => { menu.style.display = 'none'; document.removeEventListener('click', close); };
     document.addEventListener('click', close);
   }
-}
-
-function setView(v) {
-  document.querySelectorAll('.nav-tab').forEach(t => {
-    t.style.borderBottomColor = 'transparent';
-    t.style.color = '#5a6080';
-    t.style.fontWeight = '400';
-  });
-  const el = document.getElementById('nav-' + v);
-  if (el) { el.style.borderBottomColor = '#6366f1'; el.style.color = '#e8eaf2'; el.style.fontWeight = '500'; }
 }
 
 function toggleMenu(id, wrap) {

--- a/screens/overview/v3.html
+++ b/screens/overview/v3.html
@@ -85,6 +85,13 @@
     .pill-platform:hover  { color: #c9cfe0; border-color: #3a3f52; }
     .pill-platform.active { color: #e8eaf2; background: #1e2230; border-color: #3a3f52; }
 
+    .nav-tab:disabled,
+    #panel-primary-btn:disabled,
+    #panel-schedule-btn:disabled {
+      cursor: not-allowed !important;
+      opacity: 0.45;
+    }
+
     /* Side panel */
     #side-panel {
       flex-shrink: 0;
@@ -425,7 +432,7 @@
   <!-- Nav tabs — center, no grow so logo and actions stay in their own lanes -->
   <div style="display:flex;align-items:stretch;height:48px;flex-shrink:0;">
     <button onclick="navigateOverview('articles')"  id="nav-articles"  class="nav-tab" style="padding:0 14px;font-size:13px;border:none;cursor:pointer;font-family:inherit;background:transparent;border-bottom:2px solid #6366f1;color:#e8eaf2;font-weight:500;">Articles</button>
-    <button id="nav-queue" class="nav-tab" style="padding:0 14px;font-size:13px;border:none;cursor:pointer;font-family:inherit;background:transparent;border-bottom:2px solid transparent;color:#5a6080;">Queue</button>
+    <button id="nav-queue" class="nav-tab" disabled title="Publishing queue is not available yet" style="padding:0 14px;font-size:13px;border:none;cursor:pointer;font-family:inherit;background:transparent;border-bottom:2px solid transparent;color:#5a6080;">Queue</button>
     <button onclick="navigateOverview('platforms')" id="nav-platforms" class="nav-tab" style="padding:0 14px;font-size:13px;border:none;cursor:pointer;font-family:inherit;background:transparent;border-bottom:2px solid transparent;color:#5a6080;">Platforms</button>
     <button onclick="navigateOverview('settings')"  id="nav-settings"  class="nav-tab" style="padding:0 14px;font-size:13px;border:none;cursor:pointer;font-family:inherit;background:transparent;border-bottom:2px solid transparent;color:#5a6080;">Settings</button>
   </div>
@@ -560,7 +567,7 @@
         <div style="display:flex;gap:6px;">
           <button id="panel-edit-btn" style="flex:1;font-size:12px;padding:6px;border-radius:6px;background:transparent;color:#c9cfe0;border:1px solid #252a38;cursor:pointer;font-family:inherit;">Edit</button>
           <button id="panel-inspect-btn" style="flex:1;font-size:12px;padding:6px;border-radius:6px;background:transparent;color:#c9cfe0;border:1px solid #252a38;cursor:pointer;font-family:inherit;">Inspect</button>
-          <button id="panel-schedule-btn" style="flex:1;font-size:12px;padding:6px;border-radius:6px;background:transparent;color:#c9cfe0;border:1px solid #252a38;cursor:pointer;font-family:inherit;">Schedule</button>
+          <button id="panel-schedule-btn" disabled title="Publishing queue is not available yet" style="flex:1;font-size:12px;padding:6px;border-radius:6px;background:transparent;color:#c9cfe0;border:1px solid #252a38;cursor:pointer;font-family:inherit;">Schedule</button>
         </div>
       </div>
     </div>
@@ -1356,7 +1363,9 @@ function selectCard(id) {
   pb.style.background = a.action.bg;
   pb.style.color = a.action.color;
   pb.style.border = `1px solid ${a.action.border}`;
-  pb.onclick = async () => { await runArticleAction(a); };
+  pb.disabled = a.action.kind === 'schedule';
+  pb.title = pb.disabled ? 'Publishing queue is not available yet' : '';
+  pb.onclick = pb.disabled ? null : async () => { await runArticleAction(a); };
   document.getElementById('panel-edit-btn').onclick = () => {
     window.location.assign(articleEditorUrl(a.id));
   };

--- a/screens/settings/v2.html
+++ b/screens/settings/v2.html
@@ -1081,8 +1081,11 @@ function redirectToLogin() {
 
 async function initSettings() {
   const requestedSection = new URLSearchParams(window.location.search).get('section');
-  const sectionButton = document.querySelector(`.nav-btn[data-section="${requestedSection}"]`);
-  if (sectionButton) showSection(requestedSection, sectionButton);
+  const allowedSections = ['platforms', 'ai', 'account'];
+  if (allowedSections.includes(requestedSection)) {
+    const sectionButton = document.querySelector(`.nav-btn[data-section="${requestedSection}"]`);
+    if (sectionButton) showSection(requestedSection, sectionButton);
+  }
 
   try {
     const res = await fetch('/api/auth/me', { credentials: 'same-origin' });

--- a/screens/settings/v2.html
+++ b/screens/settings/v2.html
@@ -1080,6 +1080,10 @@ function redirectToLogin() {
 }
 
 async function initSettings() {
+  const requestedSection = new URLSearchParams(window.location.search).get('section');
+  const sectionButton = document.querySelector(`.nav-btn[data-section="${requestedSection}"]`);
+  if (sectionButton) showSection(requestedSection, sectionButton);
+
   try {
     const res = await fetch('/api/auth/me', { credentials: 'same-origin' });
     if (res.status === 401) {

--- a/tests/overview-v3.spec.js
+++ b/tests/overview-v3.spec.js
@@ -33,4 +33,47 @@ test.describe('Current overview screen', () => {
     await page.locator('.article-card').first().locator('.card-edit').click();
     await expect(page).toHaveURL(/\/screens\/editor\/v2\.html\?id=/);
   });
+
+  test('keeps Articles active without faking another active tab', async ({ page }) => {
+    const originalUrl = page.url();
+
+    await page.locator('#nav-articles').press('Enter');
+
+    await expect(page).toHaveURL(originalUrl);
+    await expect(page.locator('#nav-articles')).toHaveCSS('border-bottom-color', 'rgb(99, 102, 241)');
+    await expect(page.locator('#nav-platforms')).toHaveCSS('border-bottom-color', 'rgba(0, 0, 0, 0)');
+  });
+
+  test('opens the Platforms section in Settings', async ({ page }) => {
+    await page.locator('#nav-platforms').click();
+
+    await expect(page).toHaveURL(/\/screens\/settings\/v2\.html\?section=platforms$/);
+    await expect(page.locator('#section-platforms')).toBeVisible();
+    await expect(page.locator('.nav-btn[data-section="platforms"]')).toHaveClass(/active/);
+  });
+
+  test('opens Settings with keyboard activation', async ({ page }) => {
+    await page.locator('#nav-settings').press('Enter');
+
+    await expect(page).toHaveURL(/\/screens\/settings\/v2\.html$/);
+  });
+
+  test('panel Edit opens the selected article and preserves its identifier', async ({ page }) => {
+    const card = page.locator('.article-card').first();
+    const articleId = await card.getAttribute('data-id');
+    await card.click();
+
+    await page.locator('#panel-edit-btn').press('Enter');
+
+    await expect(page).toHaveURL(/\/screens\/editor\/v2\.html\?id=/);
+    expect(new URL(page.url()).searchParams.get('id')).toBe(articleId);
+  });
+
+  test('editor destinations encode article identifiers safely', async ({ page }) => {
+    const destination = await page.evaluate(() => articleEditorUrl('article / ? & value'));
+    const parsed = new URL(destination, page.url());
+
+    expect(parsed.pathname).toBe('/screens/editor/v2.html');
+    expect(parsed.searchParams.get('id')).toBe('article / ? & value');
+  });
 });

--- a/tests/overview-v3.spec.js
+++ b/tests/overview-v3.spec.js
@@ -58,6 +58,26 @@ test.describe('Current overview screen', () => {
     await expect(page).toHaveURL(/\/screens\/settings\/v2\.html$/);
   });
 
+  test('ignores an invalid Settings section without breaking initialization', async ({ page }) => {
+    await page.goto('/screens/settings/v2.html?section=x%22%5D');
+
+    await expect(page.getByRole('heading', { name: 'Publishing Platforms' })).toBeVisible();
+    await expect(page.locator('.nav-btn[data-section="platforms"]')).toHaveClass(/active/);
+  });
+
+  test('shows unavailable queue actions as disabled controls', async ({ page }) => {
+    await expect(page.locator('#nav-queue')).toBeDisabled();
+    await expect(page.locator('#panel-schedule-btn')).toBeDisabled();
+
+    const scheduledArticleId = await page.evaluate(() =>
+      ARTICLES.find(article => article.action.kind === 'schedule')?.id || null
+    );
+    expect(scheduledArticleId).not.toBeNull();
+    await page.locator(`.article-card[data-id="${scheduledArticleId}"]`).click();
+    await expect(page.locator('#panel-primary-btn')).toBeDisabled();
+    await expect(page.locator('#panel-primary-btn')).toHaveText('Schedule →');
+  });
+
   test('panel Edit opens the selected article and preserves its identifier', async ({ page }) => {
     const card = page.locator('.article-card').first();
     const articleId = await card.getAttribute('data-id');


### PR DESCRIPTION
## Summary

- keep Articles as an Overview self-transition without fake active-tab changes
- navigate Platforms to the platform-connections section and Settings to the Settings view
- wire selected-panel Edit through a shared, safely encoded editor URL
- remove the placeholder Schedule alert
- add focused Playwright coverage for pointer/keyboard navigation and article ID preservation

## Tests

- `npx playwright test overview-v3.spec.js --project=chromium` (9 passed; run on isolated port 8096 with existing installed dependencies)
- `git diff --check`

## Blockers / remaining scope

Issue #22 has not delivered a Publish Queue screen or route. The repository currently exposes job and sync-schedule APIs, but no Queue UI destination that can accept a preselected article. Consequently, `OV-02` Queue, `OV-32` selected-panel Schedule, and a derived primary Schedule action cannot be wired without inventing a route or UI state. Those controls no longer fake active navigation or display a placeholder alert.

The authoritative Overview Draw.io used for this implementation is available in the sibling specs checkout, while dependency issue #95 remains open pending its specs merge.

Refs #96