### PR TITLE
feat: add durable overview article actions

### DIFF
--- a/backend/routers/articles.py
+++ b/backend/routers/articles.py
@@ -525,7 +525,10 @@ def push_article(request: Request, article_id: str, body: dict = {}):
     idempotency_key = request.headers.get("Idempotency-Key")
     existing = store.find_job_by_idempotency_key(user_id, "push", idempotency_key)
     if existing:
-        return AsyncAccepted(jobId=existing["job_id"], status=existing["status"])
+        return AsyncAccepted(
+            jobId=existing["job_id"], status=existing["status"],
+            pollUrl=f"/api/jobs/{existing['job_id']}",
+        )
     store.set_destinations_pending(user_id, article_id, platforms)
     job = store.create_job(
         user_id,
@@ -537,7 +540,10 @@ def push_article(request: Request, article_id: str, body: dict = {}):
         max_attempts=4,
         timeout_seconds=300,
     )
-    return AsyncAccepted(jobId=job["job_id"], status=JobStatus.queued)
+    return AsyncAccepted(
+        jobId=job["job_id"], status=JobStatus.queued,
+        pollUrl=f"/api/jobs/{job['job_id']}",
+    )
 
 
 class BrowserPublishRequest(BaseModel):
@@ -886,15 +892,28 @@ def inspect_article(request: Request, article_id: str):
     if article is None:
         raise HTTPException(status_code=404, detail="Article not found")
 
+    idempotency_key = request.headers.get("Idempotency-Key")
+    existing = store.find_job_by_idempotency_key(
+        user_id, "inspect", idempotency_key
+    )
+    if existing:
+        return AsyncAccepted(
+            jobId=existing["job_id"], status=existing["status"],
+            pollUrl=f"/api/jobs/{existing['job_id']}",
+        )
     job = store.create_job(
         user_id,
         "inspect",
         article_id,
         payload={"article_id": article_id},
+        idempotency_key=idempotency_key,
         max_attempts=2,
         timeout_seconds=60,
     )
-    return AsyncAccepted(jobId=job["job_id"], status=JobStatus.queued)
+    return AsyncAccepted(
+        jobId=job["job_id"], status=JobStatus.queued,
+        pollUrl=f"/api/jobs/{job['job_id']}",
+    )
 
 
 # ── Regenerate ────────────────────────────────────────────────────────────────
@@ -917,7 +936,10 @@ def regenerate_patches(request: Request, article_id: str):
         user_id, "regenerate", idempotency_key
     )
     if existing:
-        return AsyncAccepted(jobId=existing["job_id"], status=existing["status"])
+        return AsyncAccepted(
+            jobId=existing["job_id"], status=existing["status"],
+            pollUrl=f"/api/jobs/{existing['job_id']}",
+        )
     job = store.create_job(
         user_id,
         "regenerate",
@@ -928,7 +950,10 @@ def regenerate_patches(request: Request, article_id: str):
         max_attempts=3,
         timeout_seconds=300,
     )
-    return AsyncAccepted(jobId=job["job_id"], status=JobStatus.queued)
+    return AsyncAccepted(
+        jobId=job["job_id"], status=JobStatus.queued,
+        pollUrl=f"/api/jobs/{job['job_id']}",
+    )
 
 
 # ── Chat ──────────────────────────────────────────────────────────────────────

--- a/backend/routers/jobs.py
+++ b/backend/routers/jobs.py
@@ -18,10 +18,11 @@ class SyncScheduleRequest(BaseModel):
 
 
 def _response(job: dict) -> JobResponse:
+    public_status = "retrying" if job["status"] == "waiting" else job["status"]
     return JobResponse(
         jobId=job["job_id"],
         type=job["type"],
-        status=job["status"],
+        status=public_status,
         articleId=job["article_id"],
         result=job["result"],
         error=job["error"],
@@ -36,16 +37,27 @@ def _response(job: dict) -> JobResponse:
         updatedAt=job["updated_at"],
         completedAt=job["completed_at"],
         checkpoint=job["checkpoint"],
+        operation=job["type"],
+        retryable=(
+            job["type"] in {"push", "inspect"}
+            and job["status"] in {"failed", "canceled", "expired"}
+        ),
+        pollUrl=f"/api/jobs/{job['job_id']}",
+        pollAfterMs=2000,
+        timeoutSeconds=job["timeout_seconds"],
+        cancelRequested=job["cancel_requested_at"] is not None,
     )
 
 
 @router.get("")
 def list_jobs(
     request: Request, status: str | None = None, queue: str | None = None,
+    article_id: str | None = None, active: bool | None = None,
     limit: int = Query(50, ge=1, le=200), offset: int = Query(0, ge=0),
 ):
     jobs = store.list_jobs(
-        request.state.user_id, status=status, queue=queue, limit=limit, offset=offset
+        request.state.user_id, status=status, queue=queue, article_id=article_id,
+        active=active, limit=limit, offset=offset
     )
     return {"jobs": [_response(job) for job in jobs], "count": len(jobs)}
 
@@ -95,10 +107,15 @@ def cancel_job(request: Request, job_id: str):
     return _response(job)
 
 
-@router.post("/{job_id}/retry", response_model=JobResponse)
+@router.post("/{job_id}/retry", response_model=JobResponse, status_code=202)
 def retry_job(request: Request, job_id: str):
+    idempotency_key = request.headers.get("Idempotency-Key")
+    if not idempotency_key:
+        raise HTTPException(status_code=400, detail="Idempotency-Key is required")
     try:
-        job = store.retry_job(request.state.user_id, job_id)
+        job = store.retry_job(
+            request.state.user_id, job_id, idempotency_key=idempotency_key
+        )
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     if job is None:

--- a/backend/routers/jobs.py
+++ b/backend/routers/jobs.py
@@ -18,7 +18,9 @@ class SyncScheduleRequest(BaseModel):
 
 
 def _response(job: dict) -> JobResponse:
-    public_status = "retrying" if job["status"] == "waiting" else job["status"]
+    public_status = job["status"]
+    if public_status == "waiting":
+        public_status = "retrying" if job["available_at"] is not None else "parked"
     return JobResponse(
         jobId=job["job_id"],
         type=job["type"],
@@ -40,7 +42,10 @@ def _response(job: dict) -> JobResponse:
         operation=job["type"],
         retryable=(
             job["type"] in {"push", "inspect"}
-            and job["status"] in {"failed", "canceled", "expired"}
+            and (
+                job["status"] in {"failed", "canceled", "expired"}
+                or (job["status"] == "waiting" and job["available_at"] is None)
+            )
         ),
         pollUrl=f"/api/jobs/{job['job_id']}",
         pollAfterMs=2000,

--- a/backend/schemas/overview.py
+++ b/backend/schemas/overview.py
@@ -63,6 +63,7 @@ class JobStatus(str, Enum):
     queued = "queued"
     running = "running"
     waiting = "waiting"
+    retrying = "retrying"
     completed = "completed"
     failed = "failed"
     canceled = "canceled"
@@ -168,6 +169,12 @@ class JobResponse(BaseModel):
     updated_at: Optional[datetime] = Field(default=None, alias="updatedAt")
     completed_at: Optional[datetime] = Field(default=None, alias="completedAt")
     checkpoint: Optional[dict] = None
+    operation: str
+    retryable: bool = False
+    poll_url: str = Field(alias="pollUrl")
+    poll_after_ms: int = Field(default=2000, alias="pollAfterMs")
+    timeout_seconds: int = Field(default=300, alias="timeoutSeconds")
+    cancel_requested: bool = Field(default=False, alias="cancelRequested")
 
     model_config = {"populate_by_name": True}
 
@@ -175,6 +182,7 @@ class JobResponse(BaseModel):
 class AsyncAccepted(BaseModel):
     job_id: str = Field(alias="jobId")
     status: JobStatus
+    poll_url: str = Field(alias="pollUrl")
 
     model_config = {"populate_by_name": True}
 

--- a/backend/schemas/overview.py
+++ b/backend/schemas/overview.py
@@ -63,6 +63,7 @@ class JobStatus(str, Enum):
     queued = "queued"
     running = "running"
     waiting = "waiting"
+    parked = "parked"
     retrying = "retrying"
     completed = "completed"
     failed = "failed"

--- a/backend/store/job_queue.py
+++ b/backend/store/job_queue.py
@@ -137,6 +137,7 @@ class DurableJobStoreMixin:
 
     def list_jobs(
         self, user_id: str, *, status: str | None = None, queue: str | None = None,
+        article_id: str | None = None, active: bool | None = None,
         limit: int = 50, offset: int = 0,
     ) -> list[dict]:
         clauses = ["user_id=?"]
@@ -147,6 +148,13 @@ class DurableJobStoreMixin:
         if queue:
             clauses.append("queue=?")
             params.append(queue)
+        if article_id:
+            clauses.append("article_id=?")
+            params.append(_sanitize(article_id))
+        if active is True:
+            clauses.append("status IN ('queued','running','waiting')")
+        elif active is False:
+            clauses.append("status IN ('completed','failed','canceled','expired')")
         params.extend([max(1, min(limit, 200)), max(0, offset)])
         rows = self._con.execute(
             "SELECT * FROM jobs WHERE " + " AND ".join(clauses) +
@@ -417,27 +425,48 @@ class DurableJobStoreMixin:
                 (now_s, _sanitize(error), job_id, row["attempt_count"]),
             )
 
-    def retry_job(self, user_id: str, job_id: str) -> dict | None:
+    def retry_job(
+        self, user_id: str, job_id: str, *, idempotency_key: str | None = None,
+    ) -> dict | None:
         now_s = _ts(_now())
-        with self._con:
-            row = self._con.execute(
-                "SELECT status FROM jobs WHERE job_id=? AND user_id=?", (job_id, user_id)
-            ).fetchone()
-            if row is None:
-                return None
-            if row["status"] == "running":
-                raise ValueError("A running job cannot be retried")
-            if row["status"] == "completed":
-                return self.get_job(user_id, job_id)
-            self._con.execute(
-                """UPDATE jobs SET status='queued', available_at=?, completed_at=NULL,
-                   cancel_requested_at=NULL, terminal_error=NULL, error=NULL,
-                   claimed_by=NULL, lease_expires_at=NULL, updated_at=?
-                   , max_attempts=CASE WHEN attempt_count >= max_attempts
-                                      THEN attempt_count + 1 ELSE max_attempts END
-                   WHERE job_id=? AND user_id=?""",
-                (now_s, now_s, job_id, user_id),
-            )
+        safe_key = _sanitize(idempotency_key) if idempotency_key else None
+        with self._workspace_lock.acquire():
+            with self._con:
+                row = self._con.execute(
+                    "SELECT status FROM jobs WHERE job_id=? AND user_id=?",
+                    (job_id, user_id),
+                ).fetchone()
+                if row is None:
+                    return None
+                if safe_key:
+                    repeated = self._con.execute(
+                        "SELECT 1 FROM job_retry_requests "
+                        "WHERE job_id=? AND user_id=? AND idempotency_key=?",
+                        (job_id, user_id, safe_key),
+                    ).fetchone()
+                    if repeated:
+                        return self.get_job(user_id, job_id)
+                if row["status"] in {"queued", "running"}:
+                    raise ValueError("This job is already active")
+                if row["status"] == "completed":
+                    raise ValueError("A completed job cannot be retried")
+                if safe_key:
+                    self._con.execute(
+                        "INSERT INTO job_retry_requests "
+                        "(job_id, user_id, idempotency_key, created_at) "
+                        "VALUES (?,?,?,?)",
+                        (job_id, user_id, safe_key, now_s),
+                    )
+                self._con.execute(
+                    """UPDATE jobs SET status='queued', available_at=?,
+                       completed_at=NULL, cancel_requested_at=NULL,
+                       terminal_error=NULL, error=NULL, claimed_by=NULL,
+                       lease_expires_at=NULL, updated_at=?,
+                       max_attempts=CASE WHEN attempt_count >= max_attempts
+                                         THEN attempt_count + 1 ELSE max_attempts END
+                       WHERE job_id=? AND user_id=?""",
+                    (now_s, now_s, job_id, user_id),
+                )
         return self.get_job(user_id, job_id)
 
     def begin_job_effect(

--- a/backend/store/schema.py
+++ b/backend/store/schema.py
@@ -10,7 +10,7 @@ SEED_USER_HASH = "$2b$12$BJsbJlf3SZUMUISLA8oASeFn.Q3U.Ar6TqoIFtu0F9OlYyev.DZLC"
 
 # Bump for every released schema shape. Idempotent additions migrate in place;
 # destructive changes require an explicit migration and recovery plan.
-SCHEMA_VERSION = 10
+SCHEMA_VERSION = 11
 
 _SCHEMA_SQL_PATH = Path(__file__).resolve().parent / "sql" / "schema.sql"
 

--- a/backend/store/sql/schema.sql
+++ b/backend/store/sql/schema.sql
@@ -127,6 +127,14 @@ CREATE TABLE IF NOT EXISTS jobs (
     user_id             TEXT REFERENCES users(id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS job_retry_requests (
+    job_id           TEXT NOT NULL REFERENCES jobs(job_id) ON DELETE CASCADE,
+    user_id          TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    idempotency_key  TEXT NOT NULL,
+    created_at       TEXT NOT NULL,
+    PRIMARY KEY (job_id, idempotency_key)
+);
+
 CREATE TABLE IF NOT EXISTS job_attempts (
     id           INTEGER PRIMARY KEY AUTOINCREMENT,
     job_id       TEXT NOT NULL REFERENCES jobs(job_id) ON DELETE CASCADE,

--- a/screens/overview/overview-job-lifecycle.js
+++ b/screens/overview/overview-job-lifecycle.js
@@ -6,6 +6,11 @@
   const BUSY = new Set(['submitting', 'queued', 'running', 'retrying', 'recovering', 'canceling']);
   const TERMINAL = new Set(['completed', 'done', 'failed', 'canceled', 'expired']);
 
+  function publicStatus(job) {
+    if (job.status !== 'waiting') return job.status;
+    return job.availableAt || job.available_at ? 'retrying' : 'parked';
+  }
+
   function randomKey(prefix) {
     const value = globalThis.crypto && globalThis.crypto.randomUUID
       ? globalThis.crypto.randomUUID()
@@ -44,6 +49,11 @@
       this.states.delete(articleId);
       this.pollTokens.delete(articleId);
       this.onChange(articleId, null);
+    }
+
+    stop(articleId) {
+      if (!articleId) return;
+      this._clear(articleId);
     }
 
     _storageKey(articleId, operation) {
@@ -108,14 +118,12 @@
 
     async recover(articleId) {
       if (this.isBusy(articleId)) return this.state(articleId);
-      this._set(articleId, { status: 'recovering', operation: null });
       try {
         const payload = await this.request(
           `/api/jobs?article_id=${encodeURIComponent(articleId)}&active=true&limit=10`
         );
         const job = (payload.jobs || []).find(item => item.operation === 'push' || item.operation === 'inspect');
         if (job) return this._attach(articleId, job);
-        await this.onCompleted(articleId, null);
         this._clear(articleId);
         return null;
       } catch (error) {
@@ -175,13 +183,16 @@
         ...job,
         jobId: job.jobId || job.job_id,
         operation: job.operation || job.type,
-        status: job.status === 'waiting' ? 'retrying' : job.status,
+        status: publicStatus(job),
         pollUrl: job.pollUrl || `/api/jobs/${job.jobId || job.job_id}`,
         pollAfterMs: job.pollAfterMs || 2000,
       };
       this._set(articleId, normalized);
-      if (!TERMINAL.has(normalized.status)) void this._poll(articleId, normalized.jobId);
-      else void this._finish(articleId, normalized);
+      if (TERMINAL.has(normalized.status)) {
+        void this._finish(articleId, normalized);
+      } else if (normalized.status !== 'parked') {
+        void this._poll(articleId, normalized.jobId);
+      }
       return normalized;
     }
 
@@ -198,9 +209,13 @@
           const normalized = {
             ...current, ...job,
             operation: job.operation || job.type || current.operation,
-            status: job.status === 'waiting' ? 'retrying' : job.status,
+            status: publicStatus(job),
           };
           this._set(articleId, normalized);
+          if (normalized.status === 'parked') {
+            this.pollTokens.delete(articleId);
+            return;
+          }
           if (TERMINAL.has(normalized.status)) {
             await this._finish(articleId, normalized);
             return;

--- a/screens/overview/overview-job-lifecycle.js
+++ b/screens/overview/overview-job-lifecycle.js
@@ -1,0 +1,236 @@
+(function (root, factory) {
+  const exported = factory();
+  if (typeof module === 'object' && module.exports) module.exports = exported;
+  root.OverviewJobLifecycle = exported.OverviewJobLifecycle;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  const BUSY = new Set(['submitting', 'queued', 'running', 'retrying', 'recovering', 'canceling']);
+  const TERMINAL = new Set(['completed', 'done', 'failed', 'canceled', 'expired']);
+
+  function randomKey(prefix) {
+    const value = globalThis.crypto && globalThis.crypto.randomUUID
+      ? globalThis.crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    return `${prefix}:${value}`;
+  }
+
+  class OverviewJobLifecycle {
+    constructor({ request, storage, onChange, onCompleted, sleep } = {}) {
+      this.request = request;
+      this.storage = storage;
+      this.onChange = onChange || (() => {});
+      this.onCompleted = onCompleted || (async () => {});
+      this.sleep = sleep || (milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds)));
+      this.states = new Map();
+      this.pollTokens = new Map();
+    }
+
+    state(articleId) {
+      return this.states.get(articleId) || null;
+    }
+
+    isBusy(articleId) {
+      const current = this.state(articleId);
+      return Boolean(current && BUSY.has(current.status));
+    }
+
+    _set(articleId, next) {
+      const value = { articleId, ...next };
+      this.states.set(articleId, value);
+      this.onChange(articleId, value);
+      return value;
+    }
+
+    _clear(articleId) {
+      this.states.delete(articleId);
+      this.pollTokens.delete(articleId);
+      this.onChange(articleId, null);
+    }
+
+    _storageKey(articleId, operation) {
+      return `bloghub:overview:job-key:${articleId}:${operation}`;
+    }
+
+    _submissionKey(articleId, operation) {
+      const key = this._storageKey(articleId, operation);
+      let value = this.storage && this.storage.getItem(key);
+      if (!value) {
+        value = randomKey(`${articleId}:${operation}`);
+        if (this.storage) this.storage.setItem(key, value);
+      }
+      return value;
+    }
+
+    _forgetSubmissionKey(articleId, operation) {
+      if (this.storage) this.storage.removeItem(this._storageKey(articleId, operation));
+    }
+
+    _retryStorageKey(jobId) {
+      return `bloghub:overview:retry-key:${jobId}`;
+    }
+
+    _retryKey(jobId) {
+      const key = this._retryStorageKey(jobId);
+      let value = this.storage && this.storage.getItem(key);
+      if (!value) {
+        value = randomKey(`retry:${jobId}`);
+        if (this.storage) this.storage.setItem(key, value);
+      }
+      return value;
+    }
+
+    _forgetRetryKey(jobId) {
+      if (this.storage) this.storage.removeItem(this._retryStorageKey(jobId));
+    }
+
+    async submit(articleId, operation, body = {}) {
+      if (this.isBusy(articleId)) return this.state(articleId);
+      const idempotencyKey = this._submissionKey(articleId, operation);
+      this._set(articleId, { status: 'submitting', operation, idempotencyKey });
+      try {
+        const accepted = await this.request(`/api/articles/${encodeURIComponent(articleId)}/${operation}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Idempotency-Key': idempotencyKey },
+          body: JSON.stringify(body),
+        });
+        return this._attach(articleId, {
+          ...accepted,
+          operation,
+          status: accepted.status || 'queued',
+        });
+      } catch (error) {
+        return this._set(articleId, {
+          status: 'failed', operation, idempotencyKey,
+          error: error.message || 'The action could not be submitted.',
+          retryable: true, retryMode: 'submit',
+        });
+      }
+    }
+
+    async recover(articleId) {
+      if (this.isBusy(articleId)) return this.state(articleId);
+      this._set(articleId, { status: 'recovering', operation: null });
+      try {
+        const payload = await this.request(
+          `/api/jobs?article_id=${encodeURIComponent(articleId)}&active=true&limit=10`
+        );
+        const job = (payload.jobs || []).find(item => item.operation === 'push' || item.operation === 'inspect');
+        if (job) return this._attach(articleId, job);
+        await this.onCompleted(articleId, null);
+        this._clear(articleId);
+        return null;
+      } catch (error) {
+        return this._set(articleId, {
+          status: 'recovery-error', operation: null,
+          error: error.message || 'Could not restore job status.',
+        });
+      }
+    }
+
+    async retryRecovery(articleId) {
+      this._clear(articleId);
+      return this.recover(articleId);
+    }
+
+    async retry(articleId) {
+      const current = this.state(articleId);
+      if (!current || !current.retryable) return current;
+      if (current.retryMode === 'submit') {
+        this._clear(articleId);
+        return this.submit(articleId, current.operation);
+      }
+      if (!current.jobId || this.isBusy(articleId)) return current;
+      const retryKey = this._retryKey(current.jobId);
+      this._set(articleId, { ...current, status: 'retrying', idempotencyKey: retryKey });
+      try {
+        const job = await this.request(`/api/jobs/${encodeURIComponent(current.jobId)}/retry`, {
+          method: 'POST', headers: { 'Idempotency-Key': retryKey },
+        });
+        this._forgetRetryKey(current.jobId);
+        return this._attach(articleId, job);
+      } catch (error) {
+        return this._set(articleId, {
+          ...current, status: 'failed',
+          error: error.message || 'The retry was rejected.',
+        });
+      }
+    }
+
+    async cancel(articleId) {
+      const current = this.state(articleId);
+      if (!current || !current.jobId || !['queued', 'running', 'retrying'].includes(current.status)) return current;
+      this._set(articleId, { ...current, status: 'canceling' });
+      try {
+        const job = await this.request(`/api/jobs/${encodeURIComponent(current.jobId)}/cancel`, { method: 'POST' });
+        return this._attach(articleId, job);
+      } catch (error) {
+        return this._set(articleId, {
+          ...current, status: current.status,
+          error: error.message || 'Cancellation could not be requested.',
+        });
+      }
+    }
+
+    _attach(articleId, job) {
+      const normalized = {
+        ...job,
+        jobId: job.jobId || job.job_id,
+        operation: job.operation || job.type,
+        status: job.status === 'waiting' ? 'retrying' : job.status,
+        pollUrl: job.pollUrl || `/api/jobs/${job.jobId || job.job_id}`,
+        pollAfterMs: job.pollAfterMs || 2000,
+      };
+      this._set(articleId, normalized);
+      if (!TERMINAL.has(normalized.status)) void this._poll(articleId, normalized.jobId);
+      else void this._finish(articleId, normalized);
+      return normalized;
+    }
+
+    async _poll(articleId, jobId) {
+      const token = Symbol(jobId);
+      this.pollTokens.set(articleId, token);
+      while (this.pollTokens.get(articleId) === token) {
+        const current = this.state(articleId);
+        if (!current || current.jobId !== jobId || TERMINAL.has(current.status)) return;
+        await this.sleep(current.pollAfterMs || 2000);
+        if (this.pollTokens.get(articleId) !== token) return;
+        try {
+          const job = await this.request(current.pollUrl || `/api/jobs/${encodeURIComponent(jobId)}`);
+          const normalized = {
+            ...current, ...job,
+            operation: job.operation || job.type || current.operation,
+            status: job.status === 'waiting' ? 'retrying' : job.status,
+          };
+          this._set(articleId, normalized);
+          if (TERMINAL.has(normalized.status)) {
+            await this._finish(articleId, normalized);
+            return;
+          }
+        } catch (error) {
+          this._set(articleId, {
+            ...current,
+            error: error.message || 'Job status could not be refreshed. Retrying...',
+          });
+        }
+      }
+    }
+
+    async _finish(articleId, job) {
+      this.pollTokens.delete(articleId);
+      if (job.status === 'completed' || job.status === 'done') {
+        this._forgetSubmissionKey(articleId, job.operation);
+        this._set(articleId, { ...job, status: 'completed' });
+        await this.onCompleted(articleId, job);
+        this._clear(articleId);
+        return;
+      }
+      this._forgetSubmissionKey(articleId, job.operation);
+      this._set(articleId, {
+        ...job,
+        status: job.status === 'expired' ? 'failed' : job.status,
+        error: job.error || (job.status === 'canceled' ? 'The job was canceled.' : 'The job failed.'),
+      });
+    }
+  }
+
+  return { OverviewJobLifecycle };
+});

--- a/screens/overview/v3.html
+++ b/screens/overview/v3.html
@@ -121,6 +121,26 @@
       overflow: hidden;
       background: #13172a;
     }
+    #panel-job-region {
+      margin: 0 16px 12px;
+      padding: 10px;
+      border: 1px solid #30364a;
+      border-radius: 6px;
+      background: #181d2d;
+    }
+    #panel-job-region[data-tone="error"] { border-color: #5a3038; background: #21181f; }
+    #panel-job-region[data-tone="warning"] { border-color: #554921; background: #211e16; }
+    #panel-job-region[data-tone="success"] { border-color: #28523c; background: #15231d; }
+    .panel-job-action {
+      font: 500 11px Inter, system-ui, sans-serif;
+      padding: 5px 8px;
+      border-radius: 5px;
+      border: 1px solid #3a4054;
+      color: #c9cfe0;
+      background: transparent;
+      cursor: pointer;
+    }
+    .panel-job-action:hover { border-color: #6366f1; color: #fff; }
 
     ::-webkit-scrollbar { width: 5px; }
     ::-webkit-scrollbar-track { background: transparent; }
@@ -555,6 +575,16 @@
         <div style="font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:#5a6080;margin-bottom:10px;">Timeline</div>
         <div id="panel-timeline" style="display:flex;flex-direction:column;gap:8px;"></div>
       </div>
+      <div id="panel-job-region" hidden role="status" aria-live="polite">
+        <div id="panel-job-title" style="font-size:12px;font-weight:600;color:#e8eaf2;"></div>
+        <div id="panel-job-meta" style="margin-top:4px;font:10px 'JetBrains Mono',monospace;color:#8a93b0;overflow-wrap:anywhere;"></div>
+        <div id="panel-job-error" style="display:none;margin-top:7px;font-size:11px;line-height:1.45;color:#fca5a5;"></div>
+        <div id="panel-job-actions" style="display:none;gap:6px;margin-top:8px;">
+          <button id="panel-cancel-job-btn" class="panel-job-action" type="button">Cancel</button>
+          <button id="panel-retry-job-btn" class="panel-job-action" type="button">Retry</button>
+          <button id="panel-retry-recovery-btn" class="panel-job-action" type="button">Retry recovery</button>
+        </div>
+      </div>
       <div style="padding:12px 16px;border-top:1px solid #252a38;display:flex;flex-direction:column;gap:6px;">
         <button id="panel-primary-btn" style="font-size:12px;font-weight:500;padding:8px;border-radius:6px;background:#6366f1;color:#fff;border:none;cursor:pointer;font-family:inherit;width:100%;">—</button>
         <div style="display:flex;gap:6px;">
@@ -567,6 +597,7 @@
   </div>
 </div>
 
+<script src="./overview-job-lifecycle.js"></script>
 <script>
 // --- Data ----------------------------------------------------------
 let ARTICLES = [];
@@ -622,6 +653,7 @@ let showSkeleton   = false;
 let showEmpty      = false;
 let openMenuId     = null;
 let detailsPanelOpen = true;
+const SELECTED_ARTICLE_KEY = 'bloghub:overview:selected-article';
 // Per-card active preview platform: Map<articleId, 'medium'|'hashnode'|'devto'>
 const activePreview = new Map();
 
@@ -642,7 +674,7 @@ const DOT_COLOR = {
 };
 const GATE_COLOR = { pass: '#4ade80', warn: '#fbbf24', fail: '#f87171', pending: '#5a6080' };
 const GATE_LABEL = { pass: '✓ Pass', warn: '⚠ Warn', fail: '✗ Fail', pending: '—' };
-const activeJobs = new Map();
+let jobLifecycle = null;
 
 function formatRelative(isoValue) {
   const date = new Date(isoValue);
@@ -719,7 +751,19 @@ function buildLiveArticle(raw, index) {
 async function fetchJson(url, options = {}) {
   const response = await fetch(url, options);
   if (!response.ok) {
-    throw new Error(await response.text() || `Request failed: ${response.status}`);
+    let message = `Request failed: ${response.status}`;
+    const body = await response.text();
+    try {
+      const payload = JSON.parse(body);
+      message = typeof payload.detail === 'string'
+        ? payload.detail
+        : payload.detail?.message || payload.detail?.error || message;
+    } catch (_) {
+      if (body) message = body;
+    }
+    const error = new Error(message);
+    error.status = response.status;
+    throw error;
   }
   return response.json();
 }
@@ -868,38 +912,10 @@ async function runArticleAction(article, overrideKind = null) {
     return;
   }
   if (action.kind === 'schedule') {
-    alert('Schedule is not wired yet.');
     return;
   }
   const endpoint = action.kind === 'inspect' ? 'inspect' : 'push';
-  activeJobs.set(article.id, endpoint);
-  render();
-  try {
-    const accepted = await fetchJson(`/api/articles/${article.id}/${endpoint}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({}),
-    });
-    await pollJob(accepted.jobId);
-    await loadOverview();
-  } catch (error) {
-    alert(`Action failed: ${error.message}`);
-  } finally {
-    activeJobs.delete(article.id);
-    render();
-  }
-}
-
-async function pollJob(jobId) {
-  for (let attempt = 0; attempt < 10; attempt += 1) {
-    const job = await fetchJson(`/api/jobs/${jobId}`);
-    if (job.status === 'completed' || job.status === 'done') return job;
-    if (['failed','canceled','expired','error'].includes(job.status)) {
-      throw new Error(job.error || `Job ${job.status}`);
-    }
-    await new Promise(resolve => window.setTimeout(resolve, 500));
-  }
-  throw new Error('Timed out waiting for job completion');
+  await jobLifecycle.submit(article.id, endpoint);
 }
 
 function platformActionProps(status) {
@@ -1292,6 +1308,14 @@ function syncDetailsPanel() {
     return;
   }
 
+  const article = ARTICLES.find(item => item.id === selectedId);
+  if (!article) {
+    selectedId = null;
+    sessionStorage.removeItem(SELECTED_ARTICLE_KEY);
+    panel.classList.add('hidden');
+    return;
+  }
+
   panel.classList.remove('hidden');
   if (detailsPanelOpen) {
     panel.style.width = '300px';
@@ -1304,6 +1328,81 @@ function syncDetailsPanel() {
     content.style.display = 'none';
     arrow.innerHTML = '<polyline points="15 18 9 12 15 6"/>';
   }
+  renderDetailsArticle(article);
+}
+
+function renderDetailsArticle(article) {
+  document.getElementById('panel-title').textContent = article.title;
+  document.getElementById('panel-destinations').innerHTML = ['medium','hashnode','devto'].map(platform => {
+    const destination = article.destinations[platform];
+    return `<div style="display:flex;align-items:center;justify-content:space-between;">
+      <span style="color:#c9cfe0;font-size:12px;">${PLATFORM_LABEL[platform]}</span>
+      <div style="display:flex;align-items:center;gap:6px;">
+        <span style="width:7px;height:7px;border-radius:50%;background:${DOT_COLOR[destination.status]||'#252a38'};display:inline-block;"></span>
+        <span style="font-family:'JetBrains Mono',monospace;font-size:11px;color:${DOT_COLOR[destination.status]||'#5a6080'}">${destination.label}</span>
+      </div>
+    </div>`;
+  }).join('');
+  document.getElementById('panel-timeline').innerHTML = article.timeline.map(item =>
+    `<div style="display:flex;gap:8px;">
+      <span style="color:#5a6080;font-family:'JetBrains Mono',monospace;font-size:10px;width:48px;flex-shrink:0;padding-top:1px;">${item.time}</span>
+      <span style="color:#c9cfe0;font-size:12px;line-height:1.5;">${item.event}</span>
+    </div>`
+  ).join('');
+
+  const state = jobLifecycle ? jobLifecycle.state(article.id) : null;
+  const busy = jobLifecycle ? jobLifecycle.isBusy(article.id) : false;
+  const primary = document.getElementById('panel-primary-btn');
+  primary.textContent = article.action.label;
+  primary.style.background = article.action.bg;
+  primary.style.color = article.action.color;
+  primary.style.border = `1px solid ${article.action.border}`;
+  primary.disabled = busy;
+  primary.onclick = async () => { await runArticleAction(article); };
+  const inspect = document.getElementById('panel-inspect-btn');
+  inspect.disabled = busy;
+  inspect.onclick = async () => { await runArticleAction(article, 'inspect'); };
+  renderPanelJobState(article.id, state);
+}
+
+function renderPanelJobState(articleId, state) {
+  const region = document.getElementById('panel-job-region');
+  if (!state) {
+    region.hidden = true;
+    return;
+  }
+  const labels = {
+    submitting: 'Submitting action', queued: 'Queued', running: 'Running',
+    retrying: 'Retrying', canceling: 'Canceling', canceled: 'Canceled',
+    failed: 'Action failed', recovering: 'Recovering after reload',
+    'recovery-error': 'Recovery unavailable', completed: 'Completed',
+  };
+  const operation = state.operation
+    ? `${state.operation === 'inspect' ? 'Inspection' : 'Push'} operation`
+    : '';
+  region.hidden = false;
+  region.dataset.tone = ['failed', 'canceled'].includes(state.status)
+    ? 'error'
+    : ['retrying', 'recovering', 'recovery-error', 'canceling'].includes(state.status)
+      ? 'warning'
+      : state.status === 'completed' ? 'success' : 'default';
+  document.getElementById('panel-job-title').textContent = labels[state.status] || state.status;
+  document.getElementById('panel-job-meta').textContent = [operation, state.jobId].filter(Boolean).join(' · ');
+  const error = document.getElementById('panel-job-error');
+  error.style.display = state.error ? 'block' : 'none';
+  error.textContent = state.error || '';
+
+  const cancel = document.getElementById('panel-cancel-job-btn');
+  const retry = document.getElementById('panel-retry-job-btn');
+  const retryRecovery = document.getElementById('panel-retry-recovery-btn');
+  cancel.style.display = ['queued', 'running', 'retrying'].includes(state.status) ? 'inline-flex' : 'none';
+  retry.style.display = ['failed', 'canceled'].includes(state.status) && state.retryable ? 'inline-flex' : 'none';
+  retryRecovery.style.display = state.status === 'recovery-error' ? 'inline-flex' : 'none';
+  cancel.onclick = () => jobLifecycle.cancel(articleId);
+  retry.onclick = () => jobLifecycle.retry(articleId);
+  retryRecovery.onclick = () => jobLifecycle.retryRecovery(articleId);
+  document.getElementById('panel-job-actions').style.display =
+    [cancel, retry, retryRecovery].some(button => button.style.display !== 'none') ? 'flex' : 'none';
 }
 
 // --- Interactions --------------------------------------------------
@@ -1315,34 +1414,10 @@ function selectCard(id) {
     return;
   }
   selectedId = id;
-  render();
   detailsPanelOpen = true;
-  syncDetailsPanel();
-  const a = ARTICLES.find(x => x.id === selectedId);
-  document.getElementById('panel-title').textContent = a.title;
-  document.getElementById('panel-destinations').innerHTML = ['medium','hashnode','devto'].map(p => {
-    const d = a.destinations[p];
-    return `<div style="display:flex;align-items:center;justify-content:space-between;">
-      <span style="color:#c9cfe0;font-size:12px;">${PLATFORM_LABEL[p]}</span>
-      <div style="display:flex;align-items:center;gap:6px;">
-        <span style="width:7px;height:7px;border-radius:50%;background:${DOT_COLOR[d.status]||'#252a38'};display:inline-block;"></span>
-        <span style="font-family:'JetBrains Mono',monospace;font-size:11px;color:${DOT_COLOR[d.status]||'#5a6080'}">${d.label}</span>
-      </div>
-    </div>`;
-  }).join('');
-  document.getElementById('panel-timeline').innerHTML = a.timeline.map(t =>
-    `<div style="display:flex;gap:8px;">
-      <span style="color:#5a6080;font-family:'JetBrains Mono',monospace;font-size:10px;width:48px;flex-shrink:0;padding-top:1px;">${t.time}</span>
-      <span style="color:#c9cfe0;font-size:12px;line-height:1.5;">${t.event}</span>
-    </div>`
-  ).join('');
-  const pb = document.getElementById('panel-primary-btn');
-  pb.textContent = a.action.label;
-  pb.style.background = a.action.bg;
-  pb.style.color = a.action.color;
-  pb.style.border = `1px solid ${a.action.border}`;
-  pb.onclick = async () => { await runArticleAction(a); };
-  document.getElementById('panel-inspect-btn').onclick = async () => { await runArticleAction(a, 'inspect'); };
+  sessionStorage.setItem(SELECTED_ARTICLE_KEY, id);
+  render();
+  void jobLifecycle.recover(id);
 }
 
 function toggleDetailsPanel() {
@@ -1353,6 +1428,7 @@ function toggleDetailsPanel() {
 
 function closePanel() {
   selectedId = null;
+  sessionStorage.removeItem(SELECTED_ARTICLE_KEY);
   detailsPanelOpen = true;
   render();
   syncDetailsPanel();
@@ -1432,13 +1508,31 @@ function closeMenus() {
   openMenuId = null;
 }
 
+jobLifecycle = new OverviewJobLifecycle({
+  request: fetchJson,
+  storage: sessionStorage,
+  onChange: () => render(),
+  onCompleted: async () => {
+    await loadOverview();
+    render();
+  },
+});
+
 showSkeleton = true;
 render();
 loadOverview()
+  .then(() => {
+    const restoredId = sessionStorage.getItem(SELECTED_ARTICLE_KEY);
+    if (restoredId && ARTICLES.some(article => article.id === restoredId)) {
+      selectedId = restoredId;
+      detailsPanelOpen = true;
+    }
+  })
   .catch(error => { alert(`Failed to load overview: ${error.message}`); })
   .finally(() => {
     showSkeleton = false;
     render();
+    if (selectedId) void jobLifecycle.recover(selectedId);
   });
 </script>
 </body>

--- a/screens/overview/v3.html
+++ b/screens/overview/v3.html
@@ -912,6 +912,7 @@ async function runArticleAction(article, overrideKind = null) {
     return;
   }
   if (action.kind === 'schedule') {
+    alert('Publishing queue is not available yet.');
     return;
   }
   const endpoint = action.kind === 'inspect' ? 'inspect' : 'push';
@@ -1357,8 +1358,10 @@ function renderDetailsArticle(article) {
   primary.style.background = article.action.bg;
   primary.style.color = article.action.color;
   primary.style.border = `1px solid ${article.action.border}`;
-  primary.disabled = busy;
-  primary.onclick = async () => { await runArticleAction(article); };
+  const scheduleUnavailable = article.action.kind === 'schedule';
+  primary.disabled = busy || scheduleUnavailable;
+  primary.title = scheduleUnavailable ? 'Publishing queue is not available yet' : '';
+  primary.onclick = scheduleUnavailable ? null : async () => { await runArticleAction(article); };
   const inspect = document.getElementById('panel-inspect-btn');
   inspect.disabled = busy;
   inspect.onclick = async () => { await runArticleAction(article, 'inspect'); };
@@ -1374,6 +1377,7 @@ function renderPanelJobState(articleId, state) {
   const labels = {
     submitting: 'Submitting action', queued: 'Queued', running: 'Running',
     retrying: 'Retrying', canceling: 'Canceling', canceled: 'Canceled',
+    parked: 'Needs attention',
     failed: 'Action failed', recovering: 'Recovering after reload',
     'recovery-error': 'Recovery unavailable', completed: 'Completed',
   };
@@ -1383,7 +1387,7 @@ function renderPanelJobState(articleId, state) {
   region.hidden = false;
   region.dataset.tone = ['failed', 'canceled'].includes(state.status)
     ? 'error'
-    : ['retrying', 'recovering', 'recovery-error', 'canceling'].includes(state.status)
+    : ['retrying', 'parked', 'recovering', 'recovery-error', 'canceling'].includes(state.status)
       ? 'warning'
       : state.status === 'completed' ? 'success' : 'default';
   document.getElementById('panel-job-title').textContent = labels[state.status] || state.status;
@@ -1396,7 +1400,7 @@ function renderPanelJobState(articleId, state) {
   const retry = document.getElementById('panel-retry-job-btn');
   const retryRecovery = document.getElementById('panel-retry-recovery-btn');
   cancel.style.display = ['queued', 'running', 'retrying'].includes(state.status) ? 'inline-flex' : 'none';
-  retry.style.display = ['failed', 'canceled'].includes(state.status) && state.retryable ? 'inline-flex' : 'none';
+  retry.style.display = ['failed', 'canceled', 'parked'].includes(state.status) && state.retryable ? 'inline-flex' : 'none';
   retryRecovery.style.display = state.status === 'recovery-error' ? 'inline-flex' : 'none';
   cancel.onclick = () => jobLifecycle.cancel(articleId);
   retry.onclick = () => jobLifecycle.retry(articleId);
@@ -1410,9 +1414,11 @@ function selectCard(id) {
   closeMenus();
   if (id === selectedId) {
     detailsPanelOpen = !detailsPanelOpen;
+    if (!detailsPanelOpen) jobLifecycle.stop(id);
     syncDetailsPanel();
     return;
   }
+  if (selectedId) jobLifecycle.stop(selectedId);
   selectedId = id;
   detailsPanelOpen = true;
   sessionStorage.setItem(SELECTED_ARTICLE_KEY, id);
@@ -1423,11 +1429,14 @@ function selectCard(id) {
 function toggleDetailsPanel() {
   if (!selectedId) return;
   detailsPanelOpen = !detailsPanelOpen;
+  if (!detailsPanelOpen) jobLifecycle.stop(selectedId);
   syncDetailsPanel();
 }
 
 function closePanel() {
+  const previousId = selectedId;
   selectedId = null;
+  jobLifecycle.stop(previousId);
   sessionStorage.removeItem(SELECTED_ARTICLE_KEY);
   detailsPanelOpen = true;
   render();

--- a/tests/overview-v3.spec.js
+++ b/tests/overview-v3.spec.js
@@ -33,4 +33,133 @@ test.describe('Current overview screen', () => {
     await page.locator('.article-card').first().locator('.card-edit').click();
     await expect(page).toHaveURL(/\/screens\/editor\/v2\.html\?id=/);
   });
+
+  test('submits one inspection and prevents duplicate actions while queued', async ({ page }) => {
+    let submissions = 0;
+    await page.route('**/api/articles/*/inspect', async route => {
+      submissions += 1;
+      await route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          jobId: 'job_inspect_once', status: 'queued',
+          pollUrl: '/api/jobs/job_inspect_once', pollAfterMs: 5000,
+        }),
+      });
+    });
+    await page.route('**/api/jobs/job_inspect_once', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        jobId: 'job_inspect_once', operation: 'inspect', status: 'queued',
+        pollUrl: '/api/jobs/job_inspect_once', pollAfterMs: 5000,
+      }),
+    }));
+
+    await page.locator('.article-card').first().click();
+    const inspect = page.locator('#panel-inspect-btn');
+    await inspect.click();
+    await inspect.click({ force: true });
+
+    await expect(page.locator('#panel-job-title')).toHaveText('Queued');
+    await expect(inspect).toBeDisabled();
+    expect(submissions).toBe(1);
+  });
+
+  test('recovers a running job after reload and supports durable cancel and retry', async ({ page }) => {
+    await page.locator('.article-card').first().click();
+    const articleId = await page.locator('.article-card').first().getAttribute('data-id');
+    let recoveryRequests = 0;
+    await page.route('**/api/jobs?article_id=*&active=true&limit=10', route => {
+      recoveryRequests += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ jobs: [{
+          jobId: 'job_recovered', articleId, operation: 'push', status: 'running',
+          pollUrl: '/api/jobs/job_recovered', pollAfterMs: 5000, retryable: false,
+        }] }),
+      });
+    });
+    await page.route('**/api/jobs/job_recovered', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        jobId: 'job_recovered', articleId, operation: 'push', status: 'running',
+        pollUrl: '/api/jobs/job_recovered', pollAfterMs: 5000, retryable: false,
+      }),
+    }));
+    await page.route('**/api/jobs/job_recovered/cancel', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        jobId: 'job_recovered', articleId, operation: 'push', status: 'canceled',
+        pollUrl: '/api/jobs/job_recovered', pollAfterMs: 5000,
+        retryable: true, error: 'Canceled by user',
+      }),
+    }));
+    await page.route('**/api/jobs/job_recovered/retry', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        jobId: 'job_recovered', articleId, operation: 'push', status: 'queued',
+        pollUrl: '/api/jobs/job_recovered', pollAfterMs: 5000, retryable: false,
+      }),
+    }));
+
+    await page.reload();
+    await page.locator('.article-card').first().waitFor();
+    await expect(page.locator('#panel-job-title')).toHaveText('Running');
+    expect(recoveryRequests).toBe(1);
+
+    await page.locator('#panel-cancel-job-btn').click();
+    await expect(page.locator('#panel-job-title')).toHaveText('Canceled');
+    await expect(page.locator('#panel-job-error')).toHaveText('Canceled by user');
+    await page.locator('#panel-retry-job-btn').click();
+    await expect(page.locator('#panel-job-title')).toHaveText('Queued');
+  });
+
+  test('shows a backend terminal timeout inline and refreshes after completion', async ({ page }) => {
+    let status = 'failed';
+    let articleRefreshes = 0;
+    page.on('request', request => {
+      if (request.method() === 'GET' && /\/api\/articles\?/.test(request.url())) articleRefreshes += 1;
+    });
+    await page.route('**/api/articles/*/inspect', route => route.fulfill({
+      status: 202,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        jobId: 'job_timeout', status: 'queued',
+        pollUrl: '/api/jobs/job_timeout', pollAfterMs: 10,
+      }),
+    }));
+    await page.route('**/api/jobs/job_timeout', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        jobId: 'job_timeout', operation: 'inspect', status,
+        pollUrl: '/api/jobs/job_timeout', pollAfterMs: 10,
+        retryable: true,
+        error: status === 'failed' ? 'Job exceeded its 60 second backend timeout' : null,
+      }),
+    }));
+    await page.route('**/api/jobs/job_timeout/retry', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        jobId: 'job_timeout', operation: 'inspect', status: 'queued',
+        pollUrl: '/api/jobs/job_timeout', pollAfterMs: 10, retryable: false,
+      }),
+    }));
+
+    await page.locator('.article-card').first().click();
+    await page.locator('#panel-inspect-btn').click();
+    await expect(page.locator('#panel-job-title')).toHaveText('Action failed');
+    await expect(page.locator('#panel-job-error')).toContainText('backend timeout');
+
+    status = 'completed';
+    await page.locator('#panel-retry-job-btn').click();
+    await expect(page.locator('#panel-job-region')).toBeHidden();
+    expect(articleRefreshes).toBeGreaterThan(0);
+  });
 });

--- a/tests/overview-v3.spec.js
+++ b/tests/overview-v3.spec.js
@@ -7,7 +7,7 @@ test.describe('Current overview screen', () => {
     const reset = await page.request.post('/api/dev/reset');
     expect(reset.ok()).toBeTruthy();
     await page.goto(OVERVIEW_URL);
-    await page.locator('.article-card').first().waitFor();
+    await expect(page.locator('#article-count')).not.toHaveText('— articles');
   });
 
   test('renders article cards from the backend', async ({ page }) => {
@@ -32,6 +32,74 @@ test.describe('Current overview screen', () => {
   test('opens the selected article in the editor', async ({ page }) => {
     await page.locator('.article-card').first().locator('.card-edit').click();
     await expect(page).toHaveURL(/\/screens\/editor\/v2\.html\?id=/);
+  });
+
+  test('does not reload articles when recovery finds no active job', async ({ page }) => {
+    let articleReloads = 0;
+    page.on('request', request => {
+      if (request.url().includes('/api/articles?')) articleReloads += 1;
+    });
+    await page.route('**/api/jobs?article_id=*&active=true&limit=10', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ jobs: [] }),
+    }));
+
+    const recovery = page.waitForResponse(
+      response => response.url().includes('/api/jobs?article_id=')
+    );
+    await page.locator('.article-card').first().click();
+    await recovery;
+
+    expect(articleReloads).toBe(0);
+    await expect(page.locator('#panel-job-region')).toBeHidden();
+  });
+
+  test('stops an abandoned job poller when switching cards', async ({ page }) => {
+    const cards = page.locator('.article-card');
+    const firstId = await cards.nth(0).getAttribute('data-id');
+    const secondId = await cards.nth(1).getAttribute('data-id');
+    await page.route('**/api/jobs?article_id=*&active=true&limit=10', route => {
+      const articleId = new URL(route.request().url()).searchParams.get('article_id');
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ jobs: articleId === firstId ? [{
+          jobId: 'job_switch', articleId: firstId, operation: 'push', status: 'running',
+          pollUrl: '/api/jobs/job_switch', pollAfterMs: 5000, retryable: false,
+        }] : [] }),
+      });
+    });
+
+    await cards.nth(0).click();
+    await expect(page.locator('#panel-job-title')).toHaveText('Running');
+    expect(await page.evaluate(id => jobLifecycle.pollTokens.has(id), firstId)).toBe(true);
+
+    await cards.nth(1).click();
+    await expect.poll(() => page.evaluate(id => ({
+      state: jobLifecycle.state(id),
+      polling: jobLifecycle.pollTokens.has(id),
+    }), firstId)).toEqual({ state: null, polling: false });
+    expect(secondId).not.toBe(firstId);
+  });
+
+  test('marks unavailable scheduling as disabled', async ({ page }) => {
+    const articleId = await page.evaluate(() => {
+      const article = ARTICLES[0];
+      article.action = {
+        ...article.action,
+        kind: 'schedule',
+        label: 'Schedule →',
+      };
+      render();
+      return article.id;
+    });
+
+    await page.locator(`.article-card[data-id="${articleId}"]`).click();
+    await expect(page.locator('#panel-primary-btn')).toBeDisabled();
+    await expect(page.locator('#panel-primary-btn')).toHaveAttribute(
+      'title', 'Publishing queue is not available yet'
+    );
   });
 
   test('submits one inspection and prevents duplicate actions while queued', async ({ page }) => {

--- a/tests/tests_backend/test_articles/test_inspect.py
+++ b/tests/tests_backend/test_articles/test_inspect.py
@@ -14,6 +14,14 @@ class TestInspectArticle:
         r = client.post("/api/articles/art_unknown/inspect")
         assert r.status_code == 404
 
+    def test_repeated_idempotency_key_returns_the_same_job(self, client: TestClient):
+        headers = {"Idempotency-Key": "overview-inspect-art-001"}
+        first = client.post("/api/articles/art_001/inspect", headers=headers)
+        second = client.post("/api/articles/art_001/inspect", headers=headers)
+
+        assert first.status_code == second.status_code == 202
+        assert second.json()["jobId"] == first.json()["jobId"]
+
     def test_gate_pass_for_long_article(self, client: TestClient, run_jobs):
         # art_001 word_count=1820 → expect pass
         client.post("/api/articles/art_001/inspect")

--- a/tests/tests_backend/test_articles/test_push.py
+++ b/tests/tests_backend/test_articles/test_push.py
@@ -19,6 +19,15 @@ class TestPushArticle:
         r = client.post("/api/articles/art_unknown/push", json={})
         assert r.status_code == 404
 
+    def test_repeated_idempotency_key_returns_the_same_job(self, client: TestClient):
+        headers = {"Idempotency-Key": "overview-push-art-001"}
+        first = client.post("/api/articles/art_001/push", json={}, headers=headers)
+        second = client.post("/api/articles/art_001/push", json={}, headers=headers)
+
+        assert first.status_code == second.status_code == 202
+        assert second.json()["jobId"] == first.json()["jobId"]
+        assert second.json()["pollUrl"] == f"/api/jobs/{first.json()['jobId']}"
+
     @pytest.mark.integration
     def test_destinations_updated_after_push(self, client: TestClient, run_jobs):
         client.post("/api/articles/art_001/push", json={})

--- a/tests/tests_backend/test_jobs.py
+++ b/tests/tests_backend/test_jobs.py
@@ -4,6 +4,7 @@ Tests for /api/jobs — backend/routers/jobs.py
 
 import pytest
 from fastapi.testclient import TestClient
+import backend.store as store
 
 # ─── GET /api/jobs/:jobId ─────────────────────────────────────────────────────
 
@@ -28,6 +29,60 @@ class TestJobs:
     def test_inspect_job_type(self, client: TestClient):
         job_id = client.post("/api/articles/art_001/inspect").json()["jobId"]
         assert client.get(f"/api/jobs/{job_id}").json()["type"] == "inspect"
+
+    def test_article_active_jobs_are_discoverable(self, client: TestClient):
+        target = client.post(
+            "/api/articles/art_001/inspect",
+            headers={"Idempotency-Key": "recover-inspection"},
+        ).json()
+        client.post(
+            "/api/articles/art_002/inspect",
+            headers={"Idempotency-Key": "other-inspection"},
+        )
+
+        response = client.get(
+            "/api/jobs", params={"article_id": "art_001", "active": True}
+        )
+
+        assert response.status_code == 200
+        assert [job["jobId"] for job in response.json()["jobs"]] == [target["jobId"]]
+        assert response.json()["jobs"][0]["operation"] == "inspect"
+
+    def test_job_response_drives_polling_and_timeout(self, client: TestClient):
+        job_id = client.post("/api/articles/art_001/inspect").json()["jobId"]
+        job = client.get(f"/api/jobs/{job_id}").json()
+
+        assert job["pollUrl"] == f"/api/jobs/{job_id}"
+        assert job["pollAfterMs"] == 2000
+        assert job["timeoutSeconds"] == 60
+        assert job["retryable"] is False
+
+    def test_cancel_and_idempotent_retry_are_durable(self, client: TestClient):
+        job_id = client.post("/api/articles/art_001/inspect").json()["jobId"]
+        canceled = client.post(f"/api/jobs/{job_id}/cancel")
+        assert canceled.json()["status"] == "canceled"
+        assert canceled.json()["retryable"] is True
+
+        assert client.post(f"/api/jobs/{job_id}/retry").status_code == 400
+        headers = {"Idempotency-Key": "retry-canceled-inspection"}
+        first = client.post(f"/api/jobs/{job_id}/retry", headers=headers)
+        second = client.post(f"/api/jobs/{job_id}/retry", headers=headers)
+
+        assert first.status_code == second.status_code == 202
+        assert first.json()["status"] == "queued"
+        assert second.json()["jobId"] == job_id
+
+    def test_worker_backoff_is_exposed_as_retrying(self, client: TestClient):
+        job_id = client.post("/api/articles/art_001/inspect").json()["jobId"]
+        claimed = store._backend.claim_job("test-worker", queues=("default",))
+        assert claimed["job_id"] == job_id
+        store._backend.fail_job(
+            job_id, "test-worker", "temporary outage", backoff_base_seconds=60
+        )
+
+        response = client.get(f"/api/jobs/{job_id}")
+        assert response.json()["status"] == "retrying"
+        assert response.json()["error"] == "temporary outage"
 
 
 class TestSyncSchedules:

--- a/tests/tests_backend/test_jobs.py
+++ b/tests/tests_backend/test_jobs.py
@@ -84,6 +84,21 @@ class TestJobs:
         assert response.json()["status"] == "retrying"
         assert response.json()["error"] == "temporary outage"
 
+    def test_parked_job_is_exposed_as_needing_explicit_retry(self, client: TestClient):
+        job_id = client.post("/api/articles/art_001/inspect").json()["jobId"]
+        claimed = store._backend.claim_job("test-worker", queues=("default",))
+        assert claimed["job_id"] == job_id
+        store._backend.defer_job(
+            job_id, "test-worker", "Remote result requires reconciliation"
+        )
+
+        response = client.get(f"/api/jobs/{job_id}")
+        assert response.status_code == 200
+        assert response.json()["status"] == "parked"
+        assert response.json()["retryable"] is True
+        active = client.get("/api/jobs?article_id=art_001&active=true").json()["jobs"]
+        assert active[0]["status"] == "parked"
+
 
 class TestSyncSchedules:
 

--- a/tests/tests_backend/test_store/test_job_queue.py
+++ b/tests/tests_backend/test_store/test_job_queue.py
@@ -83,6 +83,40 @@ def test_idempotency_keys_are_scoped_by_job_type(store):
     )["job_id"] == pushed["job_id"]
 
 
+def test_list_jobs_filters_article_and_active_lifecycle(store):
+    active = _enqueue(store, article_id="art_001")
+    terminal = _enqueue(store, article_id="art_001")
+    other = _enqueue(store, article_id="art_002")
+    store.request_job_cancellation(store.SEED_USER_ID, terminal["job_id"])
+
+    assert [job["job_id"] for job in store.list_jobs(
+        store.SEED_USER_ID, article_id="art_001", active=True
+    )] == [active["job_id"]]
+    assert [job["job_id"] for job in store.list_jobs(
+        store.SEED_USER_ID, article_id="art_001", active=False
+    )] == [terminal["job_id"]]
+    assert other["job_id"] not in {
+        job["job_id"] for job in store.list_jobs(
+            store.SEED_USER_ID, article_id="art_001"
+        )
+    }
+
+
+def test_retry_idempotency_survives_terminal_state(store):
+    job = _enqueue(store)
+    store.request_job_cancellation(store.SEED_USER_ID, job["job_id"])
+    first = store.retry_job(
+        store.SEED_USER_ID, job["job_id"], idempotency_key="retry-once"
+    )
+    store.request_job_cancellation(store.SEED_USER_ID, job["job_id"])
+    repeated = store.retry_job(
+        store.SEED_USER_ID, job["job_id"], idempotency_key="retry-once"
+    )
+
+    assert first["status"] == "queued"
+    assert repeated["status"] == "canceled"
+
+
 def test_queued_and_running_jobs_can_be_canceled(store):
     queued = _enqueue(store)
     canceled = store.request_job_cancellation(store.SEED_USER_ID, queued["job_id"])


### PR DESCRIPTION
## Summary
- add article-scoped durable job discovery and backend-driven polling metadata
- make Push and Inspect submissions and retries idempotent across reloads and lost responses
- render submitting, queued, running, completed, failed, canceled, retrying, timeout, and recovery states inline in the Overview sidebar
- support durable cancellation/retry and refresh the article collection/sidebar after completion
- isolate browser lifecycle behavior in `screens/overview/overview-job-lifecycle.js`

## Specification
Depends on amadou-6e/specs#4, specifically the authoritative Overview Draw.io at commit `ee142cc`.

## Tests
- `bash scripts/run-unit-tests.sh -s`: 565 passed, 1 skipped, 312 deselected
- `npx playwright test overview-v3.spec.js`: 7 passed
- `npm run check:contracts`: passed
- `node --check screens/overview/overview-job-lifecycle.js`: passed

Closes #100