### PR TITLE
feat: keep overview sidebar synchronized

### DIFF
--- a/screens/overview/sidebar-state.js
+++ b/screens/overview/sidebar-state.js
@@ -1,0 +1,77 @@
+(function initOverviewSidebarState(root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  if (root) root.OverviewSidebarState = api;
+}(typeof globalThis !== 'undefined' ? globalThis : this, function createOverviewSidebarState() {
+  const PLATFORMS = ['medium', 'hashnode', 'devto'];
+  const KNOWN_STATUSES = new Set([
+    'none', 'draft', 'review', 'ready', 'pending', 'error', 'published',
+  ]);
+
+  function normalizeDestination(value) {
+    const destination = value && typeof value === 'object' ? value : {};
+    const status = KNOWN_STATUSES.has(destination.status) ? destination.status : 'none';
+    const suppliedLabel = typeof destination.label === 'string'
+      ? destination.label.trim()
+      : '';
+    return {
+      ...destination,
+      status,
+      label: status === 'none'
+        ? 'Unavailable'
+        : suppliedLabel || `${status.charAt(0).toUpperCase()}${status.slice(1)}`,
+      url: typeof destination.url === 'string' && destination.url ? destination.url : null,
+    };
+  }
+
+  function normalizeDestinations(value) {
+    const destinations = value && typeof value === 'object' ? value : {};
+    return Object.fromEntries(
+      PLATFORMS.map(platform => [platform, normalizeDestination(destinations[platform])]),
+    );
+  }
+
+  function normalizeTimeline(value, formatTime) {
+    if (!Array.isArray(value)) return [];
+    return value
+      .filter(item => item && typeof item === 'object')
+      .map(item => ({
+        time: formatTime(item.timestamp),
+        event: typeof item.event === 'string' ? item.event : '',
+      }));
+  }
+
+  function selectedArticle(articles, selectedId) {
+    if (!selectedId || !Array.isArray(articles)) return null;
+    return articles.find(article => article.id === selectedId) || null;
+  }
+
+  function panelModel(article, activeJob) {
+    if (!article) return null;
+    const action = article.action || {
+      kind: 'push', label: 'Push drafts \u2192', color: '#fff', bg: '#6366f1', border: '#6366f1',
+    };
+    const busyLabel = activeJob === 'inspect' ? 'Inspecting\u2026' : 'Pushing\u2026';
+    return {
+      title: typeof article.title === 'string' && article.title.trim()
+        ? article.title
+        : 'Untitled article',
+      destinations: PLATFORMS.map(platform => ({
+        platform,
+        ...normalizeDestination(article.destinations && article.destinations[platform]),
+      })),
+      timeline: Array.isArray(article.timeline) ? article.timeline : [],
+      primaryAction: activeJob ? { ...action, label: busyLabel, disabled: true } : action,
+      inspectDisabled: Boolean(activeJob),
+    };
+  }
+
+  return {
+    PLATFORMS,
+    normalizeDestination,
+    normalizeDestinations,
+    normalizeTimeline,
+    selectedArticle,
+    panelModel,
+  };
+}));

--- a/screens/overview/v3.html
+++ b/screens/overview/v3.html
@@ -567,9 +567,11 @@
   </div>
 </div>
 
+<script src="./sidebar-state.js"></script>
 <script>
 // --- Data ----------------------------------------------------------
 let ARTICLES = [];
+const SidebarState = window.OverviewSidebarState;
 
 // --- Per-platform thumbnail palette --------------------------------
 // Each entry: { heading, para, codeBlock, codeLine1, codeLine2, codeLine3, codeLine4, imagePlaceholder, fade }
@@ -663,7 +665,7 @@ function formatTimelineTime(isoValue) {
 }
 
 function chooseAction(article) {
-  const destinations = Object.values(article.destinations);
+  const destinations = Object.values(article.destinations || {});
   const links = destinations.map(d => d.url).filter(Boolean);
   if (article.gate === 'fail' || destinations.some(d => d.status === 'error')) {
     return { kind: 'inspect', label: 'Inspect →', color: '#f87171', bg: '#2d1a1a', border: '#4d2a2a' };
@@ -692,27 +694,21 @@ function preferredLiveUrl(article, platform) {
 }
 
 function buildLiveArticle(raw, index) {
+  const destinations = SidebarState.normalizeDestinations(raw.destinations);
   return {
     id: raw.id,
     urgency: index + 1,
-    title: raw.title,
+    title: typeof raw.title === 'string' && raw.title.trim() ? raw.title : 'Untitled article',
     updatedAt: raw.updatedAt,
     updated: formatRelative(raw.updatedAt),
-    words: raw.wordCount,
+    words: Number.isFinite(raw.wordCount) ? raw.wordCount : 0,
     previewImageUrl: raw.previewImageUrl || null,
     source: raw.source || 'native',
     sourcePlatform: raw.sourcePlatform || null,
-    destinations: {
-      medium: raw.destinations.medium,
-      hashnode: raw.destinations.hashnode,
-      devto: raw.destinations.devto,
-    },
-    gate: raw.gate,
-    action: chooseAction(raw),
-    timeline: (raw.recentTimeline || []).map(item => ({
-      time: formatTimelineTime(item.timestamp),
-      event: item.event,
-    })),
+    destinations,
+    gate: raw.gate || 'pending',
+    action: chooseAction({ ...raw, destinations }),
+    timeline: SidebarState.normalizeTimeline(raw.recentTimeline, formatTimelineTime),
   };
 }
 
@@ -776,6 +772,11 @@ async function loadOverview() {
   `;
 
   if (hasActiveFilters()) await loadRemainingArticlesForFilters();
+}
+
+async function refreshOverview() {
+  await loadOverview();
+  render();
 }
 
 function hasMoreArticles() {
@@ -881,7 +882,7 @@ async function runArticleAction(article, overrideKind = null) {
       body: JSON.stringify({}),
     });
     await pollJob(accepted.jobId);
-    await loadOverview();
+    await refreshOverview();
   } catch (error) {
     alert(`Action failed: ${error.message}`);
   } finally {
@@ -1283,16 +1284,7 @@ function render() {
   syncDetailsPanel();
 }
 
-function syncDetailsPanel() {
-  const panel = document.getElementById('side-panel');
-  const content = document.getElementById('panel-content');
-  const arrow = document.getElementById('side-strip-arrow');
-  if (!selectedId) {
-    panel.classList.add('hidden');
-    return;
-  }
-
-  panel.classList.remove('hidden');
+function setPanelGeometry(panel, content, arrow) {
   if (detailsPanelOpen) {
     panel.style.width = '300px';
     panel.style.flexBasis = '300px';
@@ -1306,6 +1298,100 @@ function syncDetailsPanel() {
   }
 }
 
+function renderDestination(destination) {
+  const row = document.createElement('div');
+  row.style.cssText = 'display:flex;align-items:center;justify-content:space-between;';
+
+  const platform = document.createElement('span');
+  platform.style.cssText = 'color:#c9cfe0;font-size:12px;';
+  platform.textContent = PLATFORM_LABEL[destination.platform];
+
+  const statusWrap = document.createElement('div');
+  statusWrap.style.cssText = 'display:flex;align-items:center;gap:6px;';
+  const dot = document.createElement('span');
+  dot.style.cssText = 'width:7px;height:7px;border-radius:50%;display:inline-block;';
+  dot.style.background = DOT_COLOR[destination.status] || '#252a38';
+  const label = document.createElement('span');
+  label.style.cssText = "font-family:'JetBrains Mono',monospace;font-size:11px;";
+  label.style.color = DOT_COLOR[destination.status] || '#5a6080';
+  label.textContent = destination.label;
+
+  statusWrap.append(dot, label);
+  row.append(platform, statusWrap);
+  return row;
+}
+
+function renderTimelineEvent(item) {
+  const row = document.createElement('div');
+  row.style.cssText = 'display:flex;gap:8px;';
+  const time = document.createElement('span');
+  time.style.cssText = "color:#5a6080;font-family:'JetBrains Mono',monospace;font-size:10px;width:48px;flex-shrink:0;padding-top:1px;";
+  time.textContent = item.time;
+  const event = document.createElement('span');
+  event.style.cssText = 'color:#c9cfe0;font-size:12px;line-height:1.5;';
+  event.textContent = item.event || 'Activity details unavailable';
+  row.append(time, event);
+  return row;
+}
+
+function renderPanelEmpty(message) {
+  const empty = document.createElement('div');
+  empty.style.cssText = 'color:#5a6080;font-size:12px;line-height:1.5;';
+  empty.textContent = message;
+  return empty;
+}
+
+function syncDetailsPanel() {
+  const panel = document.getElementById('side-panel');
+  const content = document.getElementById('panel-content');
+  const arrow = document.getElementById('side-strip-arrow');
+  const article = SidebarState.selectedArticle(ARTICLES, selectedId);
+  if (!article) {
+    selectedId = null;
+    detailsPanelOpen = true;
+    panel.classList.add('hidden');
+    document.getElementById('panel-title').textContent = '';
+    document.getElementById('panel-destinations').replaceChildren();
+    document.getElementById('panel-timeline').replaceChildren();
+    return;
+  }
+
+  panel.classList.remove('hidden');
+  setPanelGeometry(panel, content, arrow);
+
+  const model = SidebarState.panelModel(article, activeJobs.get(article.id));
+  document.getElementById('panel-title').textContent = model.title;
+
+  const destinations = document.getElementById('panel-destinations');
+  destinations.replaceChildren(...model.destinations.map(renderDestination));
+
+  const timeline = document.getElementById('panel-timeline');
+  timeline.replaceChildren(...(
+    model.timeline.length
+      ? model.timeline.map(renderTimelineEvent)
+      : [renderPanelEmpty('No activity yet.')]
+  ));
+
+  const primary = document.getElementById('panel-primary-btn');
+  primary.textContent = model.primaryAction.label;
+  primary.style.background = model.primaryAction.bg;
+  primary.style.color = model.primaryAction.color;
+  primary.style.border = `1px solid ${model.primaryAction.border}`;
+  primary.disabled = Boolean(model.primaryAction.disabled);
+  primary.setAttribute('aria-busy', String(Boolean(model.primaryAction.disabled)));
+  primary.onclick = model.primaryAction.disabled ? null : async () => {
+    const current = SidebarState.selectedArticle(ARTICLES, selectedId);
+    if (current) await runArticleAction(current);
+  };
+
+  const inspect = document.getElementById('panel-inspect-btn');
+  inspect.disabled = model.inspectDisabled;
+  inspect.onclick = model.inspectDisabled ? null : async () => {
+    const current = SidebarState.selectedArticle(ARTICLES, selectedId);
+    if (current) await runArticleAction(current, 'inspect');
+  };
+}
+
 // --- Interactions --------------------------------------------------
 function selectCard(id) {
   closeMenus();
@@ -1315,34 +1401,8 @@ function selectCard(id) {
     return;
   }
   selectedId = id;
-  render();
   detailsPanelOpen = true;
-  syncDetailsPanel();
-  const a = ARTICLES.find(x => x.id === selectedId);
-  document.getElementById('panel-title').textContent = a.title;
-  document.getElementById('panel-destinations').innerHTML = ['medium','hashnode','devto'].map(p => {
-    const d = a.destinations[p];
-    return `<div style="display:flex;align-items:center;justify-content:space-between;">
-      <span style="color:#c9cfe0;font-size:12px;">${PLATFORM_LABEL[p]}</span>
-      <div style="display:flex;align-items:center;gap:6px;">
-        <span style="width:7px;height:7px;border-radius:50%;background:${DOT_COLOR[d.status]||'#252a38'};display:inline-block;"></span>
-        <span style="font-family:'JetBrains Mono',monospace;font-size:11px;color:${DOT_COLOR[d.status]||'#5a6080'}">${d.label}</span>
-      </div>
-    </div>`;
-  }).join('');
-  document.getElementById('panel-timeline').innerHTML = a.timeline.map(t =>
-    `<div style="display:flex;gap:8px;">
-      <span style="color:#5a6080;font-family:'JetBrains Mono',monospace;font-size:10px;width:48px;flex-shrink:0;padding-top:1px;">${t.time}</span>
-      <span style="color:#c9cfe0;font-size:12px;line-height:1.5;">${t.event}</span>
-    </div>`
-  ).join('');
-  const pb = document.getElementById('panel-primary-btn');
-  pb.textContent = a.action.label;
-  pb.style.background = a.action.bg;
-  pb.style.color = a.action.color;
-  pb.style.border = `1px solid ${a.action.border}`;
-  pb.onclick = async () => { await runArticleAction(a); };
-  document.getElementById('panel-inspect-btn').onclick = async () => { await runArticleAction(a, 'inspect'); };
+  render();
 }
 
 function toggleDetailsPanel() {
@@ -1434,7 +1494,7 @@ function closeMenus() {
 
 showSkeleton = true;
 render();
-loadOverview()
+refreshOverview()
   .catch(error => { alert(`Failed to load overview: ${error.message}`); })
   .finally(() => {
     showSkeleton = false;

--- a/screens/overview/v3.html
+++ b/screens/overview/v3.html
@@ -1259,7 +1259,7 @@ function render() {
     emptyEl.style.display = 'flex';
     loadMoreRegion.innerHTML = '';
     document.getElementById('article-count').textContent = '0 articles';
-    syncDetailsPanel();
+    syncDetailsPanel([]);
     return;
   }
   if (showSkeleton) {
@@ -1276,12 +1276,12 @@ function render() {
   if (filtered.length === 0) {
     if (!isLoadingMore) noRes.style.display = 'flex';
     renderLoadMoreRegion();
-    syncDetailsPanel();
+    syncDetailsPanel(filtered);
     return;
   }
   filtered.forEach(a => grid.appendChild(renderCard(a)));
   renderLoadMoreRegion();
-  syncDetailsPanel();
+  syncDetailsPanel(filtered);
 }
 
 function setPanelGeometry(panel, content, arrow) {
@@ -1341,11 +1341,11 @@ function renderPanelEmpty(message) {
   return empty;
 }
 
-function syncDetailsPanel() {
+function syncDetailsPanel(visibleArticles = ARTICLES) {
   const panel = document.getElementById('side-panel');
   const content = document.getElementById('panel-content');
   const arrow = document.getElementById('side-strip-arrow');
-  const article = SidebarState.selectedArticle(ARTICLES, selectedId);
+  const article = SidebarState.selectedArticle(visibleArticles, selectedId);
   if (!article) {
     selectedId = null;
     detailsPanelOpen = true;

--- a/screens/overview/v3.html
+++ b/screens/overview/v3.html
@@ -1266,7 +1266,7 @@ function render() {
     for (let i = 0; i < 5; i++) grid.appendChild(renderSkeleton());
     loadMoreRegion.innerHTML = '';
     document.getElementById('article-count').textContent = '— articles';
-    syncDetailsPanel();
+    syncDetailsPanel([]);
     return;
   }
 
@@ -1415,7 +1415,6 @@ function closePanel() {
   selectedId = null;
   detailsPanelOpen = true;
   render();
-  syncDetailsPanel();
 }
 
 function setStatusFilter(val, el) {

--- a/tests/overview-v3.spec.js
+++ b/tests/overview-v3.spec.js
@@ -1,6 +1,48 @@
 const { test, expect } = require('@playwright/test');
+const SidebarState = require('../screens/overview/sidebar-state.js');
 
 const OVERVIEW_URL = '/screens/overview/v3.html';
+
+test.describe('Overview sidebar state unit logic', () => {
+  test('normalizes missing and partial destinations as unavailable', () => {
+    const destinations = SidebarState.normalizeDestinations({
+      medium: { status: 'draft', label: '' },
+      hashnode: { status: 'unknown', label: '<b>remote</b>' },
+    });
+
+    expect(destinations.medium).toMatchObject({ status: 'draft', label: 'Draft' });
+    expect(destinations.hashnode).toMatchObject({ status: 'none', label: 'Unavailable' });
+    expect(destinations.devto).toMatchObject({ status: 'none', label: 'Unavailable' });
+  });
+
+  test('resolves selection only from the current collection', () => {
+    const first = { id: 'first' };
+    const second = { id: 'second' };
+
+    expect(SidebarState.selectedArticle([first, second], 'second')).toBe(second);
+    expect(SidebarState.selectedArticle([first], 'second')).toBeNull();
+    expect(SidebarState.selectedArticle([], 'second')).toBeNull();
+  });
+
+  test('derives explicit empty and active-job panel states', () => {
+    const article = {
+      id: 'article-1',
+      title: '',
+      destinations: {},
+      timeline: null,
+      action: { kind: 'push', label: 'Push drafts \u2192', bg: '#6366f1' },
+    };
+
+    const idle = SidebarState.panelModel(article, null);
+    expect(idle.title).toBe('Untitled article');
+    expect(idle.timeline).toEqual([]);
+    expect(idle.destinations.every(item => item.label === 'Unavailable')).toBe(true);
+
+    const busy = SidebarState.panelModel(article, 'inspect');
+    expect(busy.primaryAction).toMatchObject({ label: 'Inspecting\u2026', disabled: true });
+    expect(busy.inspectDisabled).toBe(true);
+  });
+});
 
 test.describe('Current overview screen', () => {
   test.beforeEach(async ({ page }) => {
@@ -32,5 +74,132 @@ test.describe('Current overview screen', () => {
   test('opens the selected article in the editor', async ({ page }) => {
     await page.locator('.article-card').first().locator('.card-edit').click();
     await expect(page).toHaveURL(/\/screens\/editor\/v2\.html\?id=/);
+  });
+
+  test('refreshes selected details after an article action completes', async ({ page }) => {
+    const firstCard = page.locator('.article-card').first();
+    const articleId = await firstCard.getAttribute('data-id');
+    await firstCard.click();
+    const originalTitle = await page.locator('#panel-title').innerText();
+
+    const originalPayload = await page.request.get('/api/articles?sortBy=updatedAt&sortDir=desc&page=1&pageSize=100');
+    const refreshed = await originalPayload.json();
+    const selected = refreshed.items.find(item => item.id === articleId);
+    selected.title = `${originalTitle} refreshed`;
+    selected.destinations.medium = { status: 'published', label: 'Published now', url: 'https://medium.com/test' };
+    selected.recentTimeline = [{ timestamp: '2026-08-29T12:00:00Z', event: 'Published to Medium' }];
+
+    await page.route(`**/api/articles/${articleId}/inspect`, route => route.fulfill({
+      status: 202,
+      contentType: 'application/json',
+      body: JSON.stringify({ jobId: 'job-sidebar-refresh', status: 'queued' }),
+    }));
+    let pollCount = 0;
+    await page.route('**/api/jobs/job-sidebar-refresh', route => {
+      pollCount += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: pollCount === 1 ? 'running' : 'completed' }),
+      });
+    });
+    await page.route('**/api/articles?*', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(refreshed),
+    }));
+
+    await page.locator('#panel-inspect-btn').click();
+    await expect(page.locator('#panel-primary-btn')).toHaveText('Inspecting\u2026');
+    await expect(page.locator('#panel-primary-btn')).toBeDisabled();
+
+    await expect(page.locator('#panel-title')).toHaveText(`${originalTitle} refreshed`);
+    await expect(page.locator('#panel-destinations')).toContainText('Published now');
+    await expect(page.locator('#panel-timeline')).toContainText('Published to Medium');
+    await expect(page.locator(`.article-card[data-id="${articleId}"] .article-card-title`))
+      .toHaveText(`${originalTitle} refreshed`);
+  });
+
+  test('switches every sidebar field to the newly selected article', async ({ page }) => {
+    const cards = page.locator('.article-card');
+    const firstTitle = await cards.nth(0).locator('.article-card-title').innerText();
+    const secondTitle = await cards.nth(1).locator('.article-card-title').innerText();
+
+    await cards.nth(0).click();
+    const firstDestinations = await page.locator('#panel-destinations').innerText();
+    const firstTimeline = await page.locator('#panel-timeline').innerText();
+    await expect(page.locator('#panel-title')).toHaveText(firstTitle);
+
+    await cards.nth(1).click();
+    await expect(page.locator('#panel-title')).toHaveText(secondTitle);
+    await expect(page.locator('#panel-title')).not.toHaveText(firstTitle);
+    expect(await page.locator('#panel-destinations').innerText()).not.toBe(firstDestinations);
+    expect(await page.locator('#panel-timeline').innerText()).not.toBe(firstTimeline);
+  });
+
+  test('renders remote sidebar text safely and handles partial article data', async ({ page }) => {
+    const payload = {
+      items: [{
+        id: 'partial-article',
+        title: 'Partial article',
+        updatedAt: '2026-08-29T12:00:00Z',
+        wordCount: 0,
+        gate: 'pending',
+        destinations: {
+          medium: { status: 'draft', label: '<img src=x onerror="window.sidebarInjected=true">' },
+        },
+        recentTimeline: [{
+          timestamp: '2026-08-29T12:00:00Z',
+          event: '<svg onload="window.sidebarInjected=true"></svg>',
+        }],
+      }],
+      total: 1,
+      page: 1,
+      pageSize: 100,
+    };
+    await page.route('**/api/articles?*', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    }));
+
+    await page.reload();
+    await page.locator('.article-card').click();
+
+    await expect(page.locator('#panel-destinations')).toContainText('<img src=x');
+    await expect(page.locator('#panel-destinations')).toContainText('Unavailable');
+    await expect(page.locator('#panel-timeline')).toContainText('<svg onload=');
+    await expect(page.locator('#panel-destinations img')).toHaveCount(0);
+    await expect(page.locator('#panel-timeline svg')).toHaveCount(0);
+    expect(await page.evaluate(() => window.sidebarInjected)).toBeUndefined();
+  });
+
+  test('shows an explicit empty timeline and clears removed selections', async ({ page }) => {
+    const firstCard = page.locator('.article-card').first();
+    await firstCard.click();
+    await page.evaluate(() => {
+      ARTICLES[0].timeline = [];
+      render();
+    });
+    await expect(page.locator('#panel-timeline')).toHaveText('No activity yet.');
+
+    await page.evaluate(() => {
+      ARTICLES = ARTICLES.filter(article => article.id !== selectedId);
+      render();
+    });
+    await expect(page.locator('#side-panel')).toHaveClass(/hidden/);
+    expect(await page.evaluate(() => selectedId)).toBeNull();
+  });
+
+  test('keeps a filtered selection coherent with the authoritative lifecycle', async ({ page }) => {
+    const firstCard = page.locator('.article-card').first();
+    const selectedTitle = await firstCard.locator('.article-card-title').innerText();
+    await firstCard.click();
+
+    await page.locator('#search-input').fill('definitely no matching article');
+
+    await expect(page.locator('.article-card')).toHaveCount(0);
+    await expect(page.locator('#panel-title')).toHaveText(selectedTitle);
+    await expect(page.locator('#side-panel')).not.toHaveClass(/hidden/);
   });
 });

--- a/tests/overview-v3.spec.js
+++ b/tests/overview-v3.spec.js
@@ -49,7 +49,7 @@ test.describe('Current overview screen', () => {
     const reset = await page.request.post('/api/dev/reset');
     expect(reset.ok()).toBeTruthy();
     await page.goto(OVERVIEW_URL);
-    await page.locator('.article-card').first().waitFor();
+    await expect(page.locator('#article-count')).not.toHaveText('— articles');
   });
 
   test('renders article cards from the backend', async ({ page }) => {
@@ -164,6 +164,7 @@ test.describe('Current overview screen', () => {
     }));
 
     await page.reload();
+    await expect(page.locator('#article-count')).toHaveText('1 article');
     await page.locator('.article-card').click();
 
     await expect(page.locator('#panel-destinations')).toContainText('<img src=x');

--- a/tests/overview-v3.spec.js
+++ b/tests/overview-v3.spec.js
@@ -191,15 +191,16 @@ test.describe('Current overview screen', () => {
     expect(await page.evaluate(() => selectedId)).toBeNull();
   });
 
-  test('keeps a filtered selection coherent with the authoritative lifecycle', async ({ page }) => {
+  test('OV-S14 clears selection when filtering excludes the selected article', async ({ page }) => {
     const firstCard = page.locator('.article-card').first();
-    const selectedTitle = await firstCard.locator('.article-card-title').innerText();
     await firstCard.click();
+    await expect(page.locator('#side-panel')).not.toHaveClass(/hidden/);
 
     await page.locator('#search-input').fill('definitely no matching article');
 
     await expect(page.locator('.article-card')).toHaveCount(0);
-    await expect(page.locator('#panel-title')).toHaveText(selectedTitle);
-    await expect(page.locator('#side-panel')).not.toHaveClass(/hidden/);
+    await expect(page.locator('#side-panel')).toHaveClass(/hidden/);
+    await expect(page.locator('#panel-title')).toHaveText('');
+    expect(await page.evaluate(() => selectedId)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- centralize Overview sidebar normalization and rendering from the current article collection
- refresh selected details and derived actions with collection and active-job changes, clearing selection only when the article is absent
- render remote labels and timeline events as text, with explicit unavailable and empty states
- preserve the authoritative 300 px open and 12 px collapsed desktop geometry

## Tests

- `python -m pytest --strict-markers -m "not integration and not browser"` (558 passed)
- `playwright test overview-v3.spec.js` (12 passed)
- `pytest tests/tests_ui/screens/test_overview_card.py -m browser -q` (5 passed)

Closes #97