### PR TITLE
feat: add Overview gate and card actions

### DIFF
--- a/backend/routers/articles.py
+++ b/backend/routers/articles.py
@@ -5,7 +5,7 @@ import zipfile
 from pathlib import Path
 from urllib.parse import quote
 
-from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile
+from fastapi import APIRouter, File, Header, HTTPException, Query, Request, UploadFile
 from fastapi.responses import Response
 from typing import Literal, Optional
 
@@ -109,6 +109,67 @@ def delete_articles(request: Request, body: DeleteArticleRequest):
             detail={
                 "message": "Some articles are published. Pass force=true to delete anyway.",
                 "blocked_ids": blocked,
+            },
+        )
+
+
+class DuplicateArticleSummary(BaseModel):
+    id: str
+    title: str
+
+
+class DuplicateArticleResponse(BaseModel):
+    article: DuplicateArticleSummary
+
+
+class ArchiveArticleResponse(BaseModel):
+    id: str
+    archived: bool
+
+
+def _article_not_found() -> HTTPException:
+    return HTTPException(
+        status_code=404,
+        detail={"error": "not_found", "message": "Article not found."},
+    )
+
+
+@router.post(
+    "/{article_id}/duplicate", response_model=DuplicateArticleResponse, status_code=201,
+)
+def duplicate_article(
+    request: Request,
+    article_id: str,
+    idempotency_key: str = Header(min_length=1, max_length=200),
+):
+    duplicate, _created = store.duplicate_article(
+        request.state.user_id, article_id, idempotency_key,
+    )
+    if duplicate is None:
+        raise _article_not_found()
+    return DuplicateArticleResponse(
+        article=DuplicateArticleSummary(id=duplicate["id"], title=duplicate["title"]),
+    )
+
+
+@router.post("/{article_id}/archive", response_model=ArchiveArticleResponse)
+def archive_article(request: Request, article_id: str):
+    if not store.archive_article(request.state.user_id, article_id):
+        raise _article_not_found()
+    return ArchiveArticleResponse(id=article_id, archived=True)
+
+
+@router.delete("/{article_id}", status_code=204)
+def delete_article(request: Request, article_id: str):
+    result = store.delete_article(request.state.user_id, article_id)
+    if result == "not_found":
+        raise _article_not_found()
+    if result == "published":
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "has_published_destinations",
+                "message": "Cannot delete published article. Remove its live destinations first.",
             },
         )
 

--- a/backend/routers/articles.py
+++ b/backend/routers/articles.py
@@ -153,15 +153,23 @@ def duplicate_article(
 
 
 @router.post("/{article_id}/archive", response_model=ArchiveArticleResponse)
-def archive_article(request: Request, article_id: str):
-    if not store.archive_article(request.state.user_id, article_id):
+def archive_article(
+    request: Request,
+    article_id: str,
+    idempotency_key: str | None = Header(default=None, min_length=1, max_length=200),
+):
+    if not store.archive_article(request.state.user_id, article_id, idempotency_key):
         raise _article_not_found()
     return ArchiveArticleResponse(id=article_id, archived=True)
 
 
 @router.delete("/{article_id}", status_code=204)
-def delete_article(request: Request, article_id: str):
-    result = store.delete_article(request.state.user_id, article_id)
+def delete_article(
+    request: Request,
+    article_id: str,
+    idempotency_key: str | None = Header(default=None, min_length=1, max_length=200),
+):
+    result = store.delete_article(request.state.user_id, article_id, idempotency_key)
     if result == "not_found":
         raise _article_not_found()
     if result == "published":

--- a/backend/store/__init__.py
+++ b/backend/store/__init__.py
@@ -93,6 +93,18 @@ def delete_articles(user_id: str, *a, **kw):
     return _backend.delete_articles(user_id, *a, **kw)
 
 
+def duplicate_article(user_id: str, *a, **kw):
+    return _backend.duplicate_article(user_id, *a, **kw)
+
+
+def archive_article(user_id: str, *a, **kw):
+    return _backend.archive_article(user_id, *a, **kw)
+
+
+def delete_article(user_id: str, *a, **kw):
+    return _backend.delete_article(user_id, *a, **kw)
+
+
 def find_article_by_canonical_url(user_id: str, *a, **kw):
     return _backend.find_article_by_canonical_url(user_id, *a, **kw)
 

--- a/backend/store/backends/sqlite.py
+++ b/backend/store/backends/sqlite.py
@@ -339,6 +339,13 @@ class SQLiteStore(
             (article_id,),
         ).fetchone()
         if row is None:
+            row = self._con.execute(
+                """SELECT id AS cover_asset_id FROM article_assets
+                   WHERE article_id=? AND mime_type LIKE 'image/%'
+                   ORDER BY id LIMIT 1""",
+                (article_id,),
+            ).fetchone()
+        if row is None:
             return None
         return f"/api/articles/{article_id}/assets/{row['cover_asset_id']}"
 
@@ -477,7 +484,10 @@ class SQLiteStore(
         return [self._load_article(r) for r in rows], total
 
     def get_article(self, user_id: str, article_id: str) -> dict | None:
-        row = self._con.execute("SELECT * FROM articles WHERE id=? AND user_id=?", (article_id, user_id)).fetchone()
+        row = self._con.execute(
+            "SELECT * FROM articles WHERE id=? AND user_id=? AND archived_at IS NULL",
+            (article_id, user_id),
+        ).fetchone()
         return self._load_article(row) if row else None
 
     def create_article(
@@ -822,6 +832,44 @@ class SQLiteStore(
                 duplicate_id, 1, title, body, source="user",
                 description="Article duplicated", created_by=user_id, created_at=now_s,
             )
+            asset_rows = self._con.execute(
+                """SELECT filename, asset_path, mime_type FROM article_assets
+                   WHERE article_id=? ORDER BY id""",
+                (article_id,),
+            ).fetchall()
+            source_assets_root = (
+                self._blobs_dir / "articles" / article_id / "assets"
+            ).resolve()
+            duplicate_assets_root = (
+                self._blobs_dir / "articles" / duplicate_id / "assets"
+            ).resolve()
+            for asset in asset_rows:
+                source_path = (self._blobs_dir / asset["asset_path"]).resolve()
+                try:
+                    source_path.relative_to(source_assets_root)
+                except ValueError:
+                    continue
+                if not source_path.is_file():
+                    continue
+                destination = (duplicate_assets_root / asset["filename"]).resolve()
+                try:
+                    destination.relative_to(duplicate_assets_root)
+                except ValueError:
+                    continue
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source_path, destination)
+                self._con.execute(
+                    """INSERT INTO article_assets
+                       (article_id, filename, asset_path, mime_type, created_at)
+                       VALUES (?,?,?,?,?)""",
+                    (
+                        duplicate_id,
+                        asset["filename"],
+                        str(destination.relative_to(self._blobs_dir)),
+                        asset["mime_type"],
+                        now_s,
+                    ),
+                )
             self._con.execute(
                 """INSERT INTO article_duplicate_requests
                    (user_id, source_article_id, idempotency_key, duplicate_article_id, created_at)
@@ -831,8 +879,17 @@ class SQLiteStore(
             self._con.commit()
             return self.get_article(user_id, duplicate_id), True
 
-    def archive_article(self, user_id: str, article_id: str) -> bool:
+    def archive_article(
+        self, user_id: str, article_id: str, idempotency_key: str | None = None,
+    ) -> bool:
         with self._workspace_lock.acquire():
+            if idempotency_key and self._con.execute(
+                """SELECT 1 FROM article_mutation_requests
+                   WHERE user_id=? AND article_id=? AND action='archive'
+                     AND idempotency_key=?""",
+                (user_id, article_id, idempotency_key),
+            ).fetchone():
+                return True
             cursor = self._con.execute(
                 """UPDATE articles SET archived_at=?, updated_at=?
                    WHERE id=? AND user_id=? AND archived_at IS NULL""",
@@ -840,11 +897,27 @@ class SQLiteStore(
             )
             if cursor.rowcount:
                 self._add_timeline(article_id, "Article archived")
+                if idempotency_key:
+                    self._con.execute(
+                        """INSERT INTO article_mutation_requests
+                           (user_id, article_id, action, idempotency_key, created_at)
+                           VALUES (?,?,'archive',?,?)""",
+                        (user_id, article_id, idempotency_key, _ts(_now())),
+                    )
             self._con.commit()
             return bool(cursor.rowcount)
 
-    def delete_article(self, user_id: str, article_id: str) -> str:
+    def delete_article(
+        self, user_id: str, article_id: str, idempotency_key: str | None = None,
+    ) -> str:
         with self._workspace_lock.acquire():
+            if idempotency_key and self._con.execute(
+                """SELECT 1 FROM article_mutation_requests
+                   WHERE user_id=? AND article_id=? AND action='delete'
+                     AND idempotency_key=?""",
+                (user_id, article_id, idempotency_key),
+            ).fetchone():
+                return "deleted"
             article = self._con.execute(
                 "SELECT id FROM articles WHERE id=? AND user_id=?",
                 (article_id, user_id),
@@ -861,6 +934,13 @@ class SQLiteStore(
             self._con.execute(
                 "DELETE FROM articles WHERE id=? AND user_id=?", (article_id, user_id),
             )
+            if idempotency_key:
+                self._con.execute(
+                    """INSERT INTO article_mutation_requests
+                       (user_id, article_id, action, idempotency_key, created_at)
+                       VALUES (?,?,'delete',?,?)""",
+                    (user_id, article_id, idempotency_key, _ts(_now())),
+                )
             self._con.commit()
             blob_dir = self._blobs_dir / "articles" / article_id
             if blob_dir.exists():
@@ -869,13 +949,18 @@ class SQLiteStore(
 
     def find_article_by_canonical_url(self, user_id: str, canonical_url: str) -> dict | None:
         url = canonical_url.strip().lower()
-        row = self._con.execute("SELECT * FROM articles WHERE LOWER(TRIM(canonical_url))=? AND user_id=?",
+        row = self._con.execute("""SELECT * FROM articles
+                                   WHERE LOWER(TRIM(canonical_url))=? AND user_id=?
+                                     AND archived_at IS NULL""",
                                 (url, user_id)).fetchone()
         return self._load_article(row) if row else None
 
     def find_article_by_title(self, user_id: str, title: str) -> dict | None:
         needle = " ".join(title.strip().lower().split())
-        rows = self._con.execute("SELECT * FROM articles WHERE user_id=?", (user_id,)).fetchall()
+        rows = self._con.execute(
+            "SELECT * FROM articles WHERE user_id=? AND archived_at IS NULL",
+            (user_id,),
+        ).fetchall()
         for row in rows:
             hay = " ".join(row["title"].strip().lower().split())
             if hay == needle:

--- a/backend/store/backends/sqlite.py
+++ b/backend/store/backends/sqlite.py
@@ -435,7 +435,7 @@ class SQLiteStore(
     ) -> tuple[list[dict], int]:
         params: list = []
         joins = ""
-        wheres: list[str] = ["a.user_id=?"]
+        wheres: list[str] = ["a.user_id=?", "a.archived_at IS NULL"]
         params.append(user_id)
 
         if status and platform:
@@ -777,6 +777,95 @@ class SQLiteStore(
                         shutil.rmtree(blob_dir)
             self._con.commit()
             return blocked
+
+    def duplicate_article(
+        self, user_id: str, article_id: str, idempotency_key: str,
+    ) -> tuple[dict | None, bool]:
+        with self._workspace_lock.acquire():
+            existing = self._con.execute(
+                """SELECT duplicate_article_id FROM article_duplicate_requests
+                   WHERE user_id=? AND source_article_id=? AND idempotency_key=?""",
+                (user_id, article_id, idempotency_key),
+            ).fetchone()
+            if existing is not None:
+                duplicate = self.get_article(user_id, existing["duplicate_article_id"])
+                return duplicate, False
+
+            source = self._con.execute(
+                "SELECT * FROM articles WHERE id=? AND user_id=? AND archived_at IS NULL",
+                (article_id, user_id),
+            ).fetchone()
+            if source is None:
+                return None, False
+
+            duplicate_id = f"art_{uuid.uuid4().hex[:8]}"
+            title = f"Copy of {source['title']}"
+            body = self._read_body(source)
+            now_s = _ts(_now())
+            body_path = self._write_body(duplicate_id, body)
+            self._con.execute(
+                """INSERT INTO articles
+                   (id, title, body, body_path, word_count, gate, source, source_platform,
+                    canonical_url, archived_at, created_at, updated_at, user_id)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                (duplicate_id, title, "", body_path, source["word_count"], "pending", "native",
+                 None, None, None, now_s, now_s, user_id),
+            )
+            for platform in _PLATFORMS:
+                self._con.execute(
+                    """INSERT INTO article_destinations
+                       (article_id, platform, status, label) VALUES (?,?,?,?)""",
+                    (duplicate_id, platform, "none", "—"),
+                )
+            self._add_timeline(duplicate_id, f"Duplicated from {source['title']}")
+            self._insert_article_revision(
+                duplicate_id, 1, title, body, source="user",
+                description="Article duplicated", created_by=user_id, created_at=now_s,
+            )
+            self._con.execute(
+                """INSERT INTO article_duplicate_requests
+                   (user_id, source_article_id, idempotency_key, duplicate_article_id, created_at)
+                   VALUES (?,?,?,?,?)""",
+                (user_id, article_id, idempotency_key, duplicate_id, now_s),
+            )
+            self._con.commit()
+            return self.get_article(user_id, duplicate_id), True
+
+    def archive_article(self, user_id: str, article_id: str) -> bool:
+        with self._workspace_lock.acquire():
+            cursor = self._con.execute(
+                """UPDATE articles SET archived_at=?, updated_at=?
+                   WHERE id=? AND user_id=? AND archived_at IS NULL""",
+                (_ts(_now()), _ts(_now()), article_id, user_id),
+            )
+            if cursor.rowcount:
+                self._add_timeline(article_id, "Article archived")
+            self._con.commit()
+            return bool(cursor.rowcount)
+
+    def delete_article(self, user_id: str, article_id: str) -> str:
+        with self._workspace_lock.acquire():
+            article = self._con.execute(
+                "SELECT id FROM articles WHERE id=? AND user_id=?",
+                (article_id, user_id),
+            ).fetchone()
+            if article is None:
+                return "not_found"
+            published = self._con.execute(
+                """SELECT 1 FROM article_destinations
+                   WHERE article_id=? AND status='published'""",
+                (article_id,),
+            ).fetchone()
+            if published is not None:
+                return "published"
+            self._con.execute(
+                "DELETE FROM articles WHERE id=? AND user_id=?", (article_id, user_id),
+            )
+            self._con.commit()
+            blob_dir = self._blobs_dir / "articles" / article_id
+            if blob_dir.exists():
+                shutil.rmtree(blob_dir)
+            return "deleted"
 
     def find_article_by_canonical_url(self, user_id: str, canonical_url: str) -> dict | None:
         url = canonical_url.strip().lower()

--- a/backend/store/base.py
+++ b/backend/store/base.py
@@ -138,10 +138,14 @@ class ArticleStore(Protocol):
     ) -> tuple[dict | None, bool]:
         ...
 
-    def archive_article(self, user_id: str, article_id: str) -> bool:
+    def archive_article(
+        self, user_id: str, article_id: str, idempotency_key: str | None = None,
+    ) -> bool:
         ...
 
-    def delete_article(self, user_id: str, article_id: str) -> str:
+    def delete_article(
+        self, user_id: str, article_id: str, idempotency_key: str | None = None,
+    ) -> str:
         ...
 
     def find_article_by_canonical_url(self, canonical_url: str) -> dict | None:

--- a/backend/store/base.py
+++ b/backend/store/base.py
@@ -133,6 +133,17 @@ class ArticleStore(Protocol):
     def delete_articles(self, user_id: str, ids: list[str], force: bool = False) -> list[str]:
         ...
 
+    def duplicate_article(
+        self, user_id: str, article_id: str, idempotency_key: str,
+    ) -> tuple[dict | None, bool]:
+        ...
+
+    def archive_article(self, user_id: str, article_id: str) -> bool:
+        ...
+
+    def delete_article(self, user_id: str, article_id: str) -> str:
+        ...
+
     def find_article_by_canonical_url(self, canonical_url: str) -> dict | None:
         ...
 

--- a/backend/store/schema.py
+++ b/backend/store/schema.py
@@ -10,7 +10,7 @@ SEED_USER_HASH = "$2b$12$BJsbJlf3SZUMUISLA8oASeFn.Q3U.Ar6TqoIFtu0F9OlYyev.DZLC"
 
 # Bump for every released schema shape. Idempotent additions migrate in place;
 # destructive changes require an explicit migration and recovery plan.
-SCHEMA_VERSION = 11
+SCHEMA_VERSION = 12
 
 _SCHEMA_SQL_PATH = Path(__file__).resolve().parent / "sql" / "schema.sql"
 

--- a/backend/store/schema.py
+++ b/backend/store/schema.py
@@ -10,7 +10,7 @@ SEED_USER_HASH = "$2b$12$BJsbJlf3SZUMUISLA8oASeFn.Q3U.Ar6TqoIFtu0F9OlYyev.DZLC"
 
 # Bump for every released schema shape. Idempotent additions migrate in place;
 # destructive changes require an explicit migration and recovery plan.
-SCHEMA_VERSION = 10
+SCHEMA_VERSION = 11
 
 _SCHEMA_SQL_PATH = Path(__file__).resolve().parent / "sql" / "schema.sql"
 
@@ -70,6 +70,11 @@ def apply_schema(connection: sqlite3.Connection) -> None:
         _upgrade_jobs(
             connection, normalize_legacy_statuses=previous_version < SCHEMA_VERSION,
         )
+    articles_exists = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='articles'"
+    ).fetchone()
+    if articles_exists:
+        _add_column(connection, "articles", "archived_at", "TEXT")
     connection.executescript(_SCHEMA_SQL_PATH.read_text(encoding="utf-8"))
     _upgrade_jobs(connection)
     connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")

--- a/backend/store/sql/schema.sql
+++ b/backend/store/sql/schema.sql
@@ -30,6 +30,7 @@ CREATE TABLE IF NOT EXISTS articles (
     source          TEXT NOT NULL DEFAULT 'native',
     source_platform TEXT,
     canonical_url   TEXT,
+    archived_at     TEXT,
     created_at      TEXT NOT NULL,
     updated_at      TEXT NOT NULL,
     user_id         TEXT REFERENCES users(id) ON DELETE CASCADE
@@ -37,6 +38,18 @@ CREATE TABLE IF NOT EXISTS articles (
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_articles_id_user
     ON articles(id, user_id);
+
+CREATE INDEX IF NOT EXISTS idx_articles_user_archived
+    ON articles(user_id, archived_at);
+
+CREATE TABLE IF NOT EXISTS article_duplicate_requests (
+    user_id             TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    source_article_id   TEXT NOT NULL,
+    idempotency_key     TEXT NOT NULL,
+    duplicate_article_id TEXT NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
+    created_at          TEXT NOT NULL,
+    PRIMARY KEY (user_id, source_article_id, idempotency_key)
+);
 
 CREATE TABLE IF NOT EXISTS article_destinations (
     article_id  TEXT NOT NULL REFERENCES articles(id) ON DELETE CASCADE,

--- a/backend/store/sql/schema.sql
+++ b/backend/store/sql/schema.sql
@@ -51,6 +51,15 @@ CREATE TABLE IF NOT EXISTS article_duplicate_requests (
     PRIMARY KEY (user_id, source_article_id, idempotency_key)
 );
 
+CREATE TABLE IF NOT EXISTS article_mutation_requests (
+    user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    article_id      TEXT NOT NULL,
+    action          TEXT NOT NULL CHECK (action IN ('archive', 'delete')),
+    idempotency_key TEXT NOT NULL,
+    created_at      TEXT NOT NULL,
+    PRIMARY KEY (user_id, article_id, action, idempotency_key)
+);
+
 CREATE TABLE IF NOT EXISTS article_destinations (
     article_id  TEXT NOT NULL REFERENCES articles(id) ON DELETE CASCADE,
     platform    TEXT NOT NULL,

--- a/screens/overview/overview-card-actions.css
+++ b/screens/overview/overview-card-actions.css
@@ -1,0 +1,84 @@
+.ctx-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 50;
+  min-width: 190px;
+  padding: 4px;
+  border: 1px solid #3a3f52;
+  border-radius: 6px;
+  background: #1e2335;
+  box-shadow: 0 8px 24px #00000060;
+}
+
+.ctx-item {
+  display: block;
+  width: 100%;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: 4px;
+  color: #c9cfe0;
+  background: transparent;
+  cursor: pointer;
+  font: 12px Inter, sans-serif;
+  text-align: left;
+}
+
+.ctx-item:hover { background: #252a38; }
+.ctx-item.danger { color: #f87171; }
+.ctx-item.danger:hover { background: #2d1a1a; }
+.ctx-item:disabled { cursor: default; opacity: 0.55; }
+.ctx-item:focus-visible,
+.card-context-trigger:focus-visible,
+.card-gate:focus-visible { outline: 2px solid #6366f1; outline-offset: 2px; }
+
+.card-state-controls { display: flex; align-items: center; gap: 7px; margin-left: auto; }
+.card-gate {
+  min-width: 66px;
+  height: 27px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 5px;
+  background: #181c27;
+  font: 600 10px/1 Inter, sans-serif;
+  letter-spacing: 0;
+}
+
+button.card-gate { cursor: pointer; }
+.card-gate[data-state="pass"] { color: #86efac; border: 1px solid #22c55e; background: #173127; }
+.card-gate[data-state="warn"] { color: #fde68a; border: 1px solid #fbbf24; background: #302a17; }
+.card-gate[data-state="fail"] { color: #fca5a5; border: 1px solid #ef4444; background: #302027; }
+.card-gate[data-state="pending"] { color: #8991aa; border: 1px solid #5a6080; background: #181c27; }
+
+.card-context { position: relative; }
+.card-context-trigger {
+  width: 34px;
+  height: 28px;
+  border: 1px solid #252a38;
+  border-radius: 5px;
+  color: #c9cfe0;
+  background: #181c27;
+  cursor: pointer;
+  font: 600 14px/1 Inter, sans-serif;
+}
+
+.card-context-trigger:hover { border-color: #3a3f52; color: #e8eaf2; }
+.card-delete-confirmation { width: 285px; padding: 12px; }
+.card-delete-confirmation strong,
+.card-mutation-message strong { display: block; color: #e8eaf2; font-size: 13px; }
+.card-delete-confirmation > span,
+.card-mutation-message > span {
+  display: block;
+  margin-top: 5px;
+  color: #8991aa;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.card-confirm-actions { display: flex; justify-content: flex-end; gap: 6px; margin-top: 10px; }
+.card-confirm-actions .ctx-item { width: auto; border: 1px solid #3a3f52; }
+.card-confirm-actions .danger { border-color: #ef4444; background: #ef4444; color: #fff; }
+.card-mutation-message { width: 285px; padding: 12px; color: #c9cfe0; font-size: 12px; }
+.card-mutation-message.error { border-color: #ef4444; background: #302027; }
+.card-mutation-message.error > span { color: #fca5a5; }

--- a/screens/overview/overview-card-actions.js
+++ b/screens/overview/overview-card-actions.js
@@ -187,7 +187,7 @@
       this.showPending(article, action, context);
 
       try {
-        const headers = action === 'duplicate' ? { 'Idempotency-Key': idempotencyKey } : {};
+        const headers = { 'Idempotency-Key': idempotencyKey };
         const response = await fetch(
           `/api/articles/${encodeURIComponent(article.id)}/${action === 'delete' ? '' : action}`.replace(/\/$/, ''),
           { method: action === 'delete' ? 'DELETE' : 'POST', headers },

--- a/screens/overview/overview-card-actions.js
+++ b/screens/overview/overview-card-actions.js
@@ -1,0 +1,274 @@
+(function () {
+  'use strict';
+
+  function requestKey(action, articleId) {
+    if (globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function') {
+      return `${action}:${articleId}:${globalThis.crypto.randomUUID()}`;
+    }
+    return `${action}:${articleId}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
+  }
+
+  async function responseError(response) {
+    let payload = null;
+    try {
+      payload = await response.json();
+    } catch (_error) {
+      return { status: response.status, message: `Request failed (${response.status}).` };
+    }
+    const detail = payload.detail || payload;
+    return {
+      status: response.status,
+      code: detail.error || detail.code || null,
+      message: detail.message || (typeof detail === 'string' ? detail : `Request failed (${response.status}).`),
+    };
+  }
+
+  class OverviewCardActions {
+    constructor(options) {
+      this.options = options;
+      this.open = null;
+      this.errors = new Map();
+      this.pending = new Set();
+      this.keys = new Map();
+      this.handlePointerDown = this.handlePointerDown.bind(this);
+      this.handleKeyDown = this.handleKeyDown.bind(this);
+      document.addEventListener('pointerdown', this.handlePointerDown);
+      document.addEventListener('keydown', this.handleKeyDown);
+    }
+
+    mount(card, article, tabs) {
+      const controls = document.createElement('div');
+      controls.className = 'card-state-controls';
+
+      controls.appendChild(this.createGate(article));
+
+      const context = document.createElement('div');
+      context.className = 'card-context';
+      const trigger = document.createElement('button');
+      trigger.type = 'button';
+      trigger.className = 'card-context-trigger';
+      trigger.setAttribute('aria-label', `Actions for ${article.title}`);
+      trigger.setAttribute('aria-haspopup', 'menu');
+      trigger.setAttribute('aria-expanded', 'false');
+      trigger.textContent = '...';
+      trigger.addEventListener('click', event => {
+        event.stopPropagation();
+        this.toggle(article, context, trigger);
+      });
+      context.appendChild(trigger);
+      controls.appendChild(context);
+      tabs.appendChild(controls);
+
+      const savedError = this.errors.get(article.id);
+      if (savedError) this.showError(article, context, trigger, savedError);
+
+      card.addEventListener('click', event => {
+        if (event.target.closest('.card-state-controls')) event.stopPropagation();
+      });
+    }
+
+    createGate(article) {
+      const result = ['pass', 'warn', 'fail'].includes(article.gate) ? article.gate : 'pending';
+      const interactive = result !== 'pending';
+      const gate = document.createElement(interactive ? 'button' : 'span');
+      gate.className = 'card-gate';
+      gate.dataset.state = result;
+      gate.textContent = result.toUpperCase();
+      if (!interactive) {
+        gate.setAttribute('aria-label', 'Inspection pending');
+        return gate;
+      }
+      gate.type = 'button';
+      gate.setAttribute('aria-label', `${result} inspection report for ${article.title}`);
+      gate.addEventListener('click', event => {
+        event.stopPropagation();
+        this.options.onInspect(article.id);
+      });
+      return gate;
+    }
+
+    toggle(article, context, trigger) {
+      if (this.open && this.open.articleId === article.id) {
+        if (!this.open.persistent) {
+          this.close(true);
+          return;
+        }
+        this.removePopover(this.open.context);
+        this.open = null;
+      }
+      this.close(false);
+      this.errors.delete(article.id);
+      this.open = { articleId: article.id, context, trigger };
+      trigger.setAttribute('aria-expanded', 'true');
+      this.showMenu(article, context, trigger);
+    }
+
+    showMenu(article, context, trigger) {
+      this.removePopover(context);
+      const menu = document.createElement('div');
+      menu.className = 'ctx-menu';
+      menu.setAttribute('role', 'menu');
+      menu.setAttribute('aria-label', `Actions for ${article.title}`);
+      [
+        ['Edit', 'edit'],
+        ['Duplicate', 'duplicate'],
+        ['Archive', 'archive'],
+        ['Delete', 'delete'],
+      ].forEach(([label, action]) => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = `ctx-item${action === 'delete' ? ' danger' : ''}`;
+        button.dataset.action = action;
+        button.setAttribute('role', 'menuitem');
+        button.textContent = label;
+        button.disabled = this.pending.has(article.id);
+        button.addEventListener('click', event => {
+          event.stopPropagation();
+          if (action === 'edit') {
+            this.options.onEdit(article.id);
+            return;
+          }
+          if (action === 'delete') {
+            this.showDeleteConfirmation(article, context, trigger);
+            return;
+          }
+          void this.mutate(article, action, context, trigger);
+        });
+        menu.appendChild(button);
+      });
+      context.appendChild(menu);
+      const items = Array.from(menu.querySelectorAll('.ctx-item'));
+      menu.addEventListener('keydown', event => {
+        const current = items.indexOf(document.activeElement);
+        let next = null;
+        if (event.key === 'ArrowDown') next = (current + 1) % items.length;
+        if (event.key === 'ArrowUp') next = (current - 1 + items.length) % items.length;
+        if (event.key === 'Home') next = 0;
+        if (event.key === 'End') next = items.length - 1;
+        if (next === null) return;
+        event.preventDefault();
+        items[next].focus();
+      });
+      items[0].focus();
+    }
+
+    showDeleteConfirmation(article, context, trigger) {
+      this.removePopover(context);
+      const confirmation = document.createElement('div');
+      confirmation.className = 'ctx-menu card-delete-confirmation';
+      confirmation.setAttribute('role', 'group');
+      confirmation.setAttribute('aria-label', `Delete ${article.title}`);
+      confirmation.innerHTML = `
+        <strong>Delete this article?</strong>
+        <span>Published copies are not removed.</span>
+        <div class="card-confirm-actions">
+          <button type="button" class="ctx-item card-delete-cancel">Cancel</button>
+          <button type="button" class="ctx-item danger card-delete-confirm">Delete</button>
+        </div>`;
+      confirmation.querySelector('.card-delete-cancel').addEventListener('click', event => {
+        event.stopPropagation();
+        this.showMenu(article, context, trigger);
+      });
+      confirmation.querySelector('.card-delete-confirm').addEventListener('click', event => {
+        event.stopPropagation();
+        void this.mutate(article, 'delete', context, trigger);
+      });
+      context.appendChild(confirmation);
+      confirmation.querySelector('.card-delete-cancel').focus();
+    }
+
+    async mutate(article, action, context, trigger) {
+      if (this.pending.has(article.id)) return;
+      this.pending.add(article.id);
+      this.errors.delete(article.id);
+      const keyName = `${article.id}:${action}`;
+      const idempotencyKey = this.keys.get(keyName) || requestKey(action, article.id);
+      this.keys.set(keyName, idempotencyKey);
+      this.showPending(article, action, context);
+
+      try {
+        const headers = action === 'duplicate' ? { 'Idempotency-Key': idempotencyKey } : {};
+        const response = await fetch(
+          `/api/articles/${encodeURIComponent(article.id)}/${action === 'delete' ? '' : action}`.replace(/\/$/, ''),
+          { method: action === 'delete' ? 'DELETE' : 'POST', headers },
+        );
+        if (!response.ok) throw await responseError(response);
+        let payload = null;
+        if (response.status !== 204) payload = await response.json();
+        this.keys.delete(keyName);
+        this.close(false);
+        await this.options.onSuccess(action, article.id, payload);
+      } catch (error) {
+        const normalized = error && typeof error.status === 'number'
+          ? error
+          : { status: 0, message: error.message || 'The action could not be completed.' };
+        this.errors.set(article.id, normalized);
+        this.showError(article, context, trigger, normalized);
+      } finally {
+        this.pending.delete(article.id);
+      }
+    }
+
+    showPending(article, action, context) {
+      this.removePopover(context);
+      const status = document.createElement('div');
+      status.className = 'ctx-menu card-mutation-message';
+      status.setAttribute('role', 'status');
+      status.textContent = `${action[0].toUpperCase()}${action.slice(1)} in progress...`;
+      context.appendChild(status);
+    }
+
+    showError(article, context, trigger, error) {
+      this.removePopover(context);
+      const panel = document.createElement('div');
+      panel.className = 'ctx-menu card-mutation-message error';
+      panel.setAttribute('role', 'alert');
+      const title = error.status === 404
+        ? 'Article not found'
+        : error.status === 409
+          ? 'Cannot delete published article'
+          : 'Action failed';
+      panel.innerHTML = '<strong></strong><span></span>';
+      panel.querySelector('strong').textContent = title;
+      panel.querySelector('span').textContent = error.message;
+      context.appendChild(panel);
+      trigger.setAttribute('aria-expanded', 'true');
+      this.open = { articleId: article.id, context, trigger, persistent: true };
+    }
+
+    removePopover(context) {
+      context.querySelectorAll('.ctx-menu').forEach(element => element.remove());
+    }
+
+    close(restoreFocus) {
+      if (!this.open) return;
+      const { context, trigger, persistent } = this.open;
+      if (!persistent) this.removePopover(context);
+      trigger.setAttribute('aria-expanded', persistent ? 'true' : 'false');
+      this.open = persistent ? this.open : null;
+      if (restoreFocus && !persistent && trigger.isConnected) trigger.focus();
+    }
+
+    handlePointerDown(event) {
+      if (!this.open || this.open.persistent || this.open.context.contains(event.target)) return;
+      this.close(false);
+    }
+
+    handleKeyDown(event) {
+      if (event.key !== 'Escape' || !this.open || this.open.persistent) return;
+      event.preventDefault();
+      this.close(true);
+    }
+
+    clearErrors() {
+      this.errors.clear();
+      if (this.open && this.open.persistent) {
+        this.removePopover(this.open.context);
+        this.open.trigger.setAttribute('aria-expanded', 'false');
+        this.open = null;
+      }
+    }
+  }
+
+  globalThis.OverviewCardActions = OverviewCardActions;
+})();

--- a/screens/overview/v3.html
+++ b/screens/overview/v3.html
@@ -28,6 +28,7 @@
     }
   </script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link href="./overview-card-actions.css" rel="stylesheet" />
   <style>
     * { box-sizing: border-box; }
     body { background: #0f1117; color: #c9cfe0; margin: 0; }
@@ -125,23 +126,6 @@
     ::-webkit-scrollbar { width: 5px; }
     ::-webkit-scrollbar-track { background: transparent; }
     ::-webkit-scrollbar-thumb { background: #252a38; border-radius: 3px; }
-
-    /* Context menu */
-    .ctx-menu {
-      position: absolute; top: 100%; right: 0;
-      background: #1e2335; border: 1px solid #3a3f52;
-      border-radius: 6px; padding: 4px; z-index: 50;
-      min-width: 140px; box-shadow: 0 8px 24px #00000060;
-    }
-    .ctx-item {
-      display: block; width: 100%; text-align: left;
-      padding: 6px 10px; font-size: 12px; border-radius: 4px;
-      color: #c9cfe0; background: transparent; border: none;
-      cursor: pointer; font-family: inherit;
-    }
-    .ctx-item:hover { background: #252a38; }
-    .ctx-item.danger { color: #f87171; }
-    .ctx-item.danger:hover { background: #2d1a1a; }
 
     /* Platform tab in preview pane */
     .plat-tab {
@@ -567,6 +551,7 @@
   </div>
 </div>
 
+<script src="./overview-card-actions.js"></script>
 <script>
 // --- Data ----------------------------------------------------------
 let ARTICLES = [];
@@ -620,7 +605,6 @@ let statusFilter   = 'all';
 let platformFilter = new Set();
 let showSkeleton   = false;
 let showEmpty      = false;
-let openMenuId     = null;
 let detailsPanelOpen = true;
 // Per-card active preview platform: Map<articleId, 'medium'|'hashnode'|'devto'>
 const activePreview = new Map();
@@ -723,6 +707,28 @@ async function fetchJson(url, options = {}) {
   }
   return response.json();
 }
+
+const cardActions = new OverviewCardActions({
+  onEdit(articleId) {
+    window.location.href = `../editor/v2.html?id=${encodeURIComponent(articleId)}`;
+  },
+  onInspect(articleId) {
+    window.location.href = `../inspection/v1.html?id=${encodeURIComponent(articleId)}`;
+  },
+  async onSuccess(action, articleId, payload) {
+    cardActions.clearErrors();
+    if (action === 'duplicate') {
+      await loadOverview();
+      selectedId = null;
+      render();
+      selectCard(payload.article.id);
+      return;
+    }
+    if (selectedId === articleId) selectedId = null;
+    await loadOverview();
+    render();
+  },
+});
 
 function articlesPageUrl(page) {
   return `/api/articles?sortBy=updatedAt&sortDir=desc&page=${page}&pageSize=${PAGE_SIZE}`;
@@ -1092,6 +1098,7 @@ function renderCard(a) {
     };
     tabs.appendChild(tab);
   });
+  cardActions.mount(card, a, tabs);
   card.appendChild(tabs);
 
   const media = document.createElement('div');
@@ -1308,7 +1315,7 @@ function syncDetailsPanel() {
 
 // --- Interactions --------------------------------------------------
 function selectCard(id) {
-  closeMenus();
+  cardActions.close(false);
   if (id === selectedId) {
     detailsPanelOpen = !detailsPanelOpen;
     syncDetailsPanel();
@@ -1410,26 +1417,6 @@ function setView(v) {
   });
   const el = document.getElementById('nav-' + v);
   if (el) { el.style.borderBottomColor = '#6366f1'; el.style.color = '#e8eaf2'; el.style.fontWeight = '500'; }
-}
-
-function toggleMenu(id, wrap) {
-  if (openMenuId === id) { closeMenus(); return; }
-  closeMenus();
-  openMenuId = id;
-  const menu = document.createElement('div');
-  menu.className = 'ctx-menu';
-  menu.innerHTML = `
-    <button class="ctx-item" onclick="alert('Edit ${id}');closeMenus()">Edit</button>
-    <button class="ctx-item" onclick="alert('Duplicate ${id}');closeMenus()">Duplicate</button>
-    <button class="ctx-item" onclick="alert('Archive ${id}');closeMenus()">Archive</button>
-    <button class="ctx-item danger" onclick="alert('Delete ${id}');closeMenus()">Delete</button>`;
-  wrap.appendChild(menu);
-  setTimeout(() => document.addEventListener('click', closeMenus, { once: true }), 0);
-}
-
-function closeMenus() {
-  document.querySelectorAll('.ctx-menu').forEach(m => m.remove());
-  openMenuId = null;
 }
 
 showSkeleton = true;

--- a/tests/overview-v3.spec.js
+++ b/tests/overview-v3.spec.js
@@ -90,13 +90,20 @@ test.describe('Current overview screen', () => {
     await expect(copies).toHaveClass(/selected/);
   });
 
-  test('Archive removes the article from active results while retaining it in storage', async ({ page }) => {
+  test('Archive removes the article from active results and active APIs', async ({ page }) => {
+    let idempotencyKey = null;
+    page.on('request', request => {
+      if (request.url().endsWith('/api/articles/art_004/archive')) {
+        idempotencyKey = request.headers()['idempotency-key'];
+      }
+    });
     await page.locator('.article-card[data-id="art_004"] .card-context-trigger').click();
     await page.getByRole('menuitem', { name: 'Archive' }).click();
 
     await expect(page.locator('.article-card[data-id="art_004"]')).toHaveCount(0);
     const retained = await page.request.get('/api/articles/art_004');
-    expect(retained.ok()).toBeTruthy();
+    expect(retained.status()).toBe(404);
+    expect(idempotencyKey).toBeTruthy();
   });
 
   test('Delete uses inline confirmation and Cancel sends no request', async ({ page }) => {
@@ -116,12 +123,19 @@ test.describe('Current overview screen', () => {
   });
 
   test('confirmed Delete removes an unpublished article', async ({ page }) => {
+    let idempotencyKey = null;
+    page.on('request', request => {
+      if (request.method() === 'DELETE' && request.url().endsWith('/api/articles/art_004')) {
+        idempotencyKey = request.headers()['idempotency-key'];
+      }
+    });
     await page.locator('.article-card[data-id="art_004"] .card-context-trigger').click();
     await page.getByRole('menuitem', { name: 'Delete' }).click();
     await page.locator('.card-delete-confirm').click();
 
     await expect(page.locator('.article-card[data-id="art_004"]')).toHaveCount(0);
     expect((await page.request.get('/api/articles/art_004')).status()).toBe(404);
+    expect(idempotencyKey).toBeTruthy();
   });
 
   test('published delete conflict remains inline and preserves the article', async ({ page }) => {

--- a/tests/overview-v3.spec.js
+++ b/tests/overview-v3.spec.js
@@ -33,4 +33,119 @@ test.describe('Current overview screen', () => {
     await page.locator('.article-card').first().locator('.card-edit').click();
     await expect(page).toHaveURL(/\/screens\/editor\/v2\.html\?id=/);
   });
+
+  test('renders all gate states and keeps Pending passive', async ({ page }) => {
+    await expect(page.locator('.card-gate[data-state="pass"]')).toHaveCount(3);
+    await expect(page.locator('.card-gate[data-state="warn"]')).toHaveCount(1);
+    await expect(page.locator('.card-gate[data-state="fail"]')).toHaveCount(1);
+    const pending = page.locator('.card-gate[data-state="pending"]');
+    await expect(pending).toHaveCount(1);
+    await expect(pending).toHaveText('PENDING');
+    await expect(pending).not.toHaveAttribute('role', 'button');
+  });
+
+  test('gate keyboard activation opens Inspection without selecting the card', async ({ page }) => {
+    const card = page.locator('.article-card[data-id="art_001"]');
+    await card.locator('.card-gate').press('Enter');
+
+    await expect(page).toHaveURL(/\/screens\/inspection\/v1\.html\?id=art_001$/);
+  });
+
+  test('context menu supports keyboard open, Escape, and focus restoration', async ({ page }) => {
+    const trigger = page.locator('.article-card[data-id="art_001"] .card-context-trigger');
+    await trigger.focus();
+    await trigger.press('Enter');
+    await expect(page.getByRole('menu')).toBeVisible();
+    await expect(page.getByRole('menuitem')).toHaveCount(4);
+    await page.keyboard.press('ArrowDown');
+    await expect(page.getByRole('menuitem', { name: 'Duplicate' })).toBeFocused();
+
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('menu')).toHaveCount(0);
+    await expect(trigger).toBeFocused();
+  });
+
+  test('outside click closes the context menu', async ({ page }) => {
+    const trigger = page.locator('.article-card[data-id="art_001"] .card-context-trigger');
+    await trigger.click();
+    await expect(page.getByRole('menu')).toBeVisible();
+
+    await page.locator('#article-count').click();
+    await expect(page.getByRole('menu')).toHaveCount(0);
+  });
+
+  test('context Edit opens the correct article', async ({ page }) => {
+    await page.locator('.article-card[data-id="art_002"] .card-context-trigger').click();
+    await page.getByRole('menuitem', { name: 'Edit' }).click();
+
+    await expect(page).toHaveURL(/\/screens\/editor\/v2\.html\?id=art_002$/);
+  });
+
+  test('Duplicate creates and selects exactly one copy', async ({ page }) => {
+    await page.locator('.article-card[data-id="art_001"] .card-context-trigger').click();
+    await page.getByRole('menuitem', { name: 'Duplicate' }).click();
+
+    const copies = page.locator('.article-card', { hasText: 'Copy of Building a Vector DB' });
+    await expect(copies).toHaveCount(1);
+    await expect(copies).toHaveClass(/selected/);
+  });
+
+  test('Archive removes the article from active results while retaining it in storage', async ({ page }) => {
+    await page.locator('.article-card[data-id="art_004"] .card-context-trigger').click();
+    await page.getByRole('menuitem', { name: 'Archive' }).click();
+
+    await expect(page.locator('.article-card[data-id="art_004"]')).toHaveCount(0);
+    const retained = await page.request.get('/api/articles/art_004');
+    expect(retained.ok()).toBeTruthy();
+  });
+
+  test('Delete uses inline confirmation and Cancel sends no request', async ({ page }) => {
+    let deleteRequests = 0;
+    page.on('request', request => {
+      if (request.method() === 'DELETE' && request.url().endsWith('/api/articles/art_004')) {
+        deleteRequests += 1;
+      }
+    });
+    await page.locator('.article-card[data-id="art_004"] .card-context-trigger').click();
+    await page.getByRole('menuitem', { name: 'Delete' }).click();
+    await expect(page.getByRole('group', { name: /Delete Graph Neural Networks/ })).toBeVisible();
+
+    await page.locator('.card-delete-cancel').click();
+    await expect(page.getByRole('menu')).toBeVisible();
+    expect(deleteRequests).toBe(0);
+  });
+
+  test('confirmed Delete removes an unpublished article', async ({ page }) => {
+    await page.locator('.article-card[data-id="art_004"] .card-context-trigger').click();
+    await page.getByRole('menuitem', { name: 'Delete' }).click();
+    await page.locator('.card-delete-confirm').click();
+
+    await expect(page.locator('.article-card[data-id="art_004"]')).toHaveCount(0);
+    expect((await page.request.get('/api/articles/art_004')).status()).toBe(404);
+  });
+
+  test('published delete conflict remains inline and preserves the article', async ({ page }) => {
+    const card = page.locator('.article-card[data-id="art_003"]');
+    await card.locator('.card-context-trigger').click();
+    await page.getByRole('menuitem', { name: 'Delete' }).click();
+    await page.locator('.card-delete-confirm').click();
+
+    await expect(card.getByRole('alert')).toContainText('Cannot delete published article');
+    await expect(card).toBeVisible();
+    await page.locator('#article-count').click();
+    await expect(card.getByRole('alert')).toBeVisible();
+  });
+
+  test('mutation 404 remains inline on the affected card', async ({ page }) => {
+    await page.route('**/api/articles/art_002/duplicate', route => route.fulfill({
+      status: 404,
+      contentType: 'application/json',
+      body: JSON.stringify({ detail: { error: 'not_found', message: 'Article not found.' } }),
+    }));
+    const card = page.locator('.article-card[data-id="art_002"]');
+    await card.locator('.card-context-trigger').click();
+    await page.getByRole('menuitem', { name: 'Duplicate' }).click();
+
+    await expect(card.getByRole('alert')).toContainText('Article not found');
+  });
 });

--- a/tests/tests_backend/test_article_context_actions.py
+++ b/tests/tests_backend/test_article_context_actions.py
@@ -7,6 +7,13 @@ import backend.store as store
 
 def test_duplicate_is_idempotent_and_creates_an_independent_draft(client: TestClient):
     original = client.get("/api/articles/art_001").json()
+    store.store_asset(
+        store._backend.SEED_USER_ID,
+        "art_001",
+        "diagram.png",
+        b"duplicate-me",
+        "image/png",
+    )
     headers = {"Idempotency-Key": "duplicate-art-001-once"}
 
     first = client.post("/api/articles/art_001/duplicate", headers=headers)
@@ -21,7 +28,15 @@ def test_duplicate_is_idempotent_and_creates_an_independent_draft(client: TestCl
     assert duplicate["content"] == original["content"]
     assert duplicate["word_count"] == original["word_count"]
     assert duplicate["gate"] == "pending"
+    assert duplicate["preview_image_url"].startswith(
+        f"/api/articles/{duplicate_id}/assets/"
+    )
     assert all(item["status"] == "none" for item in duplicate["destinations"].values())
+    copied_asset = client.get(
+        f"/api/articles/{duplicate_id}/assets/by-filename/diagram.png"
+    )
+    assert copied_asset.status_code == 200
+    assert copied_asset.content == b"duplicate-me"
     ids = [item["id"] for item in client.get("/api/articles").json()["items"]]
     assert ids.count(duplicate_id) == 1
 
@@ -42,15 +57,21 @@ def test_duplicate_unknown_article_returns_structured_404(client: TestClient):
 
 
 def test_archive_removes_article_from_active_list_but_retains_history(client: TestClient):
-    response = client.post("/api/articles/art_004/archive")
+    headers = {"Idempotency-Key": "archive-art-004"}
+    response = client.post("/api/articles/art_004/archive", headers=headers)
 
     assert response.status_code == 200
     assert response.json() == {"id": "art_004", "archived": True}
     ids = [item["id"] for item in client.get("/api/articles").json()["items"]]
     assert "art_004" not in ids
-    archived = store.get_article("user_seed", "art_004")
-    assert archived is not None
-    assert any(entry["event"] == "Article archived" for entry in archived["recent_timeline"])
+    assert client.get("/api/articles/art_004").status_code == 404
+    assert client.post("/api/articles/art_004/inspect").status_code == 404
+    assert client.post("/api/articles/art_004/push").status_code == 404
+    timeline = store._backend._con.execute(
+        "SELECT event FROM article_timeline WHERE article_id='art_004'"
+    ).fetchall()
+    assert any(row["event"] == "Article archived" for row in timeline)
+    assert client.post("/api/articles/art_004/archive", headers=headers).status_code == 200
 
 
 def test_archive_unknown_or_already_archived_article_returns_404(client: TestClient):
@@ -60,11 +81,30 @@ def test_archive_unknown_or_already_archived_article_returns_404(client: TestCli
 
 
 def test_delete_single_article_and_report_not_found(client: TestClient):
-    assert client.delete("/api/articles/art_004").status_code == 204
+    headers = {"Idempotency-Key": "delete-art-004"}
+    assert client.delete("/api/articles/art_004", headers=headers).status_code == 204
+    assert client.delete("/api/articles/art_004", headers=headers).status_code == 204
     missing = client.delete("/api/articles/art_004")
 
     assert missing.status_code == 404
     assert missing.json()["detail"]["error"] == "not_found"
+
+
+def test_archived_articles_do_not_match_import_identity_lookups(client: TestClient):
+    article = client.get("/api/articles/art_004").json()
+    store._backend._con.execute(
+        "UPDATE articles SET canonical_url=? WHERE id='art_004'",
+        ("https://example.test/archived",),
+    )
+    store._backend._con.commit()
+    assert client.post("/api/articles/art_004/archive").status_code == 200
+
+    assert store.find_article_by_canonical_url(
+        store._backend.SEED_USER_ID, "https://example.test/archived"
+    ) is None
+    assert store.find_article_by_title(
+        store._backend.SEED_USER_ID, article["title"]
+    ) is None
 
 
 def test_delete_published_article_returns_structured_conflict(client: TestClient):

--- a/tests/tests_backend/test_article_context_actions.py
+++ b/tests/tests_backend/test_article_context_actions.py
@@ -1,0 +1,75 @@
+"""Focused API coverage for Overview card context actions."""
+
+from fastapi.testclient import TestClient
+
+import backend.store as store
+
+
+def test_duplicate_is_idempotent_and_creates_an_independent_draft(client: TestClient):
+    original = client.get("/api/articles/art_001").json()
+    headers = {"Idempotency-Key": "duplicate-art-001-once"}
+
+    first = client.post("/api/articles/art_001/duplicate", headers=headers)
+    repeated = client.post("/api/articles/art_001/duplicate", headers=headers)
+
+    assert first.status_code == 201
+    assert repeated.status_code == 201
+    assert repeated.json() == first.json()
+    duplicate_id = first.json()["article"]["id"]
+    duplicate = client.get(f"/api/articles/{duplicate_id}").json()
+    assert duplicate["title"] == f"Copy of {original['title']}"
+    assert duplicate["content"] == original["content"]
+    assert duplicate["word_count"] == original["word_count"]
+    assert duplicate["gate"] == "pending"
+    assert all(item["status"] == "none" for item in duplicate["destinations"].values())
+    ids = [item["id"] for item in client.get("/api/articles").json()["items"]]
+    assert ids.count(duplicate_id) == 1
+
+
+def test_duplicate_requires_an_idempotency_key(client: TestClient):
+    response = client.post("/api/articles/art_001/duplicate")
+
+    assert response.status_code == 422
+
+
+def test_duplicate_unknown_article_returns_structured_404(client: TestClient):
+    response = client.post(
+        "/api/articles/missing/duplicate", headers={"Idempotency-Key": "missing"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["error"] == "not_found"
+
+
+def test_archive_removes_article_from_active_list_but_retains_history(client: TestClient):
+    response = client.post("/api/articles/art_004/archive")
+
+    assert response.status_code == 200
+    assert response.json() == {"id": "art_004", "archived": True}
+    ids = [item["id"] for item in client.get("/api/articles").json()["items"]]
+    assert "art_004" not in ids
+    archived = store.get_article("user_seed", "art_004")
+    assert archived is not None
+    assert any(entry["event"] == "Article archived" for entry in archived["recent_timeline"])
+
+
+def test_archive_unknown_or_already_archived_article_returns_404(client: TestClient):
+    assert client.post("/api/articles/art_004/archive").status_code == 200
+    assert client.post("/api/articles/art_004/archive").status_code == 404
+    assert client.post("/api/articles/missing/archive").status_code == 404
+
+
+def test_delete_single_article_and_report_not_found(client: TestClient):
+    assert client.delete("/api/articles/art_004").status_code == 204
+    missing = client.delete("/api/articles/art_004")
+
+    assert missing.status_code == 404
+    assert missing.json()["detail"]["error"] == "not_found"
+
+
+def test_delete_published_article_returns_structured_conflict(client: TestClient):
+    response = client.delete("/api/articles/art_003")
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["error"] == "has_published_destinations"
+    assert client.get("/api/articles/art_003").status_code == 200


### PR DESCRIPTION
## Summary
- render authoritative Pass, Warn, Fail, and Pending gate badges with Inspection navigation
- add accessible card context actions for Edit, idempotent Duplicate, Archive, and Delete
- persist archive state and duplicate idempotency, and expose focused mutation endpoints
- keep delete confirmation and 404/409 failures inline on the affected card

## Verification
- `uv run --with-requirements requirements.txt --with pytest python -m pytest -q -s tests/tests_backend/test_article_context_actions.py tests/tests_backend/test_articles/test_delete.py tests/tests_backend/test_store/test_schema.py` (17 passed)
- `npx playwright test tests/overview-v3.spec.js --project=chromium` in Playwright v1.59.1 container (15 passed)
- visually inspected loaded gate states and inline delete confirmation at 1440x1000

## Dependency
Implements the UI/state authority from amadou-6e/specs#4. Merge that specs PR before this implementation.

Closes #98