### PR TITLE
feat: observe and finalize browser login sessions

### DIFF
--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -28,7 +28,7 @@ import re
 import httpx
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, Response
 
 import backend.services.cli_runner as runner
 import backend.services.connection_auth as agent_auth
@@ -582,6 +582,37 @@ def get_browser_connection(request: Request, conn_id: str):
             }
     return _browser_connection_response(
         conn_id, connection, live_session,
+    )
+
+
+@router.get("/{conn_id}/browser-connection/screenshot")
+def export_browser_connection_screenshot(request: Request, conn_id: str):
+    _require_browser_extension_id(conn_id)
+    connection = store.get_browser_connection(request.state.user_id, conn_id)
+    if (
+        not connection
+        or connection["status"] != "waiting_for_login"
+        or not connection.get("skyvern_session_id")
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail=f"No active {conn_id.title()} browser login is available",
+        )
+    try:
+        screenshot = runner.capture_browser_screenshot(
+            conn_id, connection["skyvern_session_id"]
+        )
+    except runner.RunnerUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return Response(
+        content=screenshot,
+        media_type="image/png",
+        headers={
+            "Cache-Control": "no-store",
+            "Content-Disposition": (
+                f'attachment; filename="bloghub-{conn_id}-browser.png"'
+            ),
+        },
     )
 
 

--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -669,8 +669,26 @@ def complete_browser_connection(request: Request, conn_id: str):
             organization_id=connection.get("skyvern_organization_id"),
         )
     except runner.RunnerUnavailable as exc:
-        store.update_browser_connection(user_id, conn_id, "failed", error=str(exc))
+        current = store.get_browser_connection(user_id, conn_id)
+        if (
+            current
+            and current.get("skyvern_session_id") == connection["skyvern_session_id"]
+            and current["status"] == "verifying"
+        ):
+            store.update_browser_connection(user_id, conn_id, "failed", error=str(exc))
         raise HTTPException(status_code=503, detail=str(exc)) from exc
+    current = store.get_browser_connection(user_id, conn_id)
+    if (
+        not current
+        or current.get("skyvern_session_id") != connection["skyvern_session_id"]
+        or current["status"] != "verifying"
+    ):
+        if result.get("profile_id"):
+            try:
+                runner.delete_browser_profile(conn_id, result["profile_id"])
+            except runner.RunnerUnavailable:
+                pass
+        return _browser_connection_response(conn_id, None)
     if not result.get("authenticated"):
         failed = store.update_browser_connection(
             user_id, conn_id, "failed",
@@ -704,7 +722,11 @@ def disconnect_hashnode_browser_connection(request: Request):
 def disconnect_browser_connection(request: Request, conn_id: str):
     _require_browser_extension_id(conn_id)
     connection = store.get_browser_connection(request.state.user_id, conn_id)
-    if connection and connection.get("skyvern_session_id") and connection["status"] == "waiting_for_login":
+    if (
+        connection
+        and connection.get("skyvern_session_id")
+        and connection["status"] == "waiting_for_login"
+    ):
         try:
             runner.cancel_browser_login(conn_id, connection["skyvern_session_id"])
         except runner.RunnerUnavailable as exc:

--- a/backend/services/cli_runner.py
+++ b/backend/services/cli_runner.py
@@ -348,6 +348,25 @@ def get_browser_login(platform: str, session_id: str) -> dict:
     return _get(f"/browser/{platform}/login/{session_id}")
 
 
+def capture_browser_screenshot(platform: str, session_id: str) -> bytes:
+    try:
+        with _client() as client:
+            response = client.get(
+                f"/browser/{platform}/login/{session_id}/screenshot",
+                timeout=httpx.Timeout(connect=3, read=30, write=10, pool=5),
+            )
+            response.raise_for_status()
+            if response.headers.get("content-type", "").split(";", 1)[0] != "image/png":
+                raise RunnerUnavailable("Browser runner returned an invalid screenshot")
+            if len(response.content) > 12 * 1024 * 1024:
+                raise RunnerUnavailable("Browser runner screenshot exceeds the size limit")
+            return response.content
+    except RunnerUnavailable:
+        raise
+    except (httpx.ConnectError, httpx.HTTPStatusError, httpx.ReadTimeout) as exc:
+        raise RunnerUnavailable(f"Browser login runner unavailable: {exc}") from exc
+
+
 def get_hashnode_browser_login(session_id: str) -> dict:
     return get_browser_login("hashnode", session_id)
 

--- a/backend/store/backends/sqlite.py
+++ b/backend/store/backends/sqlite.py
@@ -484,11 +484,12 @@ class SQLiteStore(
         return [self._load_article(r) for r in rows], total
 
     def get_article(self, user_id: str, article_id: str) -> dict | None:
-        row = self._con.execute(
-            "SELECT * FROM articles WHERE id=? AND user_id=? AND archived_at IS NULL",
-            (article_id, user_id),
-        ).fetchone()
-        return self._load_article(row) if row else None
+        with self._workspace_lock.acquire():
+            row = self._con.execute(
+                "SELECT * FROM articles WHERE id=? AND user_id=? AND archived_at IS NULL",
+                (article_id, user_id),
+            ).fetchone()
+            return self._load_article(row) if row else None
 
     def create_article(
         self,

--- a/backend/store/locking.py
+++ b/backend/store/locking.py
@@ -13,20 +13,33 @@ class WorkspaceLock:
         self._path = Path(path).resolve()
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._thread_lock = threading.RLock()
+        self._local = threading.local()
 
     @contextmanager
     def acquire(self) -> Iterator[None]:
         with self._thread_lock:
+            depth = getattr(self._local, "depth", 0)
+            if depth:
+                self._local.depth = depth + 1
+                try:
+                    yield
+                finally:
+                    self._local.depth -= 1
+                return
             with self._path.open("a+b") as handle:
                 if handle.tell() == 0 and handle.seek(0, os.SEEK_END) == 0:
                     handle.write(b"0")
                     handle.flush()
                 handle.seek(0)
                 self._lock(handle)
+                self._local.depth = 1
                 try:
                     yield
                 finally:
-                    self._unlock(handle)
+                    try:
+                        self._unlock(handle)
+                    finally:
+                        self._local.depth = 0
 
     @staticmethod
     def _lock(handle) -> None:

--- a/cli-runner/main.py
+++ b/cli-runner/main.py
@@ -46,7 +46,7 @@ _SECRET_REDACTIONS = (
 )
 
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import StreamingResponse
+from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel, Field
 
 from blog_extensions import (
@@ -60,6 +60,7 @@ from blog_extensions import (
 from blog_extensions.runtime import execute_operation
 from skyvern_browser import (
     SkyvernUnavailable,
+    capture_browser_screenshot,
     close_browser_login,
     delete_browser_profile,
     finish_browser_login,
@@ -437,6 +438,22 @@ def browser_login_status(platform: str, session_id: str):
         raise HTTPException(422, str(exc)) from exc
     except SkyvernUnavailable as exc:
         raise HTTPException(503, _safe_reason(str(exc))) from exc
+
+
+@app.get("/browser/{platform}/login/{session_id}/screenshot")
+def browser_login_screenshot(platform: str, session_id: str):
+    _browser_extension(platform)
+    try:
+        screenshot = capture_browser_screenshot(session_id)
+    except ValueError as exc:
+        raise HTTPException(422, str(exc)) from exc
+    except SkyvernUnavailable as exc:
+        raise HTTPException(503, _safe_reason(str(exc))) from exc
+    return Response(
+        content=screenshot,
+        media_type="image/png",
+        headers={"Cache-Control": "no-store"},
+    )
 
 
 @app.delete("/browser/hashnode/login/{session_id}")

--- a/cli-runner/skyvern_browser.py
+++ b/cli-runner/skyvern_browser.py
@@ -1,11 +1,14 @@
 """Small privileged adapter around Skyvern's browser-session API."""
 from __future__ import annotations
 
+import base64
+import binascii
 import json
 import os
 from pathlib import Path
 import re
 import secrets
+import struct
 import tomllib
 from urllib.parse import quote, urlsplit, urlunsplit
 
@@ -32,6 +35,12 @@ _ORG_ID = re.compile(r"^o_[A-Za-z0-9]+$")
 
 class SkyvernUnavailable(RuntimeError):
     pass
+
+
+_SCREENSHOT_MAX_BYTES = 12 * 1024 * 1024
+_SCREENSHOT_MAX_DIMENSION = 4096
+_SCREENSHOT_MAX_PIXELS = 16_000_000
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
 
 def _api_key() -> str:
@@ -182,6 +191,71 @@ def get_live_browser_probe(session_id: str) -> dict:
         raise
     except (OSError, TimeoutError, ValueError, WebSocketException) as exc:
         raise SkyvernUnavailable("Skyvern live session probe failed") from exc
+
+
+def capture_browser_screenshot(session_id: str) -> bytes:
+    """Capture one bounded PNG frame without mutating or closing the session."""
+    if not _SESSION_ID.fullmatch(session_id):
+        raise ValueError("Invalid Skyvern session id")
+    session = get_browser_login(session_id)
+    if session.get("status") != "running":
+        raise SkyvernUnavailable("Skyvern browser session is not running")
+    base = urlsplit(SKYVERN_URL)
+    scheme = "wss" if base.scheme == "https" else "ws"
+    socket_url = urlunsplit((
+        scheme,
+        base.netloc,
+        f"/v1/stream/browser_sessions/{session_id}",
+        f"apikey={quote(_api_key(), safe='')}",
+        "",
+    ))
+    try:
+        with websocket_connect(
+            socket_url,
+            open_timeout=5,
+            close_timeout=2,
+            max_size=(_SCREENSHOT_MAX_BYTES * 2),
+        ) as websocket:
+            for _ in range(10):
+                payload = json.loads(websocket.recv(timeout=15))
+                if not isinstance(payload, dict):
+                    raise SkyvernUnavailable("Skyvern returned an invalid screenshot")
+                encoded = payload.get("screenshot")
+                if not encoded:
+                    continue
+                if payload.get("format") != "png" or not isinstance(encoded, str):
+                    raise SkyvernUnavailable("Skyvern returned an invalid screenshot")
+                if len(encoded) > ((_SCREENSHOT_MAX_BYTES + 2) // 3) * 4:
+                    raise SkyvernUnavailable("Skyvern screenshot exceeds the size limit")
+                try:
+                    screenshot = base64.b64decode(encoded, validate=True)
+                except (ValueError, binascii.Error) as exc:
+                    raise SkyvernUnavailable("Skyvern returned an invalid screenshot") from exc
+                _validate_screenshot_png(screenshot)
+                return screenshot
+        raise SkyvernUnavailable("Skyvern screenshot stream returned no frame")
+    except SkyvernUnavailable:
+        raise
+    except (OSError, TimeoutError, ValueError, WebSocketException) as exc:
+        raise SkyvernUnavailable("Skyvern screenshot capture failed") from exc
+
+
+def _validate_screenshot_png(screenshot: bytes) -> None:
+    if len(screenshot) > _SCREENSHOT_MAX_BYTES:
+        raise SkyvernUnavailable("Skyvern screenshot exceeds the size limit")
+    if len(screenshot) < 24 or not screenshot.startswith(_PNG_SIGNATURE):
+        raise SkyvernUnavailable("Skyvern returned an invalid screenshot")
+    if screenshot[12:16] != b"IHDR":
+        raise SkyvernUnavailable("Skyvern returned an invalid screenshot")
+    width, height = struct.unpack(">II", screenshot[16:24])
+    if (
+        not width
+        or not height
+        or width > _SCREENSHOT_MAX_DIMENSION
+        or height > _SCREENSHOT_MAX_DIMENSION
+        or width * height > _SCREENSHOT_MAX_PIXELS
+    ):
+        raise SkyvernUnavailable("Skyvern screenshot dimensions exceed the limit")
 
 
 def _sanitize_live_probe(payload: dict) -> dict:

--- a/contracts/settings.ts
+++ b/contracts/settings.ts
@@ -132,7 +132,7 @@ export interface SubmitCodeRequest {
  * GET  /api/connections/{id}/cli-login-status    → CliLoginStatus
  * GET  /api/connections/{id}/browser-connection  → browser profile status
  * POST /api/connections/{id}/browser-connection  → start Skyvern browser login
- * POST /api/connections/{id}/browser-connection/complete → verify closed login tab
+ * POST /api/connections/{id}/browser-connection/complete → save and verify detected login
  *
  * CLI runner (port 8001, not called directly by the UI):
  * POST /auth/{provider}/login                    → LoginResponse (includes device_code)

--- a/docs/blog-extensions.md
+++ b/docs/blog-extensions.md
@@ -88,6 +88,19 @@ Use `GET /browser/extensions` on the runner or
 `GET /api/connections/browser-extensions` on the backend to discover installed
 platforms and capabilities. Clients should hide actions that are not declared.
 
+## Active-session diagnostics
+
+An authenticated BlogHub user can export the current rendered frame of their
+active platform login with
+`GET /api/connections/{platform}/browser-connection/screenshot`. The response is
+a bounded PNG attachment with `Cache-Control: no-store`. Capture is
+provider-neutral and does not close or finalize the Skyvern session.
+
+The image is a point-in-time diagnostic artifact. It contains only visible page
+pixels and is not a durable browser profile, login credential, or replacement
+for completing the browser handoff. The endpoint is unavailable after the
+active login session has been finalized or disconnected.
+
 ## Test contract
 
 Extensions can import `assert_extension_contract` and `article_from_fixture`

--- a/experiments/skyvern/patch_skyvern_ui.cjs
+++ b/experiments/skyvern/patch_skyvern_ui.cjs
@@ -165,27 +165,49 @@ const handoffScript = `<script>(()=>{
   notify();
   const heartbeat=window.setInterval(notify,1000);
 
-  function showConfirmation(){
-    if(document.getElementById("bloghub-login-complete"))return;
+  function showConfirmation(loginPhase){
     const label=platform==="medium"?"Medium":"Hashnode";
-    const overlay=document.createElement("main");
+    let overlay=document.getElementById("bloghub-login-complete");
+    if(overlay){
+      const badge=overlay.querySelector("[data-login-badge]");
+      const title=overlay.querySelector("[data-login-title]");
+      const copy=overlay.querySelector("[data-login-copy]");
+      const button=overlay.querySelector("button");
+      if(loginPhase==="connected"){
+        badge.textContent="Connected";
+        title.textContent=label+" connected";
+        copy.textContent="Your connection is saved and verified. You can close this tab and return to BlogHub.";
+        button.hidden=false;
+      }else if(loginPhase==="failed"){
+        badge.textContent="Not connected";
+        title.textContent=label+" verification failed";
+        copy.textContent="Return to BlogHub to review the error and retry.";
+        button.hidden=false;
+      }
+      return;
+    }
+    overlay=document.createElement("main");
     overlay.id="bloghub-login-complete";
     overlay.setAttribute("role","status");
     overlay.style.cssText="position:fixed;inset:0;z-index:2147483647;display:grid;place-items:center;background:#0d0f14;color:#e7eaf2;font-family:Inter,ui-sans-serif,system-ui,sans-serif";
     const content=document.createElement("section");
     content.style.cssText="width:min(460px,calc(100vw - 48px));text-align:center";
     const badge=document.createElement("div");
-    badge.textContent="Signed in";
+    badge.dataset.loginBadge="";
+    badge.textContent="Sign-in detected";
     badge.style.cssText="display:inline-block;margin-bottom:18px;padding:6px 10px;border:1px solid #2f7d4a;border-radius:5px;color:#71d892;font-size:12px;font-weight:700";
     const title=document.createElement("h1");
-    title.textContent=label+" login successful";
+    title.dataset.loginTitle="";
+    title.textContent="Saving "+label+" login";
     title.style.cssText="margin:0 0 12px;font-size:28px;line-height:1.2;font-weight:700";
     const copy=document.createElement("p");
-    copy.textContent="Close this tab to save and verify the browser profile, then return to BlogHub.";
+    copy.dataset.loginCopy="";
+    copy.textContent="BlogHub is saving and verifying the browser profile. Keep this tab open for a moment.";
     copy.style.cssText="margin:0 auto 24px;color:#9aa3b7;font-size:15px;line-height:1.6";
     const button=document.createElement("button");
     button.type="button";
     button.textContent="Close tab";
+    button.hidden=true;
     button.style.cssText="padding:10px 18px;border:0;border-radius:5px;background:#6366f1;color:#fff;font:inherit;font-weight:600;cursor:pointer";
     button.addEventListener("click",()=>window.close());
     content.append(badge,title,copy,button);
@@ -197,7 +219,9 @@ const handoffScript = `<script>(()=>{
     if(event.source!==window.opener||event.origin!==returnOrigin)return;
     const data=event.data||{};
     if(data.type!=="bloghub-browser-login-state"||data.platform!==platform)return;
-    if(data.loginPhase==="signed_in_pending_save")showConfirmation();
+    if(["signed_in_pending_save","verifying","connected","failed"].includes(data.loginPhase)){
+      showConfirmation(data.loginPhase);
+    }
   });
   window.addEventListener("beforeunload",()=>window.clearInterval(heartbeat));
 })();</script>`;

--- a/screens/settings/v2.html
+++ b/screens/settings/v2.html
@@ -223,6 +223,8 @@ const _platformSync = {
 let _browserLoginTabs = {};
 let _browserLoginTabTimers = {};
 let _browserLoginPolls = {};
+let _browserLoginCompletions = {};
+let _browserLoginCompletionControllers = {};
 const _authTimers = new Map();
 
 const AUTH_STATES = {
@@ -412,20 +414,20 @@ function browserPlatformCard(conn) {
   const loginPhase = browserConnection.loginPhase || browserStatus;
   const browserConnected = browserStatus === 'connected';
   const connected = apiConnected || browserConnected;
-  const waiting = ['waiting_for_login', 'verifying'].includes(browserStatus) && !apiConnected;
-  const signedInPendingSave = loginPhase === 'signed_in_pending_save' && !apiConnected;
+  const finalizing = ['signed_in_pending_save', 'verifying'].includes(loginPhase) && !apiConnected;
+  const waiting = browserStatus === 'waiting_for_login' && !apiConnected && !finalizing;
   const failed = browserStatus === 'failed' && !apiConnected;
-  const statusColor = connected || signedInPendingSave ? '#4ade80' : waiting ? '#fbbf24' : failed ? '#f87171' : '#5a6080';
-  const statusLabel = connected ? 'Connected' : signedInPendingSave ? 'Signed in · close tab' : waiting
-    ? (browserStatus === 'verifying' ? 'Verifying login' : 'Finish signing in')
+  const statusColor = connected ? '#4ade80' : finalizing || waiting ? '#fbbf24' : failed ? '#f87171' : '#5a6080';
+  const statusLabel = connected ? 'Connected' : finalizing ? 'Verifying login' : waiting
+    ? 'Finish signing in'
     : failed ? 'Login failed' : 'Not connected';
   const tokenMethod = id === 'hashnode' ? 'API token · Hashnode Plus' : 'Integration token';
   const method = apiConnected && browserConnected ? 'Token + browser login' : apiConnected
     ? tokenMethod : browserConnected
     ? 'Browser login · Persistent profile' : '';
   const helper = connected ? (browserConnected ? 'Browser session verified' : 'Token stored securely')
-    : signedInPendingSave ? `Close the ${conn.label} login tab to save and verify this connection.`
-    : waiting ? `Close the login tab after ${conn.label} confirms sign-in.`
+    : finalizing ? 'Saving and verifying the browser profile.'
+    : waiting ? `${conn.label} will connect automatically after sign-in.`
     : failed ? esc(browserConnection.error || `${conn.label} sign-in was not completed.`)
     : 'Choose API token or browser login.';
 
@@ -438,6 +440,9 @@ function browserPlatformCard(conn) {
       style="font-size:11px;padding:4px 10px;border-radius:4px;border:1px solid #252a38;background:transparent;color:#c9cfe0;cursor:${syncState.status === 'running' ? 'wait' : 'pointer'};font-family:inherit;">${syncState.status === 'running' ? 'Syncing…' : 'Sync articles'}</button>` : '';
     actions = `${syncAction}<button onclick="disconnectBrowserPlatformConnection('${id}', '${connectedMethod}')"
       style="font-size:11px;color:#f87171;background:transparent;border:none;cursor:pointer;font-family:inherit;">Disconnect</button>`;
+  } else if (finalizing) {
+    actions = `<button onclick="disconnectBrowserPlatform('${id}')"
+      style="font-size:11px;color:#f87171;background:transparent;border:none;cursor:pointer;font-family:inherit;">Cancel</button>`;
   } else if (waiting) {
     actions = `<button onclick="openBrowserLogin('${id}')"
       style="font-size:11px;padding:4px 10px;border-radius:4px;border:1px solid #252a38;background:transparent;color:#c9cfe0;cursor:pointer;font-family:inherit;">Open login</button>
@@ -454,7 +459,7 @@ function browserPlatformCard(conn) {
   const tokenBadge = id === 'hashnode'
     ? '<span style="font-size:9px;font-weight:600;color:#a5b4fc;border:1px solid #3b4670;border-radius:3px;padding:2px 5px;">PLUS</span>'
     : '';
-  const methodMenu = !connected && !waiting && _browserMethodMenus[id] ? `
+  const methodMenu = !connected && !waiting && !finalizing && _browserMethodMenus[id] ? `
     <div class="browser-methods" id="${id}-method-menu">
       <button class="browser-method" onclick="chooseBrowserPlatformApiToken('${id}')">
         <span style="width:30px;height:30px;border-radius:5px;background:#1d2945;color:#7fa4ff;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;">API</span>
@@ -561,8 +566,8 @@ function browserLoginOrigin(id) {
   catch { return null; }
 }
 
-function notifyBrowserLoginTab(id, tab) {
-  const origin = browserLoginOrigin(id);
+function notifyBrowserLoginTab(id, tab, knownOrigin = null) {
+  const origin = knownOrigin || browserLoginOrigin(id);
   if (!tab || tab.closed || !origin) return;
   tab.postMessage({
     type: 'bloghub-browser-login-state',
@@ -580,6 +585,9 @@ async function refreshBrowserLoginState(id, tab) {
       _browserConnections[id] = await res.json();
       renderPlatforms(_connections.filter(c => c.type === 'blog'));
       notifyBrowserLoginTab(id, tab);
+      if (_browserConnections[id]?.loginPhase === 'signed_in_pending_save') {
+        void completeBrowserLogin(id, tab);
+      }
     }
   } catch { /* Keep the browser available while a transient probe fails. */ }
   finally { _browserLoginPolls[id] = false; }
@@ -642,30 +650,50 @@ function openBrowserLogin(id) {
   }
 }
 
-async function completeBrowserLogin(id) {
-  _browserConnections[id] = {
-    ..._browserConnections[id], status: 'verifying', loginPhase: 'verifying',
-  };
-  if (_browserLoginTabTimers[id]) clearInterval(_browserLoginTabTimers[id]);
-  _browserLoginTabTimers[id] = null;
-  _browserLoginTabs[id] = null;
-  renderPlatforms(_connections.filter(c => c.type === 'blog'));
-  try {
-    const res = await fetch(`/api/connections/${id}/browser-connection/complete`, { method: 'POST' });
-    if (res.status === 401) {
-      redirectToLogin();
-      return;
+function completeBrowserLogin(id, tab = _browserLoginTabs[id]) {
+  if (_browserLoginCompletions[id]) return _browserLoginCompletions[id];
+  const origin = browserLoginOrigin(id);
+  const controller = new AbortController();
+  _browserLoginCompletionControllers[id] = controller;
+  const completion = (async () => {
+    _browserConnections[id] = {
+      ..._browserConnections[id], status: 'verifying', loginPhase: 'verifying',
+    };
+    renderPlatforms(_connections.filter(c => c.type === 'blog'));
+    notifyBrowserLoginTab(id, tab, origin);
+    try {
+      const res = await fetch(`/api/connections/${id}/browser-connection/complete`, {
+        method: 'POST', signal: controller.signal,
+      });
+      if (res.status === 401) {
+        redirectToLogin();
+        return;
+      }
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.detail || `HTTP ${res.status}`);
+      _browserConnections[id] = data;
+    } catch (error) {
+      if (error.name === 'AbortError') return;
+      _browserConnections[id] = {
+        platform: id, status: 'failed', loginPhase: 'failed', error: error.message,
+      };
     }
-    const data = await res.json();
-    if (!res.ok) throw new Error(data.detail || `HTTP ${res.status}`);
-    _browserConnections[id] = data;
-  } catch (error) {
-    _browserConnections[id] = { platform: id, status: 'failed', error: error.message };
-  }
-  renderPlatforms(_connections.filter(c => c.type === 'blog'));
+    renderPlatforms(_connections.filter(c => c.type === 'blog'));
+    updateCount(_connections);
+    notifyBrowserLoginTab(id, tab, origin);
+  })();
+  _browserLoginCompletions[id] = completion.finally(() => {
+    delete _browserLoginCompletions[id];
+    if (_browserLoginCompletionControllers[id] === controller) {
+      delete _browserLoginCompletionControllers[id];
+    }
+  });
+  return _browserLoginCompletions[id];
 }
 
 async function disconnectBrowserPlatform(id) {
+  _browserLoginCompletionControllers[id]?.abort();
+  delete _browserLoginCompletionControllers[id];
   if (_browserLoginTabTimers[id]) clearInterval(_browserLoginTabTimers[id]);
   _browserLoginTabTimers[id] = null;
   _browserLoginTabs[id]?.close();

--- a/tests/settings.spec.js
+++ b/tests/settings.spec.js
@@ -180,17 +180,25 @@ test.describe('Settings screen', () => {
     );
   });
 
-  test('Medium live login waits for user close and survives Settings reload', async ({ page, context }) => {
+  test('Medium live login finalizes automatically while the tab stays open', async ({ page, context }) => {
     let completeRequests = 0;
     let started = false;
+    let completed = false;
     const authorizationUrl = 'http://localhost:8000/health';
     await page.route('**/api/connections/medium/browser-connection/complete', route => {
       completeRequests += 1;
+      completed = true;
       return route.fulfill({ json: {
-        platform: 'medium', status: 'connected', authorizationUrl: null,
+        platform: 'medium', status: 'connected', loginPhase: 'connected', authorizationUrl: null,
       }});
     });
     await page.route('**/api/connections/medium/browser-connection', route => {
+      if (route.request().method() === 'GET' && completed) {
+        return route.fulfill({ json: {
+          platform: 'medium', status: 'connected', loginPhase: 'connected',
+          authorizationUrl: null, verifiedAt: '2026-08-20T08:00:00Z', error: null,
+        }});
+      }
       if (route.request().method() === 'GET' && !started) {
         return route.fulfill({ json: {
           platform: 'medium', status: 'disconnected', loginPhase: 'disconnected',
@@ -217,26 +225,42 @@ test.describe('Settings screen', () => {
     const loginTab = await loginTabPromise;
     await loginTab.waitForURL('**/health?*');
 
-    await expect(card.getByText('Signed in · close tab', { exact: true })).toBeVisible();
+    await expect(card.getByText('Connected', { exact: true })).toBeVisible();
+    expect(completeRequests).toBe(1);
     expect(loginTab.isClosed()).toBe(false);
-    expect(completeRequests).toBe(0);
 
     await page.reload();
     await expect(page.locator('#plat-card-medium').getByText(
-      'Signed in · close tab', { exact: true },
-    )).toBeVisible();
-    await loginTab.evaluate(origin => window.opener.postMessage({
-      type: 'bloghub-browser-login-ready', platform: 'medium',
-    }, origin), 'http://localhost:8000');
-    await loginTab.close();
-
-    await expect(page.locator('#plat-card-medium').getByText(
       'Connected', { exact: true },
     )).toBeVisible();
-    expect(completeRequests).toBe(1);
+    await loginTab.close();
   });
 
-  test('Skyvern shows the provider-neutral handoff until the user closes it', async ({ page }) => {
+  test('a stuck verifying login can be canceled', async ({ page }) => {
+    let canceled = false;
+    await page.route('**/api/connections/medium/browser-connection', route => {
+      if (route.request().method() === 'DELETE') {
+        canceled = true;
+        return route.fulfill({ json: {
+          platform: 'medium', status: 'disconnected', loginPhase: 'disconnected',
+        }});
+      }
+      return route.fulfill({ json: {
+        platform: 'medium', status: 'verifying', loginPhase: 'verifying',
+        authorizationUrl: null, verifiedAt: null, error: null,
+      }});
+    });
+    await page.reload();
+
+    const card = page.locator('#plat-card-medium');
+    await expect(card.getByText('Verifying login', { exact: true })).toBeVisible();
+    await card.getByRole('button', { name: 'Cancel' }).click();
+
+    expect(canceled).toBe(true);
+    await expect(card.getByText('Not connected', { exact: true })).toBeVisible();
+  });
+
+  test('Skyvern confirms automatic handoff and leaves closure to the user', async ({ page }) => {
     test.skip(!process.env.BLOGHUB_SKYVERN_UI_URL, 'Patched Skyvern UI is opt-in.');
     await page.goto('http://localhost:8000/health');
     await page.evaluate(() => {
@@ -247,6 +271,11 @@ test.describe('Settings screen', () => {
           platform: event.data.platform,
           loginPhase: 'signed_in_pending_save',
         }, event.origin);
+        setTimeout(() => event.source.postMessage({
+          type: 'bloghub-browser-login-state',
+          platform: event.data.platform,
+          loginPhase: 'connected',
+        }, event.origin), 50);
       });
     });
     const skyvernUrl = new URL(
@@ -259,10 +288,10 @@ test.describe('Settings screen', () => {
     await page.evaluate(url => window.open(url, '_blank'), skyvernUrl.href);
     const popup = await popupPromise;
     await expect(popup.getByRole('heading', {
-      name: 'Medium login successful',
+      name: 'Medium connected',
     })).toBeVisible();
     await expect(popup.getByText(
-      'Close this tab to save and verify the browser profile, then return to BlogHub.',
+      'Your connection is saved and verified. You can close this tab and return to BlogHub.',
       { exact: true },
     )).toBeVisible();
     expect(popup.isClosed()).toBe(false);

--- a/tests/tests_backend/test_blog_extension_runner.py
+++ b/tests/tests_backend/test_blog_extension_runner.py
@@ -97,6 +97,19 @@ def test_login_status_preserves_unknown_probe_state(monkeypatch):
     }
 
 
+def test_browser_login_screenshot_returns_non_cacheable_png(monkeypatch):
+    screenshot = b"\x89PNG\r\n\x1a\ncurrent-frame"
+    monkeypatch.setattr(
+        runner_main, "capture_browser_screenshot", lambda *_args: screenshot,
+    )
+
+    response = runner_main.browser_login_screenshot("medium", "pbs_test")
+
+    assert response.body == screenshot
+    assert response.media_type == "image/png"
+    assert response.headers["cache-control"] == "no-store"
+
+
 def test_public_operation_requires_explicit_approval():
     request = runner_main.BrowserOperationRequest(
         organization_id="o_test",

--- a/tests/tests_backend/test_browser_connections.py
+++ b/tests/tests_backend/test_browser_connections.py
@@ -202,6 +202,59 @@ def test_hashnode_browser_login_rejects_unverified_profile(client, monkeypatch):
     assert persisted["skyvern_profile_id"] == "bp_failed"
 
 
+def test_verifying_browser_login_can_be_canceled_immediately(client, monkeypatch):
+    store.start_browser_connection(
+        "user_seed", "medium", session_id="pbs_verifying",
+        organization_id="o_org", app_url="http://localhost/login",
+    )
+    store.update_browser_connection("user_seed", "medium", "verifying")
+    canceled = []
+    monkeypatch.setattr(
+        connections_router.runner,
+        "cancel_browser_login",
+        lambda *args: canceled.append(args),
+    )
+
+    response = client.delete("/api/connections/medium/browser-connection")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "disconnected"
+    assert store.get_browser_connection("user_seed", "medium") is None
+    assert canceled == []
+
+
+def test_canceled_login_discards_a_late_completion_result(client, monkeypatch):
+    store.start_browser_connection(
+        "user_seed", "medium", session_id="pbs_late",
+        organization_id="o_org", app_url="http://localhost/login",
+    )
+    deleted_profiles = []
+
+    def complete_after_cancel(*_args, **_kwargs):
+        store.delete_browser_connection("user_seed", "medium")
+        return {
+            "authenticated": True,
+            "profile_id": "bp_late",
+            "organization_id": "o_org",
+        }
+
+    monkeypatch.setattr(
+        connections_router.runner, "complete_browser_login", complete_after_cancel,
+    )
+    monkeypatch.setattr(
+        connections_router.runner,
+        "delete_browser_profile",
+        lambda platform, profile_id: deleted_profiles.append((platform, profile_id)),
+    )
+
+    response = client.post("/api/connections/medium/browser-connection/complete")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "disconnected"
+    assert deleted_profiles == [("medium", "bp_late")]
+    assert store.get_browser_connection("user_seed", "medium") is None
+
+
 def test_hashnode_browser_retry_reuses_provider_session_profile(client, monkeypatch):
     store.start_browser_connection(
         "user_seed", "hashnode", session_id="pbs_previous",

--- a/tests/tests_backend/test_browser_connections.py
+++ b/tests/tests_backend/test_browser_connections.py
@@ -84,6 +84,54 @@ def test_browser_connection_reports_unknown_when_live_probe_is_unavailable(
     assert payload["browserSession"]["authenticated"] is None
 
 
+def test_active_browser_connection_exports_screenshot(client, monkeypatch):
+    screenshot = b"\x89PNG\r\n\x1a\ncurrent-frame"
+    store.start_browser_connection(
+        "user_seed", "medium", session_id="pbs_medium",
+        organization_id="o_org", app_url="http://localhost/login",
+    )
+    seen = []
+    monkeypatch.setattr(
+        connections_router.runner,
+        "capture_browser_screenshot",
+        lambda platform, session_id: seen.append((platform, session_id)) or screenshot,
+    )
+
+    response = client.get(
+        "/api/connections/medium/browser-connection/screenshot"
+    )
+
+    assert response.status_code == 200
+    assert response.content == screenshot
+    assert response.headers["content-type"] == "image/png"
+    assert response.headers["cache-control"] == "no-store"
+    assert response.headers["content-disposition"] == (
+        'attachment; filename="bloghub-medium-browser.png"'
+    )
+    assert seen == [("medium", "pbs_medium")]
+
+
+def test_browser_screenshot_requires_owned_active_session(client, monkeypatch):
+    other = store.create_user("other@example.com", "password-hash")
+    store.start_browser_connection(
+        other["id"], "medium", session_id="pbs_foreign",
+        organization_id="o_other", app_url="http://localhost/foreign",
+    )
+    called = []
+    monkeypatch.setattr(
+        connections_router.runner,
+        "capture_browser_screenshot",
+        lambda *_args: called.append(True) or b"unexpected",
+    )
+
+    response = client.get(
+        "/api/connections/medium/browser-connection/screenshot"
+    )
+
+    assert response.status_code == 409
+    assert called == []
+
+
 def test_hashnode_browser_login_persists_only_profile_references(client, monkeypatch):
     monkeypatch.setattr(
         connections_router.runner,

--- a/tests/tests_backend/test_skyvern_browser.py
+++ b/tests/tests_backend/test_skyvern_browser.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import base64
 import importlib.util
+import json
 from pathlib import Path
+import struct
+
+import pytest
 
 
 RUNNER = Path(__file__).resolve().parents[2] / "cli-runner"
@@ -41,6 +46,15 @@ class FakeWebSocket:
 
     def recv(self, timeout=None):
         return next(self.messages)
+
+
+def _png(width=1920, height=1200, payload=b""):
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + b"\x00\x00\x00\x0dIHDR"
+        + struct.pack(">II", width, height)
+        + payload
+    )
 
 
 def test_start_login_uses_non_expiring_live_profile_session(monkeypatch):
@@ -121,6 +135,80 @@ def test_live_browser_probe_returns_only_sanitized_evidence(monkeypatch):
     assert "token=" not in seen["url"]
     assert "local-api-key" not in repr(probe)
     assert "must-not-escape" not in repr(probe)
+
+
+def test_browser_screenshot_exports_a_bounded_png(monkeypatch):
+    screenshot = _png(payload=b"current-frame")
+    socket = FakeWebSocket([
+        json.dumps({"status": "running"}),
+        json.dumps({
+            "status": "running",
+            "format": "png",
+            "screenshot": base64.b64encode(screenshot).decode(),
+        }),
+    ])
+    seen = {}
+    monkeypatch.setattr(
+        skyvern_browser,
+        "get_browser_login",
+        lambda *_args: {"status": "running"},
+    )
+    monkeypatch.setattr(skyvern_browser, "_api_key", lambda: "local-api-key")
+
+    def connect(url, **kwargs):
+        seen.update(url=url, kwargs=kwargs)
+        return socket
+
+    monkeypatch.setattr(skyvern_browser, "websocket_connect", connect)
+
+    assert skyvern_browser.capture_browser_screenshot("pbs_session123") == screenshot
+    assert "/v1/stream/browser_sessions/pbs_session123" in seen["url"]
+    assert "apikey=local-api-key" in seen["url"]
+    assert seen["kwargs"]["max_size"] == skyvern_browser._SCREENSHOT_MAX_BYTES * 2
+
+
+def test_browser_screenshot_rejects_malformed_png(monkeypatch):
+    socket = FakeWebSocket([json.dumps({
+        "status": "running",
+        "format": "png",
+        "screenshot": base64.b64encode(b"not-a-png").decode(),
+    })])
+    monkeypatch.setattr(
+        skyvern_browser,
+        "get_browser_login",
+        lambda *_args: {"status": "running"},
+    )
+    monkeypatch.setattr(skyvern_browser, "_api_key", lambda: "key")
+    monkeypatch.setattr(
+        skyvern_browser, "websocket_connect", lambda *_args, **_kwargs: socket,
+    )
+
+    with pytest.raises(
+        skyvern_browser.SkyvernUnavailable, match="invalid screenshot"
+    ):
+        skyvern_browser.capture_browser_screenshot("pbs_session123")
+
+
+def test_browser_screenshot_rejects_oversized_dimensions(monkeypatch):
+    socket = FakeWebSocket([json.dumps({
+        "status": "running",
+        "format": "png",
+        "screenshot": base64.b64encode(_png(width=5000, height=1200)).decode(),
+    })])
+    monkeypatch.setattr(
+        skyvern_browser,
+        "get_browser_login",
+        lambda *_args: {"status": "running"},
+    )
+    monkeypatch.setattr(skyvern_browser, "_api_key", lambda: "key")
+    monkeypatch.setattr(
+        skyvern_browser, "websocket_connect", lambda *_args, **_kwargs: socket,
+    )
+
+    with pytest.raises(
+        skyvern_browser.SkyvernUnavailable, match="dimensions exceed"
+    ):
+        skyvern_browser.capture_browser_screenshot("pbs_session123")
 
 
 def test_start_login_reuses_identity_provider_profile(monkeypatch):

--- a/tests/tests_backend/test_store/test_locking.py
+++ b/tests/tests_backend/test_store/test_locking.py
@@ -1,0 +1,12 @@
+from backend.store.locking import WorkspaceLock
+
+
+def test_workspace_lock_is_reentrant_within_a_thread(tmp_path):
+    lock = WorkspaceLock(tmp_path / "workspace.lock")
+    nested = False
+
+    with lock.acquire():
+        with lock.acquire():
+            nested = True
+
+    assert nested

--- a/tests/tests_ui/screens/test_settings.py
+++ b/tests/tests_ui/screens/test_settings.py
@@ -178,14 +178,19 @@ def test_hashnode_browser_login_opens_normal_tab(settings_page, context):
     assert login_tab.is_closed()
 
 
-def test_live_medium_login_waits_for_user_close_and_recovers_after_reload(
+def test_live_medium_login_finalizes_automatically_and_survives_reload(
     settings_page, context,
 ):
     page = settings_page
     authorization_url = f"{BASE_URL}/health"
-    requests_seen = {"complete": 0, "started": False}
+    requests_seen = {"complete": 0, "started": False, "completed": False}
 
     def browser_connection(route):
+        if route.request.method == "GET" and requests_seen["completed"]:
+            route.fulfill(json=_browser_payload(
+                "medium", "connected", login_phase="connected",
+            ))
+            return
         if route.request.method == "GET" and not requests_seen["started"]:
             route.fulfill(json=_browser_payload(
                 "medium", "disconnected", login_phase="disconnected",
@@ -208,6 +213,7 @@ def test_live_medium_login_waits_for_user_close_and_recovers_after_reload(
 
     def complete_connection(route):
         requests_seen["complete"] += 1
+        requests_seen["completed"] = True
         route.fulfill(json=_browser_payload("medium", "connected"))
 
     page.route(
@@ -227,26 +233,45 @@ def test_live_medium_login_waits_for_user_close_and_recovers_after_reload(
 
     login_tab = login_tab_info.value
     login_tab.wait_for_url(f"{BASE_URL}/health?*")
-    card.get_by_text("Signed in · close tab", exact=True).wait_for(timeout=5000)
+    card.get_by_text("Connected", exact=True).wait_for(timeout=5000)
     assert not login_tab.is_closed()
-    assert requests_seen["complete"] == 0
+    assert requests_seen["complete"] == 1
 
     page.reload()
     page.locator("#plat-card-medium").get_by_text(
-        "Signed in · close tab", exact=True,
-    ).wait_for(timeout=5000)
-    login_tab.evaluate(
-        """origin => window.opener.postMessage({
-          type: 'bloghub-browser-login-ready', platform: 'medium'
-        }, origin)""",
-        BASE_URL,
-    )
-    login_tab.close()
-
-    page.locator("#plat-card-medium").get_by_text(
         "Connected", exact=True,
     ).wait_for(timeout=5000)
+    login_tab.close()
     assert requests_seen["complete"] == 1
+
+
+def test_stuck_verifying_login_can_be_canceled(settings_page):
+    page = settings_page
+    canceled = {"value": False}
+
+    def browser_connection(route):
+        if route.request.method == "DELETE":
+            canceled["value"] = True
+            route.fulfill(json=_browser_payload(
+                "medium", "disconnected", login_phase="disconnected",
+            ))
+            return
+        route.fulfill(json=_browser_payload(
+            "medium", "verifying", login_phase="verifying",
+        ))
+
+    page.route(
+        f"{BASE_URL}/api/connections/medium/browser-connection",
+        browser_connection,
+    )
+    page.reload()
+
+    card = page.locator("#plat-card-medium")
+    card.get_by_text("Verifying login", exact=True).wait_for(timeout=5000)
+    card.get_by_role("button", name="Cancel").click()
+
+    assert canceled["value"] is True
+    card.get_by_text("Not connected", exact=True).wait_for(timeout=5000)
 
 
 def test_hashnode_connected_card_offers_sync_and_disconnect(page):


### PR DESCRIPTION
Closes #112

Stacked on #111.

## Summary

- export one bounded PNG frame from an active Skyvern browser session without closing it
- distinguish live Skyvern authentication from the durable BlogHub connection state
- finalize browser login automatically as soon as fresh authentication is detected
- keep the provider tab open through profile persistence and show a connected confirmation afterward
- provide Cancel during verification and prevent late completion responses from reconnecting a canceled account
- reject missing, finalized, foreign, malformed, oversized, and over-dimensioned screenshot captures

## Verification

- 13 focused browser-connection backend tests passed
- focused Playwright automatic-handoff flow passed
- focused Playwright stuck-verification cancellation flow passed
- Skyvern UI patch passed Node syntax validation
- live Medium and Hashnode sessions finalized with saved profiles
- authoritative Settings state transitions updated in amadou-6e/specs#3
