### PR TITLE
feat: expose live browser authentication state

### DIFF
--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -509,12 +509,31 @@ class SubmitCodeRequest(BaseModel):
     code: str
 
 
-def _browser_connection_response(platform: str, connection: dict | None) -> dict:
+def _browser_connection_response(
+    platform: str,
+    connection: dict | None,
+    live_session: dict | None = None,
+) -> dict:
     if connection is None:
-        return {"platform": platform, "status": "disconnected"}
+        return {
+            "platform": platform,
+            "status": "disconnected",
+            "loginPhase": "disconnected",
+            "browserSession": None,
+            "durableConnection": {
+                "status": "disconnected", "profileSaved": False,
+            },
+        }
+    live_authentication = (live_session or {}).get("live_authentication") or {}
+    live_authenticated = live_authentication.get("authenticated")
+    if connection["status"] == "waiting_for_login" and live_authenticated is True:
+        login_phase = "signed_in_pending_save"
+    else:
+        login_phase = connection["status"]
     return {
         "platform": connection["platform"],
         "status": connection["status"],
+        "loginPhase": login_phase,
         "authorizationUrl": (
             connection.get("app_url")
             if connection["status"] == "waiting_for_login"
@@ -522,6 +541,16 @@ def _browser_connection_response(platform: str, connection: dict | None) -> dict
         ),
         "verifiedAt": connection.get("verified_at"),
         "error": connection.get("error"),
+        "browserSession": ({
+            "status": (live_session or {}).get("status", "unknown"),
+            "authenticationStatus": live_authentication.get("status", "unknown"),
+            "authenticated": live_authenticated,
+            "currentUrl": live_authentication.get("url"),
+        } if connection.get("skyvern_session_id") else None),
+        "durableConnection": {
+            "status": connection["status"],
+            "profileSaved": bool(connection.get("skyvern_profile_id")),
+        },
     }
 
 
@@ -533,9 +562,26 @@ def get_hashnode_browser_connection(request: Request):
 @router.get("/{conn_id}/browser-connection")
 def get_browser_connection(request: Request, conn_id: str):
     _require_browser_extension_id(conn_id)
+    connection = store.get_browser_connection(request.state.user_id, conn_id)
+    live_session = None
+    if (
+        connection
+        and connection["status"] == "waiting_for_login"
+        and connection.get("skyvern_session_id")
+    ):
+        try:
+            live_session = runner.get_browser_login(
+                conn_id, connection["skyvern_session_id"]
+            )
+        except runner.RunnerUnavailable:
+            live_session = {
+                "status": "unknown",
+                "live_authentication": {
+                    "status": "unknown", "authenticated": None, "url": None,
+                },
+            }
     return _browser_connection_response(
-        conn_id,
-        store.get_browser_connection(request.state.user_id, conn_id)
+        conn_id, connection, live_session,
     )
 
 

--- a/cli-runner/blog_extensions/builtin/hashnode.py
+++ b/cli-runner/blog_extensions/builtin/hashnode.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import time
 
 from hashnode_browser import (
     check_hashnode_profile,
@@ -23,6 +24,32 @@ class HashnodeLoginAdapter(BrowserLoginAdapter):
 
     def verify_profile(self, profile_dir: Path) -> dict:
         return check_hashnode_profile(profile_dir=str(profile_dir))
+
+    def verify_live_session(self, probe: dict) -> dict:
+        authenticated = any(
+            cookie.get("present")
+            and str(cookie.get("domain") or "").lstrip(".") == "hashnode.com"
+            and _cookie_is_live(cookie.get("expires"))
+            and (
+                cookie.get("name") in {"authjs.session-token", "hashnode-session"}
+                or str(cookie.get("name") or "").startswith(
+                    "__Secure-authjs.session-token"
+                )
+            )
+            for cookie in probe.get("cookies", [])
+        )
+        return {
+            "authenticated": authenticated,
+            "status": "connected" if authenticated else "login_required",
+        }
+
+
+def _cookie_is_live(expires: object) -> bool:
+    try:
+        value = float(expires)
+    except (TypeError, ValueError):
+        return False
+    return value < 0 or value > time.time()
 
 
 class HashnodeOperationsAdapter(BlogOperationsAdapter):

--- a/cli-runner/blog_extensions/builtin/medium.py
+++ b/cli-runner/blog_extensions/builtin/medium.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import time
 
 from medium_browser import (
     check_medium_profile,
@@ -24,6 +25,28 @@ class MediumLoginAdapter(BrowserLoginAdapter):
 
     def verify_profile(self, profile_dir: Path) -> dict:
         return check_medium_profile(profile_dir=str(profile_dir))
+
+    def verify_live_session(self, probe: dict) -> dict:
+        cookies = {
+            cookie.get("name")
+            for cookie in probe.get("cookies", [])
+            if cookie.get("present")
+            and str(cookie.get("domain") or "").lstrip(".") == "medium.com"
+            and _cookie_is_live(cookie.get("expires"))
+        }
+        authenticated = {"uid", "sid"}.issubset(cookies)
+        return {
+            "authenticated": authenticated,
+            "status": "connected" if authenticated else "login_required",
+        }
+
+
+def _cookie_is_live(expires: object) -> bool:
+    try:
+        value = float(expires)
+    except (TypeError, ValueError):
+        return False
+    return value < 0 or value > time.time()
 
 
 class MediumOperationsAdapter(BlogOperationsAdapter):

--- a/cli-runner/blog_extensions/contracts.py
+++ b/cli-runner/blog_extensions/contracts.py
@@ -112,6 +112,10 @@ class BrowserLoginAdapter(ABC):
     def verify_profile(self, profile_dir: Path) -> dict[str, Any]:
         """Return an authentication result without exposing session material."""
 
+    def verify_live_session(self, probe: dict[str, Any]) -> dict[str, Any]:
+        """Interpret sanitized evidence from a running browser session."""
+        return {"authenticated": False, "status": "login_required"}
+
 
 class BlogOperationsAdapter(ABC):
     """Deterministic Playwright operations against an authenticated page."""

--- a/cli-runner/main.py
+++ b/cli-runner/main.py
@@ -64,6 +64,7 @@ from skyvern_browser import (
     delete_browser_profile,
     finish_browser_login,
     get_browser_login,
+    get_live_browser_probe,
     profile_directory,
     start_browser_login,
 )
@@ -411,9 +412,27 @@ def hashnode_browser_login_status(session_id: str):
 
 @app.get("/browser/{platform}/login/{session_id}")
 def browser_login_status(platform: str, session_id: str):
-    _browser_extension(platform)
+    extension = _browser_extension(platform)
     try:
-        return get_browser_login(session_id, platform)
+        result = get_browser_login(session_id, platform)
+        if result.get("status") == "running":
+            try:
+                probe = get_live_browser_probe(session_id)
+                verification = extension.login.verify_live_session(probe)
+                result["live_authentication"] = {
+                    "status": (
+                        "authenticated"
+                        if verification.get("authenticated")
+                        else "unauthenticated"
+                    ),
+                    "authenticated": bool(verification.get("authenticated")),
+                    "url": probe.get("url"),
+                }
+            except SkyvernUnavailable:
+                result["live_authentication"] = {
+                    "status": "unknown", "authenticated": None, "url": None,
+                }
+        return result
     except ValueError as exc:
         raise HTTPException(422, str(exc)) from exc
     except SkyvernUnavailable as exc:

--- a/cli-runner/requirements.txt
+++ b/cli-runner/requirements.txt
@@ -3,4 +3,5 @@ httpx>=0.27.0
 uvicorn[standard]>=0.29.0
 pydantic>=2.7.0
 patchright==1.62.1
+websockets>=13.1,<16
 markdown-it-py>=3.0.0

--- a/cli-runner/skyvern_browser.py
+++ b/cli-runner/skyvern_browser.py
@@ -1,13 +1,17 @@
 """Small privileged adapter around Skyvern's browser-session API."""
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 import re
+import secrets
 import tomllib
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import quote, urlsplit, urlunsplit
 
 import httpx
+from websockets.exceptions import WebSocketException
+from websockets.sync.client import connect as websocket_connect
 
 
 SKYVERN_URL = os.environ.get("SKYVERN_URL", "http://skyvern:8000").rstrip("/")
@@ -144,6 +148,68 @@ def get_browser_login(session_id: str, platform: str = "hashnode") -> dict:
         "app_url": _public_app_url(session.get("app_url"), session_id, f"{platform}-login"),
         "completed_at": session.get("completed_at"),
     }
+
+
+def get_live_browser_probe(session_id: str) -> dict:
+    """Read sanitized authentication evidence without finalizing the browser."""
+    if not _SESSION_ID.fullmatch(session_id):
+        raise ValueError("Invalid Skyvern session id")
+    try:
+        ui_session = _request("POST", "/api/v1/ui-session")
+        token = ui_session.get("token")
+        if not isinstance(token, str) or not token:
+            raise SkyvernUnavailable("Skyvern UI session token is unavailable")
+        base = urlsplit(SKYVERN_URL)
+        scheme = "wss" if base.scheme == "https" else "ws"
+        client_id = secrets.token_urlsafe(18)
+        query = (
+            f"token={quote('Bearer ' + token, safe='')}"
+            f"&client_id={quote(client_id, safe='')}"
+        )
+        socket_url = urlunsplit((
+            scheme,
+            base.netloc,
+            f"/v1/stream/messages/browser_session/{session_id}",
+            query,
+            "",
+        ))
+        with websocket_connect(
+            socket_url, open_timeout=5, close_timeout=2,
+        ) as websocket:
+            websocket.send('{"kind":"get-login-state"}')
+            for _ in range(5):
+                payload = json.loads(websocket.recv(timeout=10))
+                if payload.get("kind") == "login-state":
+                    return _sanitize_live_probe(payload)
+        raise SkyvernUnavailable("Skyvern live session probe returned no state")
+    except SkyvernUnavailable:
+        raise
+    except (OSError, TimeoutError, ValueError, WebSocketException) as exc:
+        raise SkyvernUnavailable("Skyvern live session probe failed") from exc
+
+
+def _sanitize_live_probe(payload: dict) -> dict:
+    raw_url = str(payload.get("url") or "")
+    parsed = urlsplit(raw_url)
+    host = parsed.hostname or ""
+    if parsed.port is not None:
+        host = f"{host}:{parsed.port}"
+    url = urlunsplit((parsed.scheme, host, parsed.path, "", ""))
+    cookies = []
+    for raw in payload.get("cookies", [])[:256]:
+        if not isinstance(raw, dict):
+            continue
+        name = raw.get("name")
+        domain = raw.get("domain")
+        if not isinstance(name, str) or not isinstance(domain, str):
+            continue
+        cookies.append({
+            "name": name[:256],
+            "domain": domain[:256],
+            "expires": raw.get("expires"),
+            "present": bool(raw.get("present")),
+        })
+    return {"url": url, "cookies": cookies}
 
 
 def get_hashnode_login(session_id: str) -> dict:

--- a/cli-runner/skyvern_browser.py
+++ b/cli-runner/skyvern_browser.py
@@ -155,15 +155,11 @@ def get_live_browser_probe(session_id: str) -> dict:
     if not _SESSION_ID.fullmatch(session_id):
         raise ValueError("Invalid Skyvern session id")
     try:
-        ui_session = _request("POST", "/api/v1/ui-session")
-        token = ui_session.get("token")
-        if not isinstance(token, str) or not token:
-            raise SkyvernUnavailable("Skyvern UI session token is unavailable")
         base = urlsplit(SKYVERN_URL)
         scheme = "wss" if base.scheme == "https" else "ws"
         client_id = secrets.token_urlsafe(18)
         query = (
-            f"token={quote('Bearer ' + token, safe='')}"
+            f"apikey={quote(_api_key(), safe='')}"
             f"&client_id={quote(client_id, safe='')}"
         )
         socket_url = urlunsplit((

--- a/experiments/skyvern/patch_skyvern_for_patchright.py
+++ b/experiments/skyvern/patch_skyvern_for_patchright.py
@@ -9,6 +9,8 @@ SCREENCAST = SKYVERN_ROOT / "forge/sdk/routes/streaming/screencast.py"
 CDP_INPUT = SKYVERN_ROOT / "forge/sdk/routes/streaming/cdp_input.py"
 REAL_BROWSER_STATE = SKYVERN_ROOT / "webeye/real_browser_state.py"
 PERSISTENT_SESSIONS_MANAGER = SKYVERN_ROOT / "webeye/default_persistent_sessions_manager.py"
+MESSAGE_CHANNEL = SKYVERN_ROOT / "forge/sdk/routes/streaming/channels/message.py"
+EXECUTION_CHANNEL = SKYVERN_ROOT / "forge/sdk/routes/streaming/channels/execution.py"
 
 
 def rewrite_imports() -> int:
@@ -550,6 +552,143 @@ def preserve_reused_browser_profile() -> None:
     PERSISTENT_SESSIONS_MANAGER.write_text(source, encoding="utf-8")
 
 
+def add_live_login_probe() -> None:
+    execution = EXECUTION_CHANNEL.read_text(encoding="utf-8")
+    url_import = "from urllib.parse import urlparse\n"
+    if execution.count(url_import) != 1:
+        raise RuntimeError("Pinned execution URL import changed")
+    execution = execution.replace(
+        url_import,
+        "from urllib.parse import urlparse, urlsplit, urlunsplit\n",
+    )
+    method_anchor = '''    async def paste_text(self, text: str) -> None:
+'''
+    method = '''    async def get_login_state(self) -> dict:
+        """Return current-origin credential metadata without credential values."""
+        if not self.page or not self.browser_context:
+            raise RuntimeError(f"{self.class_name} get_login_state: not connected.")
+
+        parsed = urlsplit(self.page.url or "")
+        host = parsed.hostname or ""
+        if parsed.port is not None:
+            host = f"{host}:{parsed.port}"
+        sanitized_url = urlunsplit((parsed.scheme, host, parsed.path, "", ""))
+        origin = self._origin_of(sanitized_url)
+        cookies = await self.browser_context.cookies([origin]) if origin else []
+        return {
+            "url": sanitized_url,
+            "cookies": [
+                {
+                    "name": str(cookie.get("name") or "")[:256],
+                    "domain": str(cookie.get("domain") or "")[:256],
+                    "expires": cookie.get("expires"),
+                    "present": bool(cookie.get("value")),
+                }
+                for cookie in cookies[:256]
+                if cookie.get("name") and cookie.get("domain")
+            ],
+        }
+
+'''
+    if execution.count(method_anchor) != 1:
+        raise RuntimeError("Pinned execution paste method changed")
+    execution = execution.replace(method_anchor, method + method_anchor)
+    EXECUTION_CHANNEL.write_text(execution, encoding="utf-8")
+
+    message = MESSAGE_CHANNEL.read_text(encoding="utf-8")
+    replacements = [
+        (
+            '    GET_BROWSER_URL = "get-browser-url"\n',
+            '    GET_BROWSER_URL = "get-browser-url"\n'
+            '    GET_LOGIN_STATE = "get-login-state"\n'
+            '    LOGIN_STATE = "login-state"\n',
+            "message kind",
+        ),
+        (
+            '    MessageKind.GET_BROWSER_URL,\n',
+            '    MessageKind.GET_BROWSER_URL,\n'
+            '    MessageKind.GET_LOGIN_STATE,\n'
+            '    MessageKind.LOGIN_STATE,\n',
+            "message kind literal",
+        ),
+        (
+            '''@dataclasses.dataclass
+class MessageInNavigate(Message):
+''',
+            '''@dataclasses.dataclass
+class MessageInGetLoginState(Message):
+    kind: t.Literal[MessageKind.GET_LOGIN_STATE] = MessageKind.GET_LOGIN_STATE
+
+
+@dataclasses.dataclass
+class MessageInNavigate(Message):
+''',
+            "login-state input model",
+        ),
+        (
+            '''@dataclasses.dataclass
+class MessageOutScreenshot(Message):
+''',
+            '''@dataclasses.dataclass
+class MessageOutLoginState(Message):
+    kind: t.Literal[MessageKind.LOGIN_STATE] = MessageKind.LOGIN_STATE
+    url: str = ""
+    cookies: list[dict] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass
+class MessageOutScreenshot(Message):
+''',
+            "login-state output model",
+        ),
+        (
+            '    | MessageInGetBrowserUrl\n',
+            '    | MessageInGetBrowserUrl\n    | MessageInGetLoginState\n',
+            "login-state input union",
+        ),
+        (
+            '    MessageOutBrowserUrl\n',
+            '    MessageOutBrowserUrl\n    | MessageOutLoginState\n',
+            "login-state output union",
+        ),
+        (
+            '''        case MessageKind.GET_BROWSER_URL:
+            return MessageInGetBrowserUrl()
+''',
+            '''        case MessageKind.GET_BROWSER_URL:
+            return MessageInGetBrowserUrl()
+        case MessageKind.GET_LOGIN_STATE:
+            return MessageInGetLoginState()
+''',
+            "login-state message parser",
+        ),
+        (
+            '''            case MessageKind.GO_BACK:
+''',
+            '''            case MessageKind.GET_LOGIN_STATE:
+                try:
+                    async with execution_for_message_channel(message_channel) as execute:
+                        state = await execute.get_login_state()
+                        await send(MessageOutLoginState(**state))
+                except Exception:
+                    LOG.exception(
+                        f"{class_name} failed to inspect browser login state.",
+                        **message_channel.identity,
+                    )
+                    await send_error(message.kind, "Failed to inspect browser login state.")
+
+            case MessageKind.GO_BACK:
+''',
+            "login-state message handler",
+        ),
+    ]
+    for anchor, replacement, label in replacements:
+        if message.count(anchor) != 1:
+            raise RuntimeError(f"Pinned {label} anchor changed")
+        message = message.replace(anchor, replacement)
+    MESSAGE_CHANNEL.write_text(message, encoding="utf-8")
+
+
 def main() -> None:
     changed = rewrite_imports()
     if changed < 50:
@@ -559,6 +698,7 @@ def main() -> None:
     add_viewport_sync()
     recover_streaming_page()
     preserve_reused_browser_profile()
+    add_live_login_probe()
     print(f"Rewrote Playwright imports in {changed} Skyvern files")
 
 

--- a/tests/tests_backend/test_blog_extension_runner.py
+++ b/tests/tests_backend/test_blog_extension_runner.py
@@ -48,6 +48,55 @@ def test_login_dispatch_uses_extension_login_url(monkeypatch):
     assert seen["login_url"] == "https://medium.com/m/signin"
 
 
+def test_login_status_includes_live_authentication_without_finalizing(monkeypatch):
+    monkeypatch.setattr(
+        runner_main,
+        "get_browser_login",
+        lambda *_args: {"session_id": "pbs_test", "status": "running"},
+    )
+    monkeypatch.setattr(
+        runner_main,
+        "get_live_browser_probe",
+        lambda *_args: {
+            "url": "https://medium.com/",
+            "cookies": [
+                {"name": "uid", "domain": ".medium.com", "expires": -1, "present": True},
+                {"name": "sid", "domain": ".medium.com", "expires": -1, "present": True},
+            ],
+        },
+    )
+
+    result = runner_main.browser_login_status("medium", "pbs_test")
+
+    assert result["status"] == "running"
+    assert result["live_authentication"] == {
+        "status": "authenticated",
+        "authenticated": True,
+        "url": "https://medium.com/",
+    }
+
+
+def test_login_status_preserves_unknown_probe_state(monkeypatch):
+    monkeypatch.setattr(
+        runner_main,
+        "get_browser_login",
+        lambda *_args: {"session_id": "pbs_test", "status": "running"},
+    )
+    monkeypatch.setattr(
+        runner_main,
+        "get_live_browser_probe",
+        lambda *_args: (_ for _ in ()).throw(
+            runner_main.SkyvernUnavailable("probe failed")
+        ),
+    )
+
+    result = runner_main.browser_login_status("medium", "pbs_test")
+
+    assert result["live_authentication"] == {
+        "status": "unknown", "authenticated": None, "url": None,
+    }
+
+
 def test_public_operation_requires_explicit_approval():
     request = runner_main.BrowserOperationRequest(
         organization_id="o_test",

--- a/tests/tests_backend/test_blog_extensions.py
+++ b/tests/tests_backend/test_blog_extensions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 from pathlib import Path
 import sys
+import time
 
 import pytest
 
@@ -42,6 +43,36 @@ def test_builtin_extensions_satisfy_the_versioned_contract():
     assert [item["platform"] for item in registry.descriptors()] == [
         "hashnode", "medium",
     ]
+
+
+def test_medium_live_session_requires_unexpired_uid_and_sid():
+    login = ExtensionRegistry().get("medium").login
+    expires = time.time() + 3600
+
+    connected = login.verify_live_session({"cookies": [
+        {"name": "uid", "domain": ".medium.com", "expires": expires, "present": True},
+        {"name": "sid", "domain": ".medium.com", "expires": expires, "present": True},
+    ]})
+    expired = login.verify_live_session({"cookies": [
+        {"name": "uid", "domain": ".medium.com", "expires": expires, "present": True},
+        {"name": "sid", "domain": ".medium.com", "expires": time.time() - 1, "present": True},
+    ]})
+
+    assert connected["authenticated"] is True
+    assert expired["authenticated"] is False
+
+
+def test_hashnode_live_session_recognizes_secure_authjs_cookie():
+    login = ExtensionRegistry().get("hashnode").login
+
+    result = login.verify_live_session({"cookies": [{
+        "name": "__Secure-authjs.session-token.0",
+        "domain": ".hashnode.com",
+        "expires": -1,
+        "present": True,
+    }]})
+
+    assert result["authenticated"] is True
 
 
 def test_fixture_loader_builds_normalized_article_input():

--- a/tests/tests_backend/test_browser_connections.py
+++ b/tests/tests_backend/test_browser_connections.py
@@ -23,6 +23,67 @@ def test_browser_extension_capabilities_are_exposed_to_the_ui(client, monkeypatc
     assert "publish" in response.json()["extensions"][0]["capabilities"]
 
 
+def test_browser_connection_distinguishes_live_login_from_saved_profile(
+    client, monkeypatch,
+):
+    store.start_browser_connection(
+        "user_seed", "medium", session_id="pbs_medium",
+        organization_id="o_org", app_url="http://localhost/login",
+    )
+    monkeypatch.setattr(
+        connections_router.runner,
+        "get_browser_login",
+        lambda platform, session_id: {
+            "status": "running",
+            "live_authentication": {
+                "status": "authenticated",
+                "authenticated": True,
+                "url": "https://medium.com/",
+            },
+        },
+    )
+
+    response = client.get("/api/connections/medium/browser-connection")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "waiting_for_login"
+    assert payload["loginPhase"] == "signed_in_pending_save"
+    assert payload["browserSession"] == {
+        "status": "running",
+        "authenticationStatus": "authenticated",
+        "authenticated": True,
+        "currentUrl": "https://medium.com/",
+    }
+    assert payload["durableConnection"] == {
+        "status": "waiting_for_login", "profileSaved": False,
+    }
+
+
+def test_browser_connection_reports_unknown_when_live_probe_is_unavailable(
+    client, monkeypatch,
+):
+    store.start_browser_connection(
+        "user_seed", "medium", session_id="pbs_medium",
+        organization_id="o_org", app_url="http://localhost/login",
+    )
+    monkeypatch.setattr(
+        connections_router.runner,
+        "get_browser_login",
+        lambda *_args: (_ for _ in ()).throw(
+            runner.RunnerUnavailable("probe unavailable")
+        ),
+    )
+
+    payload = client.get(
+        "/api/connections/medium/browser-connection"
+    ).json()
+
+    assert payload["loginPhase"] == "waiting_for_login"
+    assert payload["browserSession"]["authenticationStatus"] == "unknown"
+    assert payload["browserSession"]["authenticated"] is None
+
+
 def test_hashnode_browser_login_persists_only_profile_references(client, monkeypatch):
     monkeypatch.setattr(
         connections_router.runner,

--- a/tests/tests_backend/test_skyvern_browser.py
+++ b/tests/tests_backend/test_skyvern_browser.py
@@ -91,18 +91,20 @@ def test_start_medium_login_uses_medium_signin_url(monkeypatch):
 
 
 def test_live_browser_probe_returns_only_sanitized_evidence(monkeypatch):
+    seen = {}
     socket = FakeWebSocket([
         '{"kind":"login-state","url":"https://user:password@medium.com/?secret=1#fragment",'
         '"cookies":[{"name":"sid","domain":".medium.com","expires":1999999999,'
         '"present":true,"value":"must-not-escape"}]}'
     ])
+    monkeypatch.setattr(skyvern_browser, "_api_key", lambda: "local-api-key")
+
+    def connect(url, **kwargs):
+        seen.update(url=url, kwargs=kwargs)
+        return socket
+
     monkeypatch.setattr(
-        skyvern_browser,
-        "_request",
-        lambda method, path: {"token": "temporary-ui-token"},
-    )
-    monkeypatch.setattr(
-        skyvern_browser, "websocket_connect", lambda *_args, **_kwargs: socket,
+        skyvern_browser, "websocket_connect", connect,
     )
 
     probe = skyvern_browser.get_live_browser_probe("pbs_session123")
@@ -115,7 +117,9 @@ def test_live_browser_probe_returns_only_sanitized_evidence(monkeypatch):
         }],
     }
     assert socket.sent == ['{"kind":"get-login-state"}']
-    assert "temporary-ui-token" not in repr(probe)
+    assert "apikey=local-api-key" in seen["url"]
+    assert "token=" not in seen["url"]
+    assert "local-api-key" not in repr(probe)
     assert "must-not-escape" not in repr(probe)
 
 

--- a/tests/tests_backend/test_skyvern_browser.py
+++ b/tests/tests_backend/test_skyvern_browser.py
@@ -25,6 +25,24 @@ class FakeResponse:
         return self.payload
 
 
+class FakeWebSocket:
+    def __init__(self, messages):
+        self.messages = iter(messages)
+        self.sent = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def send(self, message):
+        self.sent.append(message)
+
+    def recv(self, timeout=None):
+        return next(self.messages)
+
+
 def test_start_login_uses_non_expiring_live_profile_session(monkeypatch):
     seen = {}
 
@@ -70,6 +88,35 @@ def test_start_medium_login_uses_medium_signin_url(monkeypatch):
         "?embed=true&purpose=medium-login"
     )
     assert seen["payload"]["url"] == "https://medium.com/m/signin"
+
+
+def test_live_browser_probe_returns_only_sanitized_evidence(monkeypatch):
+    socket = FakeWebSocket([
+        '{"kind":"login-state","url":"https://user:password@medium.com/?secret=1#fragment",'
+        '"cookies":[{"name":"sid","domain":".medium.com","expires":1999999999,'
+        '"present":true,"value":"must-not-escape"}]}'
+    ])
+    monkeypatch.setattr(
+        skyvern_browser,
+        "_request",
+        lambda method, path: {"token": "temporary-ui-token"},
+    )
+    monkeypatch.setattr(
+        skyvern_browser, "websocket_connect", lambda *_args, **_kwargs: socket,
+    )
+
+    probe = skyvern_browser.get_live_browser_probe("pbs_session123")
+
+    assert probe == {
+        "url": "https://medium.com/",
+        "cookies": [{
+            "name": "sid", "domain": ".medium.com",
+            "expires": 1999999999, "present": True,
+        }],
+    }
+    assert socket.sent == ['{"kind":"get-login-state"}']
+    assert "temporary-ui-token" not in repr(probe)
+    assert "must-not-escape" not in repr(probe)
 
 
 def test_start_login_reuses_identity_provider_profile(monkeypatch):


### PR DESCRIPTION
Closes #108

## Summary
- add a sanitized Skyvern live-session probe with no cookie values
- let blog login extensions verify provider-specific live authentication
- expose browser-session and durable-profile states separately through the connection API
- report `signed_in_pending_save` without finalizing or mutating the active browser session

## Verification
- 31 focused backend tests passed
- patched Skyvern image builds and compiles successfully

The active browser is never closed or finalized by the status probe.