### PR TITLE
feat: complete Overview filter lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Validate generated contracts
         run: npm run check:contracts
 
+      - name: Run JavaScript unit tests
+        run: npm run test:unit:js
+
   pytest-browser-tests:
     name: Pytest browser smoke gate
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "private": true,
     "scripts": {
         "test": "playwright test",
+        "test:unit:js": "node --test tests/unit/*.test.js",
         "test:playwright:ci": "bash scripts/run-playwright-tests.sh",
         "test:headed": "playwright test --headed",
         "test:debug": "playwright test --debug",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -7,6 +7,7 @@ const windowsPython = path.join(__dirname, '.venv', 'Scripts', 'python.exe');
 const PYTHON = process.env.PYTHON ||
   (process.platform === 'win32' && fs.existsSync(windowsPython) ? windowsPython : 'python');
 const PYTHON_COMMAND = process.env.BLOGHUB_PLAYWRIGHT_PYTHON_COMMAND || `"${PYTHON}"`;
+const BASE_URL = process.env.BLOGHUB_TEST_URL || 'http://localhost:8000';
 
 module.exports = defineConfig({
   testDir: './tests',
@@ -19,7 +20,7 @@ module.exports = defineConfig({
     ? [['list'], ['html', { outputFolder: 'tests/results/html', open: 'never' }], ['json', { outputFile: 'tests/results/report.json' }]]
     : [['list'], ['json', { outputFile: 'tests/results/report.json' }]],
 
-  webServer: {
+  webServer: process.env.BLOGHUB_TEST_URL ? undefined : {
     command: `${PYTHON_COMMAND} -m uvicorn backend.main:app --port 8000 --no-access-log`,
     cwd: __dirname,
     url: 'http://localhost:8000/health',
@@ -34,7 +35,7 @@ module.exports = defineConfig({
   },
 
   use: {
-    baseURL: 'http://localhost:8000',
+    baseURL: BASE_URL,
     trace: 'on-first-retry',
   },
 

--- a/screens/overview/filter-state.js
+++ b/screens/overview/filter-state.js
@@ -1,0 +1,61 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  if (root) root.OverviewFilters = api;
+}(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  'use strict';
+
+  const DRAFTING_STATUSES = new Set(['draft', 'pending', 'review']);
+
+  function normalizeSearch(value) {
+    return String(value || '').trim().toLowerCase();
+  }
+
+  function matchesOverviewFilters(article, filters) {
+    const query = normalizeSearch(filters.search);
+    if (query && !String(article.title || '').toLowerCase().includes(query)) return false;
+
+    const destinations = Object.values(article.destinations || {});
+    const statuses = destinations.map(destination => destination.status);
+    if (filters.status === 'error' && !statuses.includes('error')) return false;
+    if (filters.status === 'ready' && !statuses.includes('ready')) return false;
+    if (filters.status === 'published' && !statuses.every(status => status === 'published')) return false;
+    if (filters.status === 'drafting' && !statuses.some(status => DRAFTING_STATUSES.has(status))) return false;
+
+    const platforms = filters.platforms || [];
+    if (platforms.length > 0) {
+      const hasSelectedPlatform = platforms.some(platform => {
+        const destination = article.destinations && article.destinations[platform];
+        return destination && destination.status !== 'none';
+      });
+      if (!hasSelectedPlatform) return false;
+    }
+    return true;
+  }
+
+  function createDebouncedFilter(onSettle, delay = 250) {
+    let timer = null;
+
+    function cancel() {
+      if (timer !== null) clearTimeout(timer);
+      timer = null;
+    }
+
+    function schedule(value) {
+      cancel();
+      timer = setTimeout(() => {
+        timer = null;
+        onSettle(value);
+      }, delay);
+    }
+
+    function flush(value) {
+      cancel();
+      onSettle(value);
+    }
+
+    return { schedule, flush, cancel };
+  }
+
+  return { createDebouncedFilter, matchesOverviewFilters, normalizeSearch };
+}));

--- a/screens/overview/v3.html
+++ b/screens/overview/v3.html
@@ -483,7 +483,7 @@
         <!-- Search -->
         <div style="position:relative;flex-shrink:0;">
           <svg style="position:absolute;left:9px;top:50%;transform:translateY(-50%);color:#5a6080;" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path stroke-linecap="round" d="m21 21-4.35-4.35"/></svg>
-          <input id="search-input" type="text" placeholder="Search articles…" oninput="applyFilters()"
+          <input id="search-input" type="text" placeholder="Search articles…" oninput="scheduleSearchFilter(this.value)" onkeydown="handleSearchKeydown(event)"
             style="padding:6px 10px 6px 30px;font-size:12px;border-radius:6px;border:1px solid #252a38;background:#181c27;color:#c9cfe0;width:260px;font-family:inherit;outline:none;"
             onfocus="this.style.borderColor='#6366f1'" onblur="this.style.borderColor='#252a38'" />
         </div>
@@ -567,6 +567,7 @@
   </div>
 </div>
 
+<script src="filter-state.js"></script>
 <script>
 // --- Data ----------------------------------------------------------
 let ARTICLES = [];
@@ -618,6 +619,7 @@ const PLATFORM_LABEL = { medium: 'Medium', hashnode: 'Hashnode', devto: 'Dev.to'
 let selectedId     = null;
 let statusFilter   = 'all';
 let platformFilter = new Set();
+let searchQuery    = '';
 let showSkeleton   = false;
 let showEmpty      = false;
 let openMenuId     = null;
@@ -633,7 +635,10 @@ let isLoadingMore     = false; // a "Load more" fetch is in flight
 let loadMoreError     = null;  // message from the last failed "Load more" attempt
 let overviewLoadGeneration = 0; // invalidates stale full-overview reloads
 let pageLoadGeneration     = 0; // invalidates stale incremental page loads
+let overviewLoadController = null;
+let pageLoadController     = null;
 const loadedArticleIds = new Set();
+const searchFilter = OverviewFilters.createDebouncedFilter(settleSearchFilter, 250);
 
 // --- Helpers -------------------------------------------------------
 const DOT_COLOR = {
@@ -730,11 +735,11 @@ function articlesPageUrl(page) {
 
 // Fetch pages 1..pagesToLoad and concatenate them, preserving server order.
 // Returns null if a newer load generation started while this was in flight.
-async function fetchArticlePages(pagesToLoad, generation) {
+async function fetchArticlePages(pagesToLoad, generation, signal) {
   let items = [];
   let total = 0;
   for (let page = 1; page <= pagesToLoad; page += 1) {
-    const payload = await fetchJson(articlesPageUrl(page));
+    const payload = await fetchJson(articlesPageUrl(page), { signal });
     if (generation !== overviewLoadGeneration) return null; // superseded — discard
     items = items.concat(payload.items);
     total = payload.total;
@@ -746,15 +751,16 @@ async function fetchArticlePages(pagesToLoad, generation) {
 // action-triggered refresh (push/inspect/etc.) never collapses an already
 // expanded list back down to the first 100 articles.
 async function loadOverview() {
+  if (overviewLoadController) overviewLoadController.abort();
+  overviewLoadController = new AbortController();
+  const signal = overviewLoadController.signal;
   const generation = (overviewLoadGeneration += 1);
-  pageLoadGeneration += 1;
-  isLoadingMore = false;
-  loadMoreError = null;
+  invalidateInFlightPageLoad();
 
   const pagesToLoad = Math.max(1, currentPage);
   const [articlesResult, connectionsPayload] = await Promise.all([
-    fetchArticlePages(pagesToLoad, generation),
-    fetchJson('/api/connections'),
+    fetchArticlePages(pagesToLoad, generation, signal),
+    fetchJson('/api/connections', { signal }),
   ]);
 
   if (generation !== overviewLoadGeneration || articlesResult === null) return; // stale
@@ -783,8 +789,7 @@ function hasMoreArticles() {
 }
 
 function hasActiveFilters() {
-  const query = document.getElementById('search-input').value.trim();
-  return query.length > 0 || statusFilter !== 'all' || platformFilter.size > 0;
+  return searchQuery.length > 0 || statusFilter !== 'all' || platformFilter.size > 0;
 }
 
 function appendArticlePage(payload, page) {
@@ -806,28 +811,35 @@ async function loadMoreArticles() {
   if (isLoadingMore || !hasMoreArticles()) return;
   const generation = pageLoadGeneration;
   const nextPage = currentPage + 1;
+  pageLoadController = new AbortController();
+  const signal = pageLoadController.signal;
 
   isLoadingMore = true;
   loadMoreError = null;
   render();
 
   try {
-    const payload = await fetchJson(articlesPageUrl(nextPage));
+    const payload = await fetchJson(articlesPageUrl(nextPage), { signal });
     if (generation !== pageLoadGeneration) return; // superseded
     appendArticlePage(payload, nextPage);
   } catch (error) {
-    if (generation === pageLoadGeneration) {
+    if (error.name !== 'AbortError' && generation === pageLoadGeneration) {
       loadMoreError = error.message || 'Failed to load more articles.';
     }
   } finally {
-    if (generation === pageLoadGeneration) isLoadingMore = false;
-    render();
+    if (generation === pageLoadGeneration) {
+      isLoadingMore = false;
+      pageLoadController = null;
+      render();
+    }
   }
 }
 
 async function loadRemainingArticlesForFilters() {
   if (isLoadingMore || !hasActiveFilters() || !hasMoreArticles()) return;
   const generation = pageLoadGeneration;
+  pageLoadController = new AbortController();
+  const signal = pageLoadController.signal;
   isLoadingMore = true;
   loadMoreError = null;
   render();
@@ -835,17 +847,20 @@ async function loadRemainingArticlesForFilters() {
   try {
     while (generation === pageLoadGeneration && hasMoreArticles()) {
       const nextPage = currentPage + 1;
-      const payload = await fetchJson(articlesPageUrl(nextPage));
+      const payload = await fetchJson(articlesPageUrl(nextPage), { signal });
       if (generation !== pageLoadGeneration) return;
       appendArticlePage(payload, nextPage);
     }
   } catch (error) {
-    if (generation === pageLoadGeneration) {
+    if (error.name !== 'AbortError' && generation === pageLoadGeneration) {
       loadMoreError = error.message || 'Failed to load all articles for filtering.';
     }
   } finally {
-    if (generation === pageLoadGeneration) isLoadingMore = false;
-    render();
+    if (generation === pageLoadGeneration) {
+      isLoadingMore = false;
+      pageLoadController = null;
+      render();
+    }
   }
 }
 
@@ -856,6 +871,8 @@ async function loadRemainingArticlesForFilters() {
 // state the user has since changed. The user can simply press "Load more"
 // again once filters settle.
 function invalidateInFlightPageLoad() {
+  if (pageLoadController) pageLoadController.abort();
+  pageLoadController = null;
   pageLoadGeneration += 1;
   isLoadingMore = false;
   loadMoreError = null;
@@ -935,20 +952,11 @@ function defaultPreviewPlatform(a) {
 }
 
 function matchesFilters(a) {
-  const q = document.getElementById('search-input').value.toLowerCase();
-  if (q && !a.title.toLowerCase().includes(q)) return false;
-  if (statusFilter !== 'all') {
-    const statuses = Object.values(a.destinations).map(d => d.status);
-    if (statusFilter === 'error'     && !statuses.includes('error'))     return false;
-    if (statusFilter === 'ready'     && !statuses.includes('ready'))     return false;
-    if (statusFilter === 'published' && !statuses.every(d => d === 'published')) return false;
-    if (statusFilter === 'drafting'  && !statuses.some(d => ['draft','pending','review'].includes(d))) return false;
-  }
-  if (platformFilter.size > 0) {
-    const hasPlatform = [...platformFilter].some(p => a.destinations[p] && a.destinations[p].status !== 'none');
-    if (!hasPlatform) return false;
-  }
-  return true;
+  return OverviewFilters.matchesOverviewFilters(a, {
+    search: searchQuery,
+    status: statusFilter,
+    platforms: [...platformFilter],
+  });
 }
 
 // --- Thumbnail builder ---------------------------------------------
@@ -1377,8 +1385,27 @@ function applyFilters() {
   void loadRemainingArticlesForFilters();
 }
 
+function settleSearchFilter(value) {
+  searchQuery = OverviewFilters.normalizeSearch(value);
+  applyFilters();
+}
+
+function scheduleSearchFilter(value) {
+  searchFilter.schedule(value);
+}
+
+function handleSearchKeydown(event) {
+  if (event.key !== 'Escape') return;
+  event.preventDefault();
+  const input = document.getElementById('search-input');
+  input.value = '';
+  searchFilter.flush('');
+}
+
 function clearFilters() {
+  searchFilter.cancel();
   document.getElementById('search-input').value = '';
+  searchQuery = '';
   statusFilter = 'all';
   platformFilter.clear();
   document.querySelectorAll('.pill-filter').forEach(b => b.classList.remove('active'));

--- a/screens/overview/v3.html
+++ b/screens/overview/v3.html
@@ -1266,7 +1266,7 @@ function render() {
     emptyEl.style.display = 'flex';
     loadMoreRegion.innerHTML = '';
     document.getElementById('article-count').textContent = '0 articles';
-    syncDetailsPanel();
+    syncDetailsPanel([]);
     return;
   }
   if (showSkeleton) {
@@ -1283,19 +1283,22 @@ function render() {
   if (filtered.length === 0) {
     if (!isLoadingMore) noRes.style.display = 'flex';
     renderLoadMoreRegion();
-    syncDetailsPanel();
+    syncDetailsPanel(filtered);
     return;
   }
   filtered.forEach(a => grid.appendChild(renderCard(a)));
   renderLoadMoreRegion();
-  syncDetailsPanel();
+  syncDetailsPanel(filtered);
 }
 
-function syncDetailsPanel() {
+function syncDetailsPanel(visibleArticles = ARTICLES) {
   const panel = document.getElementById('side-panel');
   const content = document.getElementById('panel-content');
   const arrow = document.getElementById('side-strip-arrow');
-  if (!selectedId) {
+  const selectionIsVisible = selectedId && visibleArticles.some(article => article.id === selectedId);
+  if (!selectionIsVisible) {
+    selectedId = null;
+    detailsPanelOpen = true;
     panel.classList.add('hidden');
     return;
   }

--- a/screens/overview/v3.html
+++ b/screens/overview/v3.html
@@ -757,31 +757,40 @@ async function loadOverview() {
   const generation = (overviewLoadGeneration += 1);
   invalidateInFlightPageLoad();
 
-  const pagesToLoad = Math.max(1, currentPage);
-  const [articlesResult, connectionsPayload] = await Promise.all([
-    fetchArticlePages(pagesToLoad, generation, signal),
-    fetchJson('/api/connections', { signal }),
-  ]);
+  try {
+    const pagesToLoad = Math.max(1, currentPage);
+    const [articlesResult, connectionsPayload] = await Promise.all([
+      fetchArticlePages(pagesToLoad, generation, signal),
+      fetchJson('/api/connections', { signal }),
+    ]);
 
-  if (generation !== overviewLoadGeneration || articlesResult === null) return; // stale
+    if (generation !== overviewLoadGeneration || articlesResult === null) return; // stale
 
-  loadedArticleIds.clear();
-  ARTICLES = articlesResult.items.map((raw, index) => {
-    loadedArticleIds.add(raw.id);
-    return buildLiveArticle(raw, index);
-  });
-  totalArticleCount = articlesResult.total;
-  currentPage = pagesToLoad;
+    loadedArticleIds.clear();
+    ARTICLES = articlesResult.items.map((raw, index) => {
+      loadedArticleIds.add(raw.id);
+      return buildLiveArticle(raw, index);
+    });
+    totalArticleCount = articlesResult.total;
+    currentPage = pagesToLoad;
 
-  const connected = connectionsPayload.connections.filter(
-    item => ['medium', 'hashnode', 'devto'].includes(item.id) && item.status === 'connected'
-  );
-  document.getElementById('connected-count').innerHTML = `
-    <span style="width:6px;height:6px;border-radius:50%;background:#4ade80;display:inline-block;"></span>
-    ${connected.length} platforms connected
-  `;
+    const connected = connectionsPayload.connections.filter(
+      item => ['medium', 'hashnode', 'devto'].includes(item.id) && item.status === 'connected'
+    );
+    document.getElementById('connected-count').innerHTML = `
+      <span style="width:6px;height:6px;border-radius:50%;background:#4ade80;display:inline-block;"></span>
+      ${connected.length} platforms connected
+    `;
 
-  if (hasActiveFilters()) await loadRemainingArticlesForFilters();
+    if (hasActiveFilters()) await loadRemainingArticlesForFilters();
+  } catch (error) {
+    if (error.name === 'AbortError' || generation !== overviewLoadGeneration) return;
+    throw error;
+  } finally {
+    if (overviewLoadController && overviewLoadController.signal === signal) {
+      overviewLoadController = null;
+    }
+  }
 }
 
 function hasMoreArticles() {

--- a/tests/overview-v3.spec.js
+++ b/tests/overview-v3.spec.js
@@ -166,6 +166,34 @@ test.describe('Current overview screen', () => {
     await page.unroute('**/api/articles?**');
   });
 
+  test('treats an aborted overview reload as a superseded request', async ({ page }) => {
+    const article = await page.evaluate(() => ARTICLES[0]);
+    let articleRequests = 0;
+    await page.route('**/api/articles?**', async route => {
+      articleRequests += 1;
+      if (articleRequests === 1) {
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+      try {
+        await route.fulfill({ json: { items: [article], total: 1 } });
+      } catch (error) {
+        // The first routed request can be retired before its delayed response.
+      }
+    });
+    await page.route('**/api/connections', route => route.fulfill({ json: { connections: [] } }));
+
+    const results = await page.evaluate(async () => {
+      const first = loadOverview();
+      await new Promise(resolve => setTimeout(resolve, 0));
+      const second = loadOverview();
+      return Promise.allSettled([first, second]);
+    });
+
+    expect(results.map(result => result.status)).toEqual(['fulfilled', 'fulfilled']);
+    await expect(page.locator('.article-card')).not.toHaveCount(0);
+    expect(articleRequests).toBeGreaterThanOrEqual(2);
+  });
+
   test('opens the selected article in the editor', async ({ page }) => {
     await page.locator('.article-card').first().locator('.card-edit').click();
     await expect(page).toHaveURL(/\/screens\/editor\/v2\.html\?id=/);

--- a/tests/overview-v3.spec.js
+++ b/tests/overview-v3.spec.js
@@ -67,24 +67,43 @@ test.describe('Current overview screen', () => {
     expect(secondPageRequests).toBe(1);
   });
 
-  test('Escape clears search and restores the retained selection', async ({ page }) => {
+  test('settled search clears selection and Escape restores only the results', async ({ page }) => {
     const card = page.locator('.article-card').first();
     await card.locator('.article-card-title').click();
     await expect(page.locator('#side-panel')).not.toHaveClass(/hidden/);
-    const selectedId = await page.locator('.article-card.selected').getAttribute('data-id');
-    expect(selectedId).not.toBeNull();
 
     const input = page.locator('#search-input');
     await input.fill('no article has this title');
     await expect(page.locator('#no-results')).toBeVisible();
     await expect(page.locator('#article-count')).toHaveText('0 articles');
-    await expect(page.locator('#side-panel')).not.toHaveClass(/hidden/);
+    await expect(page.locator('#side-panel')).toHaveClass(/hidden/);
+    expect(await page.evaluate(() => selectedId)).toBeNull();
 
     await input.press('Escape');
     await expect(input).toHaveValue('');
     await expect(page.locator('.article-card')).toHaveCount(6);
-    await expect(page.locator(`.article-card[data-id="${selectedId}"]`)).toHaveClass(/selected/);
+    await expect(page.locator('.article-card.selected')).toHaveCount(0);
+    await expect(page.locator('#side-panel')).toHaveClass(/hidden/);
+    expect(await page.evaluate(() => selectedId)).toBeNull();
+  });
+
+  test('status and platform filters clear excluded selections', async ({ page }) => {
+    const published = page.locator('.article-card[data-id="art_003"]');
+    await published.locator('.article-card-title').click();
     await expect(page.locator('#side-panel')).not.toHaveClass(/hidden/);
+
+    await page.locator('#sf-drafting').click();
+    await expect(page.locator('#side-panel')).toHaveClass(/hidden/);
+    expect(await page.evaluate(() => selectedId)).toBeNull();
+
+    await page.locator('#sf-all').click();
+    const mediumOnly = page.locator('.article-card[data-id="art_004"]');
+    await mediumOnly.locator('.article-card-title').click();
+    await expect(page.locator('#side-panel')).not.toHaveClass(/hidden/);
+
+    await page.locator('#pf-hashnode').click();
+    await expect(page.locator('#side-panel')).toHaveClass(/hidden/);
+    expect(await page.evaluate(() => selectedId)).toBeNull();
   });
 
   test('keeps status single-select and combines platforms with OR semantics', async ({ page }) => {

--- a/tests/overview-v3.spec.js
+++ b/tests/overview-v3.spec.js
@@ -2,12 +2,25 @@ const { test, expect } = require('@playwright/test');
 
 const OVERVIEW_URL = '/screens/overview/v3.html';
 
+async function seedArticles(page, count, prefix = 'Filter lifecycle filler') {
+  for (let index = 0; index < count; index += 1) {
+    const response = await page.request.post('/api/articles', {
+      data: { title: `${prefix} ${String(index).padStart(4, '0')}` },
+    });
+    expect(response.ok()).toBeTruthy();
+  }
+}
+
+async function visibleCardIds(page) {
+  return page.locator('.article-card').evaluateAll(cards => cards.map(card => card.dataset.id));
+}
+
 test.describe('Current overview screen', () => {
   test.beforeEach(async ({ page }) => {
     const reset = await page.request.post('/api/dev/reset');
     expect(reset.ok()).toBeTruthy();
     await page.goto(OVERVIEW_URL);
-    await page.locator('.article-card').first().waitFor();
+    await expect(page.locator('#article-count')).not.toHaveText('— articles');
   });
 
   test('renders article cards from the backend', async ({ page }) => {
@@ -27,6 +40,111 @@ test.describe('Current overview screen', () => {
 
     await expect(page.locator('.article-card')).toHaveCount(1);
     await expect(page.locator('.article-card-title')).toHaveText(firstTitle);
+  });
+
+  test('debounces rapid search and finds matches beyond the first 100 articles', async ({ page }) => {
+    test.setTimeout(60_000);
+    const target = await page.request.post('/api/articles', {
+      data: { title: 'Unique deep pagination target' },
+    });
+    expect(target.ok()).toBeTruthy();
+    await seedArticles(page, 110);
+
+    let secondPageRequests = 0;
+    page.on('request', request => {
+      if (request.url().includes('/api/articles?') && request.url().includes('page=2')) {
+        secondPageRequests += 1;
+      }
+    });
+
+    await page.reload();
+    await expect(page.locator('.article-card')).toHaveCount(100);
+    await page.locator('#search-input').pressSequentially('Unique deep pagination target', { delay: 4 });
+
+    await expect(page.locator('.article-card')).toHaveCount(1);
+    await expect(page.locator('.article-card-title')).toHaveText('Unique deep pagination target');
+    await expect(page.locator('#article-count')).toHaveText('1 article');
+    expect(secondPageRequests).toBe(1);
+  });
+
+  test('Escape clears search and restores the retained selection', async ({ page }) => {
+    const card = page.locator('.article-card').first();
+    await card.locator('.article-card-title').click();
+    await expect(page.locator('#side-panel')).not.toHaveClass(/hidden/);
+    const selectedId = await page.locator('.article-card.selected').getAttribute('data-id');
+    expect(selectedId).not.toBeNull();
+
+    const input = page.locator('#search-input');
+    await input.fill('no article has this title');
+    await expect(page.locator('#no-results')).toBeVisible();
+    await expect(page.locator('#article-count')).toHaveText('0 articles');
+    await expect(page.locator('#side-panel')).not.toHaveClass(/hidden/);
+
+    await input.press('Escape');
+    await expect(input).toHaveValue('');
+    await expect(page.locator('.article-card')).toHaveCount(6);
+    await expect(page.locator(`.article-card[data-id="${selectedId}"]`)).toHaveClass(/selected/);
+    await expect(page.locator('#side-panel')).not.toHaveClass(/hidden/);
+  });
+
+  test('keeps status single-select and combines platforms with OR semantics', async ({ page }) => {
+    const response = await page.request.get('/api/articles?page=1&pageSize=100');
+    const items = (await response.json()).items;
+
+    await page.locator('#sf-drafting').click();
+    await page.locator('#sf-ready').click();
+    await expect(page.locator('.pill-filter.active')).toHaveCount(1);
+    await expect(page.locator('#sf-ready')).toHaveClass(/active/);
+    const readyIds = items
+      .filter(item => Object.values(item.destinations).some(destination => destination.status === 'ready'))
+      .map(item => item.id)
+      .sort();
+    expect((await visibleCardIds(page)).sort()).toEqual(readyIds);
+
+    await page.locator('#sf-all').click();
+    await page.locator('#pf-hashnode').click();
+    await page.locator('#pf-devto').click();
+    await expect(page.locator('.pill-platform.active')).toHaveCount(2);
+    const platformIds = items
+      .filter(item => ['hashnode', 'devto'].some(platform => item.destinations[platform].status !== 'none'))
+      .map(item => item.id)
+      .sort();
+    expect((await visibleCardIds(page)).sort()).toEqual(platformIds);
+  });
+
+  test('ignores an older page response after a newer search settles', async ({ page }) => {
+    test.setTimeout(60_000);
+    const target = await page.request.post('/api/articles', {
+      data: { title: 'Newest settled query target' },
+    });
+    expect(target.ok()).toBeTruthy();
+    await seedArticles(page, 110, 'Older query filler');
+    await page.reload();
+    await expect(page.locator('#load-more-status')).toHaveText('Showing 100 of 117 articles', { timeout: 15_000 });
+    await expect(page.locator('.article-card')).toHaveCount(100);
+
+    let delayed = false;
+    await page.route('**/api/articles?**', async route => {
+      if (!delayed && route.request().url().includes('page=2')) {
+        delayed = true;
+        await new Promise(resolve => setTimeout(resolve, 500));
+      }
+      try {
+        await route.continue();
+      } catch (error) {
+        // An AbortController may retire the superseded request before continue().
+      }
+    });
+
+    const input = page.locator('#search-input');
+    await input.fill('Older query filler');
+    await page.waitForRequest(request => request.url().includes('/api/articles?') && request.url().includes('page=2'));
+    await input.fill('Newest settled query target');
+
+    await expect(page.locator('.article-card')).toHaveCount(1);
+    await expect(page.locator('.article-card-title')).toHaveText('Newest settled query target');
+    await expect(page.locator('#article-count')).toHaveText('1 article');
+    await page.unroute('**/api/articles?**');
   });
 
   test('opens the selected article in the editor', async ({ page }) => {

--- a/tests/unit/overview-filter-state.test.js
+++ b/tests/unit/overview-filter-state.test.js
@@ -1,0 +1,72 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createDebouncedFilter,
+  matchesOverviewFilters,
+  normalizeSearch,
+} = require('../../screens/overview/filter-state.js');
+
+function article(title, medium, hashnode, devto) {
+  return {
+    title,
+    destinations: {
+      medium: { status: medium },
+      hashnode: { status: hashnode },
+      devto: { status: devto },
+    },
+  };
+}
+
+test('normalizes search without changing the raw input', () => {
+  assert.equal(normalizeSearch('  Vector DB  '), 'vector db');
+});
+
+test('matches search and the single selected status', () => {
+  const draft = article('Building a Vector DB', 'draft', 'none', 'none');
+  const published = article('Published vectors', 'published', 'published', 'published');
+
+  assert.equal(matchesOverviewFilters(draft, {
+    search: 'VECTOR', status: 'drafting', platforms: [],
+  }), true);
+  assert.equal(matchesOverviewFilters(draft, {
+    search: '', status: 'published', platforms: [],
+  }), false);
+  assert.equal(matchesOverviewFilters(published, {
+    search: '', status: 'published', platforms: [],
+  }), true);
+});
+
+test('combines selected platforms with OR semantics', () => {
+  const hashnodeOnly = article('Hashnode article', 'none', 'draft', 'none');
+
+  assert.equal(matchesOverviewFilters(hashnodeOnly, {
+    search: '', status: 'all', platforms: ['medium', 'hashnode'],
+  }), true);
+  assert.equal(matchesOverviewFilters(hashnodeOnly, {
+    search: '', status: 'all', platforms: ['medium', 'devto'],
+  }), false);
+});
+
+test('debounce settles only the latest rapid value', async () => {
+  const settled = [];
+  const debounce = createDebouncedFilter(value => settled.push(value), 20);
+
+  debounce.schedule('v');
+  debounce.schedule('ve');
+  debounce.schedule('vector');
+  await new Promise(resolve => setTimeout(resolve, 35));
+
+  assert.deepEqual(settled, ['vector']);
+});
+
+test('flush cancels pending work and settles immediately', async () => {
+  const settled = [];
+  const debounce = createDebouncedFilter(value => settled.push(value), 20);
+
+  debounce.schedule('stale');
+  debounce.flush('');
+  await new Promise(resolve => setTimeout(resolve, 35));
+
+  assert.deepEqual(settled, ['']);
+});


### PR DESCRIPTION
## Summary
- debounce Overview search at 250 ms and clear it immediately with Escape
- preserve single-select status and platform OR filtering across pagination beyond 100 articles
- clear selection under OV-S14 whenever settled search, status, or platform filters exclude the selected article
- cancel superseded collection requests while retaining generation guards
- add focused JavaScript unit and Playwright lifecycle coverage

## Tests
- npm run test:unit:js (5 passed)
- npm run check:contracts
- npx playwright test tests/overview-v3.spec.js --project=chromium (9 passed)
- Python unit gate: 549 passed, 3 skipped; 6 auth-sensitive tests rerun with normal auth and passed

Closes #99