### PR TITLE
feat: complete browser login handoff

### DIFF
--- a/experiments/skyvern/patch_skyvern_for_patchright.py
+++ b/experiments/skyvern/patch_skyvern_for_patchright.py
@@ -107,8 +107,6 @@ def set_viewer_device_scale(entity_id: str, scale: float) -> None:
 '''
     state_replacement = state_anchor + '''    hidpi_capture_in_flight = False
     last_hidpi_capture_at = 0.0
-    hashnode_login_streak = 0
-    hashnode_login_complete = False
 '''
     if source.count(state_anchor) != 1:
         raise RuntimeError("Pinned screencast state anchor changed")
@@ -229,59 +227,17 @@ def set_viewer_device_scale(entity_id: str, scale: float) -> None:
 
     forwarding_anchor = '''    async def _frame_forwarding_loop() -> None:
 '''
-    capture_loop = '''    async def _refresh_hashnode_login_state() -> None:
-        nonlocal hashnode_login_streak, hashnode_login_complete
-        page = attached_page
-        if entity_type != "browser_session" or page is None:
-            hashnode_login_streak = 0
-            hashnode_login_complete = False
-            return
-        try:
-            cookies = await page.context.cookies(["https://hashnode.com/"])
-            authenticated = any(
-                bool(cookie.get("value"))
-                and (
-                    cookie.get("name") in {"authjs.session-token", "hashnode-session"}
-                    or str(cookie.get("name", "")).startswith("__Secure-authjs.session-token")
-                )
-                for cookie in cookies
-            )
-        except Exception:
-            authenticated = False
-        hashnode_login_streak = hashnode_login_streak + 1 if authenticated else 0
-        # OAuth callbacks can briefly expose a session cookie before the app
-        # rejects it. Require a sustained authenticated state before replacing
-        # the browser with BlogHub's success message.
-        current_url = str(getattr(page, "url", "") or "").lower()
-        outside_login = not any(part in current_url for part in ("/login", "/signin", "/onboard"))
-        hashnode_login_complete = hashnode_login_streak >= 20 and outside_login
-
-    async def _capture_polling_loop() -> None:
+    capture_loop = '''    async def _capture_polling_loop() -> None:
         while True:
             session = cdp_session
             if session is not None:
                 await _capture_hidpi_frame(session)
-            await _refresh_hashnode_login_state()
             await asyncio.sleep(0.5)
 
 '''
     if source.count(forwarding_anchor) != 1:
         raise RuntimeError("Pinned frame forwarding loop changed")
     source = source.replace(forwarding_anchor, capture_loop + forwarding_anchor)
-
-    url_anchor = '''                try:
-                    current_url = getattr(attached_page, "url", "") or ""
-                except Exception:
-                    pass
-'''
-    url_replacement = url_anchor + '''            if hashnode_login_complete and current_url.startswith(
-                ("https://hashnode.com/", "https://www.hashnode.com/")
-            ):
-                current_url = current_url.split("#", 1)[0] + "#bloghub-authenticated"
-'''
-    if source.count(url_anchor) != 1:
-        raise RuntimeError("Pinned screencast URL forwarding changed")
-    source = source.replace(url_anchor, url_replacement)
 
     task_anchor = '''        forward_task = asyncio.create_task(_frame_forwarding_loop())
         poll_task = asyncio.create_task(_completion_polling_loop())

--- a/experiments/skyvern/patch_skyvern_ui.cjs
+++ b/experiments/skyvern/patch_skyvern_ui.cjs
@@ -119,41 +119,8 @@ if (browserSession.split(backendWaitMessage).length !== 2) {
 }
 browserSession = browserSession.replace(backendWaitMessage, "Starting the browser.");
 
-const readyState = "const H=u.length>0;return";
-const readyStateWithLogin =
-  "const H=u.length>0,Q=blogHubHashnodeLoginComplete(y);return";
-const streamRender = "H?i.jsx(q5e,{";
-const streamRenderWithLogin =
-  "Q?i.jsx(blogHubHashnodeLoginCompleteView,{}):H?i.jsx(q5e,{";
-if (
-  browserSession.split(readyState).length !== 2 ||
-  browserSession.split(streamRender).length !== 2
-) {
-  throw new Error("Pinned Skyvern browser-session render changed");
-}
-browserSession = browserSession
-  .replace(readyState, readyStateWithLogin)
-  .replace(streamRender, streamRenderWithLogin);
-
-const loginCompleteHelpers = `function blogHubHashnodeLoginComplete(t){
-  if(new URLSearchParams(window.location.search).get("purpose")!=="hashnode-login")return false;
-  try{
-    const e=new URL(t),n=e.hostname.toLowerCase();
-    return(n==="hashnode.com"||n==="www.hashnode.com")&&e.hash==="#bloghub-authenticated";
-  }catch{return false}
-}
-function blogHubHashnodeLoginCompleteView(){
-  return i.jsx("main",{style:{minHeight:"100vh",display:"grid",placeItems:"center",background:"#0d0f14",color:"#e7eaf2",fontFamily:"Inter,ui-sans-serif,system-ui,sans-serif"},children:i.jsxs("section",{style:{width:"min(460px,calc(100vw - 48px))",textAlign:"center"},children:[
-    i.jsx("div",{style:{display:"inline-block",marginBottom:"18px",padding:"6px 10px",border:"1px solid #2f7d4a",borderRadius:"5px",color:"#71d892",fontSize:"12px",fontWeight:700},children:"Signed in"}),
-    i.jsx("h1",{style:{margin:"0 0 12px",fontSize:"28px",lineHeight:1.2,fontWeight:700},children:"Hashnode login successful"}),
-    i.jsx("p",{style:{margin:"0 auto 24px",color:"#9aa3b7",fontSize:"15px",lineHeight:1.6},children:"Close this tab to save and verify the browser profile, then return to BlogHub."}),
-    i.jsx("button",{type:"button",onClick:()=>window.close(),style:{padding:"10px 18px",border:0,borderRadius:"5px",background:"#6366f1",color:"#fff",font:"inherit",fontWeight:600,cursor:"pointer"},children:"Close tab"})
-  ]})})
-}`;
-
 source =
   source.slice(0, browserSessionStart) +
-  loginCompleteHelpers +
   browserSession +
   source.slice(browserSessionEnd);
 
@@ -180,4 +147,62 @@ const digest = crypto.createHash("sha256").update(source).digest("hex").slice(0,
 const patchedBundleName = bundleName.replace(/\.js$/, `-bloghub-${digest}.js`);
 fs.renameSync(bundle, path.join(assets, patchedBundleName));
 indexHtml = indexHtml.replace(`assets/${bundleName}`, `assets/${patchedBundleName}`);
+const handoffScript = `<script>(()=>{
+  const params=new URLSearchParams(window.location.search);
+  const purpose=params.get("purpose")||"";
+  const platform=purpose.endsWith("-login")?purpose.slice(0,-6):"";
+  if(!["hashnode","medium"].includes(platform))return;
+  let returnOrigin="";
+  try{
+    const parsed=new URL(params.get("returnOrigin")||"");
+    if(parsed.protocol==="http:"||parsed.protocol==="https:")returnOrigin=parsed.origin;
+  }catch{}
+  if(!returnOrigin)return;
+
+  const notify=()=>window.opener?.postMessage({
+    type:"bloghub-browser-login-ready",platform
+  },returnOrigin);
+  notify();
+  const heartbeat=window.setInterval(notify,1000);
+
+  function showConfirmation(){
+    if(document.getElementById("bloghub-login-complete"))return;
+    const label=platform==="medium"?"Medium":"Hashnode";
+    const overlay=document.createElement("main");
+    overlay.id="bloghub-login-complete";
+    overlay.setAttribute("role","status");
+    overlay.style.cssText="position:fixed;inset:0;z-index:2147483647;display:grid;place-items:center;background:#0d0f14;color:#e7eaf2;font-family:Inter,ui-sans-serif,system-ui,sans-serif";
+    const content=document.createElement("section");
+    content.style.cssText="width:min(460px,calc(100vw - 48px));text-align:center";
+    const badge=document.createElement("div");
+    badge.textContent="Signed in";
+    badge.style.cssText="display:inline-block;margin-bottom:18px;padding:6px 10px;border:1px solid #2f7d4a;border-radius:5px;color:#71d892;font-size:12px;font-weight:700";
+    const title=document.createElement("h1");
+    title.textContent=label+" login successful";
+    title.style.cssText="margin:0 0 12px;font-size:28px;line-height:1.2;font-weight:700";
+    const copy=document.createElement("p");
+    copy.textContent="Close this tab to save and verify the browser profile, then return to BlogHub.";
+    copy.style.cssText="margin:0 auto 24px;color:#9aa3b7;font-size:15px;line-height:1.6";
+    const button=document.createElement("button");
+    button.type="button";
+    button.textContent="Close tab";
+    button.style.cssText="padding:10px 18px;border:0;border-radius:5px;background:#6366f1;color:#fff;font:inherit;font-weight:600;cursor:pointer";
+    button.addEventListener("click",()=>window.close());
+    content.append(badge,title,copy,button);
+    overlay.append(content);
+    document.body.append(overlay);
+  }
+
+  window.addEventListener("message",event=>{
+    if(event.source!==window.opener||event.origin!==returnOrigin)return;
+    const data=event.data||{};
+    if(data.type!=="bloghub-browser-login-state"||data.platform!==platform)return;
+    if(data.loginPhase==="signed_in_pending_save")showConfirmation();
+  });
+  window.addEventListener("beforeunload",()=>window.clearInterval(heartbeat));
+})();</script>`;
+if (!indexHtml.includes("</body>")) {
+  throw new Error("Pinned Skyvern UI document body changed");
+}
+indexHtml = indexHtml.replace("</body>", `${handoffScript}</body>`);
 fs.writeFileSync(indexPath, indexHtml);

--- a/screens/settings/v2.html
+++ b/screens/settings/v2.html
@@ -222,6 +222,7 @@ const _platformSync = {
 };
 let _browserLoginTabs = {};
 let _browserLoginTabTimers = {};
+let _browserLoginPolls = {};
 const _authTimers = new Map();
 
 const AUTH_STATES = {
@@ -408,12 +409,14 @@ function browserPlatformCard(conn) {
   const apiConnected = conn.status === 'connected';
   const browserConnection = _browserConnections[id] || { platform: id, status: 'disconnected' };
   const browserStatus = browserConnection.status || 'disconnected';
+  const loginPhase = browserConnection.loginPhase || browserStatus;
   const browserConnected = browserStatus === 'connected';
   const connected = apiConnected || browserConnected;
   const waiting = ['waiting_for_login', 'verifying'].includes(browserStatus) && !apiConnected;
+  const signedInPendingSave = loginPhase === 'signed_in_pending_save' && !apiConnected;
   const failed = browserStatus === 'failed' && !apiConnected;
-  const statusColor = connected ? '#4ade80' : waiting ? '#fbbf24' : failed ? '#f87171' : '#5a6080';
-  const statusLabel = connected ? 'Connected' : waiting
+  const statusColor = connected || signedInPendingSave ? '#4ade80' : waiting ? '#fbbf24' : failed ? '#f87171' : '#5a6080';
+  const statusLabel = connected ? 'Connected' : signedInPendingSave ? 'Signed in · close tab' : waiting
     ? (browserStatus === 'verifying' ? 'Verifying login' : 'Finish signing in')
     : failed ? 'Login failed' : 'Not connected';
   const tokenMethod = id === 'hashnode' ? 'API token · Hashnode Plus' : 'Integration token';
@@ -421,6 +424,7 @@ function browserPlatformCard(conn) {
     ? tokenMethod : browserConnected
     ? 'Browser login · Persistent profile' : '';
   const helper = connected ? (browserConnected ? 'Browser session verified' : 'Token stored securely')
+    : signedInPendingSave ? `Close the ${conn.label} login tab to save and verify this connection.`
     : waiting ? `Close the login tab after ${conn.label} confirms sign-in.`
     : failed ? esc(browserConnection.error || `${conn.label} sign-in was not completed.`)
     : 'Choose API token or browser login.';
@@ -546,22 +550,60 @@ function createBrowserLoginTab(url='about:blank') {
 function browserLoginUrl(id, url) {
   const target = new URL(url, window.location.href);
   target.searchParams.set('purpose', `${id}-login`);
+  target.searchParams.set('returnOrigin', window.location.origin);
   return target.href;
+}
+
+function browserLoginOrigin(id) {
+  const url = _browserConnections[id]?.authorizationUrl;
+  if (!url) return null;
+  try { return new URL(url, window.location.href).origin; }
+  catch { return null; }
+}
+
+function notifyBrowserLoginTab(id, tab) {
+  const origin = browserLoginOrigin(id);
+  if (!tab || tab.closed || !origin) return;
+  tab.postMessage({
+    type: 'bloghub-browser-login-state',
+    platform: id,
+    loginPhase: _browserConnections[id]?.loginPhase || _browserConnections[id]?.status || 'unknown',
+  }, origin);
+}
+
+async function refreshBrowserLoginState(id, tab) {
+  if (_browserLoginPolls[id]) return;
+  _browserLoginPolls[id] = true;
+  try {
+    const res = await fetch(`/api/connections/${id}/browser-connection`);
+    if (res.ok) {
+      _browserConnections[id] = await res.json();
+      renderPlatforms(_connections.filter(c => c.type === 'blog'));
+      notifyBrowserLoginTab(id, tab);
+    }
+  } catch { /* Keep the browser available while a transient probe fails. */ }
+  finally { _browserLoginPolls[id] = false; }
 }
 
 function watchBrowserLoginTab(id, tab) {
   if (_browserLoginTabTimers[id]) clearInterval(_browserLoginTabTimers[id]);
   _browserLoginTabs[id] = tab;
   if (!tab) return;
-  _browserLoginTabTimers[id] = setInterval(() => {
-    if (!tab.closed) return;
+  notifyBrowserLoginTab(id, tab);
+  _browserLoginTabTimers[id] = setInterval(async () => {
+    if (!tab.closed) {
+      await refreshBrowserLoginState(id, tab);
+      return;
+    }
     clearInterval(_browserLoginTabTimers[id]);
     _browserLoginTabTimers[id] = null;
     _browserLoginTabs[id] = null;
-    if (_browserConnections[id]?.status === 'waiting_for_login') {
+    if (['waiting_for_login', 'signed_in_pending_save'].includes(
+      _browserConnections[id]?.loginPhase || _browserConnections[id]?.status
+    )) {
       completeBrowserLogin(id);
     }
-  }, 500);
+  }, 750);
 }
 
 async function startBrowserLogin(id) {
@@ -601,10 +643,11 @@ function openBrowserLogin(id) {
 }
 
 async function completeBrowserLogin(id) {
-  _browserConnections[id] = { ..._browserConnections[id], status: 'verifying' };
+  _browserConnections[id] = {
+    ..._browserConnections[id], status: 'verifying', loginPhase: 'verifying',
+  };
   if (_browserLoginTabTimers[id]) clearInterval(_browserLoginTabTimers[id]);
   _browserLoginTabTimers[id] = null;
-  _browserLoginTabs[id]?.close();
   _browserLoginTabs[id] = null;
   renderPlatforms(_connections.filter(c => c.type === 'blog'));
   try {
@@ -647,6 +690,14 @@ async function disconnectBrowserPlatformConnection(id, method) {
   if (method === 'browser' || method === 'both') await disconnectBrowserPlatform(id);
   if (method === 'api' || method === 'both') await doDisconnect(id);
 }
+
+window.addEventListener('message', (event) => {
+  const id = event.data?.platform;
+  if (event.data?.type !== 'bloghub-browser-login-ready' || !BROWSER_LOGIN_PLATFORMS.has(id)) return;
+  if (event.origin !== browserLoginOrigin(id)) return;
+  _browserLoginTabs[id] = event.source;
+  watchBrowserLoginTab(id, event.source);
+});
 
 // ─── CliProviderCard C ─────────────────────────────────────────────────────────
 function renderAI(conns) {

--- a/tests/settings.spec.js
+++ b/tests/settings.spec.js
@@ -180,6 +180,99 @@ test.describe('Settings screen', () => {
     );
   });
 
+  test('Medium live login waits for user close and survives Settings reload', async ({ page, context }) => {
+    let completeRequests = 0;
+    let started = false;
+    const authorizationUrl = 'http://localhost:8000/health';
+    await page.route('**/api/connections/medium/browser-connection/complete', route => {
+      completeRequests += 1;
+      return route.fulfill({ json: {
+        platform: 'medium', status: 'connected', authorizationUrl: null,
+      }});
+    });
+    await page.route('**/api/connections/medium/browser-connection', route => {
+      if (route.request().method() === 'GET' && !started) {
+        return route.fulfill({ json: {
+          platform: 'medium', status: 'disconnected', loginPhase: 'disconnected',
+          authorizationUrl: null, verifiedAt: null, error: null,
+        }});
+      }
+      if (route.request().method() === 'POST') started = true;
+      const loginPhase = route.request().method() === 'POST'
+        ? 'waiting_for_login' : 'signed_in_pending_save';
+      return route.fulfill({
+        status: route.request().method() === 'POST' ? 201 : 200,
+        json: {
+          platform: 'medium', status: 'waiting_for_login', loginPhase,
+          authorizationUrl, verifiedAt: null, error: null,
+        },
+      });
+    });
+    await page.reload();
+
+    const loginTabPromise = context.waitForEvent('page');
+    const card = page.locator('#plat-card-medium');
+    await card.getByRole('button', { name: 'Connect' }).click();
+    await card.getByRole('button', { name: /Browser login/ }).click();
+    const loginTab = await loginTabPromise;
+    await loginTab.waitForURL('**/health?*');
+
+    await expect(card.getByText('Signed in · close tab', { exact: true })).toBeVisible();
+    expect(loginTab.isClosed()).toBe(false);
+    expect(completeRequests).toBe(0);
+
+    await page.reload();
+    await expect(page.locator('#plat-card-medium').getByText(
+      'Signed in · close tab', { exact: true },
+    )).toBeVisible();
+    await loginTab.evaluate(origin => window.opener.postMessage({
+      type: 'bloghub-browser-login-ready', platform: 'medium',
+    }, origin), 'http://localhost:8000');
+    await loginTab.close();
+
+    await expect(page.locator('#plat-card-medium').getByText(
+      'Connected', { exact: true },
+    )).toBeVisible();
+    expect(completeRequests).toBe(1);
+  });
+
+  test('Skyvern shows the provider-neutral handoff until the user closes it', async ({ page }) => {
+    test.skip(!process.env.BLOGHUB_SKYVERN_UI_URL, 'Patched Skyvern UI is opt-in.');
+    await page.goto('http://localhost:8000/health');
+    await page.evaluate(() => {
+      window.addEventListener('message', event => {
+        if (event.data?.type !== 'bloghub-browser-login-ready') return;
+        event.source.postMessage({
+          type: 'bloghub-browser-login-state',
+          platform: event.data.platform,
+          loginPhase: 'signed_in_pending_save',
+        }, event.origin);
+      });
+    });
+    const skyvernUrl = new URL(
+      '/browser-session/pbs_test/stream', process.env.BLOGHUB_SKYVERN_UI_URL,
+    );
+    skyvernUrl.searchParams.set('purpose', 'medium-login');
+    skyvernUrl.searchParams.set('returnOrigin', 'http://localhost:8000');
+
+    const popupPromise = page.waitForEvent('popup');
+    await page.evaluate(url => window.open(url, '_blank'), skyvernUrl.href);
+    const popup = await popupPromise;
+    await expect(popup.getByRole('heading', {
+      name: 'Medium login successful',
+    })).toBeVisible();
+    await expect(popup.getByText(
+      'Close this tab to save and verify the browser profile, then return to BlogHub.',
+      { exact: true },
+    )).toBeVisible();
+    expect(popup.isClosed()).toBe(false);
+
+    const closed = popup.waitForEvent('close');
+    await popup.getByRole('button', { name: 'Close tab' }).click();
+    await closed;
+    expect(popup.isClosed()).toBe(true);
+  });
+
   // ── 3. Browser login flow ────────────────────────────────────────────────────
 
   /**

--- a/tests/tests_ui/screens/test_settings.py
+++ b/tests/tests_ui/screens/test_settings.py
@@ -34,14 +34,19 @@ def _hashnode_browser_payload(status="disconnected", authorization_url=None):
     }
 
 
-def _browser_payload(platform, status="disconnected", authorization_url=None):
-    return {
+def _browser_payload(
+    platform, status="disconnected", authorization_url=None, login_phase=None,
+):
+    payload = {
         "platform": platform,
         "status": status,
         "authorizationUrl": authorization_url,
         "verifiedAt": None,
         "error": None,
     }
+    if login_phase is not None:
+        payload["loginPhase"] = login_phase
+    return payload
 
 
 def _show_disconnected_hashnode(page):
@@ -119,7 +124,9 @@ def test_hashnode_browser_login_opens_normal_tab(settings_page, context):
                 ),
             )
         else:
-            route.fulfill(json=_hashnode_browser_payload())
+            route.fulfill(json=_hashnode_browser_payload(
+                "waiting_for_login", f"{BASE_URL}/health",
+            ))
 
     page.route(
         f"{BASE_URL}/api/connections/hashnode/browser-connection",
@@ -141,7 +148,12 @@ def test_hashnode_browser_login_opens_normal_tab(settings_page, context):
         card.get_by_role("button", name=re.compile(r"Browser login")).click()
 
     login_tab = login_tab_info.value
-    login_tab.wait_for_url(f"{BASE_URL}/health?purpose=hashnode-login")
+    login_tab.wait_for_url(f"{BASE_URL}/health?*")
+    login_query = parse_qs(urlparse(login_tab.url).query)
+    assert login_query == {
+        "purpose": ["hashnode-login"],
+        "returnOrigin": [BASE_URL],
+    }
     open_call = page.evaluate("window.__hashnodeOpenCalls[0]")
     assert open_call == ["about:blank", "_blank"]
     assert page.get_by_role("button", name="I've signed in").count() == 0
@@ -164,6 +176,77 @@ def test_hashnode_browser_login_opens_normal_tab(settings_page, context):
     card.get_by_text("Connected", exact=True).wait_for(timeout=5000)
     card.get_by_text("Browser login · Persistent profile", exact=True).wait_for()
     assert login_tab.is_closed()
+
+
+def test_live_medium_login_waits_for_user_close_and_recovers_after_reload(
+    settings_page, context,
+):
+    page = settings_page
+    authorization_url = f"{BASE_URL}/health"
+    requests_seen = {"complete": 0, "started": False}
+
+    def browser_connection(route):
+        if route.request.method == "GET" and not requests_seen["started"]:
+            route.fulfill(json=_browser_payload(
+                "medium", "disconnected", login_phase="disconnected",
+            ))
+            return
+        if route.request.method == "POST":
+            requests_seen["started"] = True
+            route.fulfill(
+                status=201,
+                json=_browser_payload(
+                    "medium", "waiting_for_login", authorization_url,
+                    "waiting_for_login",
+                ),
+            )
+            return
+        route.fulfill(json=_browser_payload(
+            "medium", "waiting_for_login", authorization_url,
+            "signed_in_pending_save",
+        ))
+
+    def complete_connection(route):
+        requests_seen["complete"] += 1
+        route.fulfill(json=_browser_payload("medium", "connected"))
+
+    page.route(
+        f"{BASE_URL}/api/connections/medium/browser-connection/complete",
+        complete_connection,
+    )
+    page.route(
+        f"{BASE_URL}/api/connections/medium/browser-connection",
+        browser_connection,
+    )
+    page.reload()
+
+    with context.expect_page() as login_tab_info:
+        card = page.locator("#plat-card-medium")
+        card.get_by_role("button", name="Connect").click()
+        card.get_by_role("button", name=re.compile(r"Browser login")).click()
+
+    login_tab = login_tab_info.value
+    login_tab.wait_for_url(f"{BASE_URL}/health?*")
+    card.get_by_text("Signed in · close tab", exact=True).wait_for(timeout=5000)
+    assert not login_tab.is_closed()
+    assert requests_seen["complete"] == 0
+
+    page.reload()
+    page.locator("#plat-card-medium").get_by_text(
+        "Signed in · close tab", exact=True,
+    ).wait_for(timeout=5000)
+    login_tab.evaluate(
+        """origin => window.opener.postMessage({
+          type: 'bloghub-browser-login-ready', platform: 'medium'
+        }, origin)""",
+        BASE_URL,
+    )
+    login_tab.close()
+
+    page.locator("#plat-card-medium").get_by_text(
+        "Connected", exact=True,
+    ).wait_for(timeout=5000)
+    assert requests_seen["complete"] == 1
 
 
 def test_hashnode_connected_card_offers_sync_and_disconnect(page):


### PR DESCRIPTION
Closes #109

Stacked on #110.

## Summary
- poll the backend-derived live login phase while the Skyvern tab remains open
- show a provider-neutral Medium or Hashnode success screen inside Skyvern
- require the user to close the tab before BlogHub finalizes and saves the profile
- recover the tab-to-Settings handoff after a Settings reload
- remove the old Hashnode-only URL-fragment completion heuristic

## Verification
- complete Settings Playwright suite: 9 passed, 1 opt-in live test skipped
- explicit Skyvern handoff browser test passed
- patched Skyvern backend and UI images both build successfully
- original `bloghub40` stack and authenticated Medium session remained running throughout