### PR TITLE
feat: sync connected browser platforms automatically

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -45,6 +45,8 @@ def startup_cleanup():
     store.delete_expired_sessions()
     store.expire_connection_auth_flows()
     store.recover_orphaned_jobs()
+    store.ensure_connected_sync_schedules(interval_seconds=60)
+    store.enqueue_due_sync_jobs()
     store.recover_agent_sessions()
     store.cleanup_agent_sessions(
         retention_days=int(os.environ.get("BLOGHUB_AGENT_SESSION_RETENTION_DAYS", "90"))

--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -61,11 +61,37 @@ _BLOG_IDS = {"medium", "hashnode", "devto"}
 _CLI_IDS = {"anthropic", "openai"}
 _PROVIDER_MAP = {"anthropic": "anthropic", "openai": "openai"}
 _BROWSER_EXTENSION_ID = re.compile(r"^[a-z][a-z0-9_.-]{1,79}$")
+_BROWSER_SYNC_INTERVAL_SECONDS = 15 * 60
 
 
 def _require_browser_extension_id(platform: str) -> None:
     if not _BROWSER_EXTENSION_ID.fullmatch(platform):
         raise HTTPException(status_code=400, detail="Invalid browser extension id")
+
+
+def _ensure_browser_sync(user_id: str, platform: str, session_id: str) -> None:
+    schedules = store.list_sync_schedules(user_id)
+    schedule = next(
+        (item for item in schedules if item["platform"] == platform), None
+    )
+    if (
+        schedule is None
+        or not schedule["enabled"]
+        or schedule["interval_seconds"] != _BROWSER_SYNC_INTERVAL_SECONDS
+    ):
+        store.upsert_sync_schedule(
+            user_id, platform, _BROWSER_SYNC_INTERVAL_SECONDS, enabled=True
+        )
+    store.create_job(
+        user_id,
+        "sync",
+        None,
+        {"platform": platform, "scheduled": False, "trigger": "browser_connection"},
+        queue="sync",
+        idempotency_key=f"browser-connection:{platform}:{session_id}",
+        max_attempts=4,
+        timeout_seconds=900,
+    )
 
 # ── Mock draft data ───────────────────────────────────────────────────────────
 # Real implementation would call each platform's API with the stored token.
@@ -656,6 +682,11 @@ def complete_browser_connection(request: Request, conn_id: str):
     _require_browser_extension_id(conn_id)
     user_id = request.state.user_id
     connection = store.get_browser_connection(user_id, conn_id)
+    if connection and connection["status"] == "connected":
+        _ensure_browser_sync(
+            user_id, conn_id, connection["skyvern_session_id"]
+        )
+        return _browser_connection_response(conn_id, connection)
     if not connection or connection["status"] != "waiting_for_login":
         raise HTTPException(status_code=409, detail=f"No {conn_id.title()} browser login is active")
     store.update_browser_connection(user_id, conn_id, "verifying")
@@ -710,6 +741,7 @@ def complete_browser_connection(request: Request, conn_id: str):
     connected = store.update_browser_connection(
         user_id, conn_id, "connected", profile_id=result["profile_id"]
     )
+    _ensure_browser_sync(user_id, conn_id, connection["skyvern_session_id"])
     return _browser_connection_response(conn_id, connected)
 
 
@@ -736,7 +768,9 @@ def disconnect_browser_connection(request: Request, conn_id: str):
             runner.delete_browser_profile(conn_id, connection["skyvern_profile_id"])
         except runner.RunnerUnavailable as exc:
             raise HTTPException(status_code=503, detail=str(exc)) from exc
-    store.delete_browser_connection(request.state.user_id, conn_id)
+    user_id = request.state.user_id
+    store.delete_browser_connection(user_id, conn_id)
+    store.delete_sync_schedule(user_id, conn_id)
     return {"platform": conn_id, "status": "disconnected"}
 
 

--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -61,7 +61,7 @@ _BLOG_IDS = {"medium", "hashnode", "devto"}
 _CLI_IDS = {"anthropic", "openai"}
 _PROVIDER_MAP = {"anthropic": "anthropic", "openai": "openai"}
 _BROWSER_EXTENSION_ID = re.compile(r"^[a-z][a-z0-9_.-]{1,79}$")
-_BROWSER_SYNC_INTERVAL_SECONDS = 15 * 60
+_BROWSER_SYNC_INTERVAL_SECONDS = 60
 
 
 def _require_browser_extension_id(platform: str) -> None:

--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -70,18 +70,11 @@ def _require_browser_extension_id(platform: str) -> None:
 
 
 def _ensure_browser_sync(user_id: str, platform: str, session_id: str) -> None:
-    schedules = store.list_sync_schedules(user_id)
-    schedule = next(
-        (item for item in schedules if item["platform"] == platform), None
+    if platform not in {"hashnode", "medium"}:
+        return
+    store.ensure_connected_sync_schedules(
+        user_id, interval_seconds=_BROWSER_SYNC_INTERVAL_SECONDS,
     )
-    if (
-        schedule is None
-        or not schedule["enabled"]
-        or schedule["interval_seconds"] != _BROWSER_SYNC_INTERVAL_SECONDS
-    ):
-        store.upsert_sync_schedule(
-            user_id, platform, _BROWSER_SYNC_INTERVAL_SECONDS, enabled=True
-        )
     store.create_job(
         user_id,
         "sync",
@@ -770,7 +763,8 @@ def disconnect_browser_connection(request: Request, conn_id: str):
             raise HTTPException(status_code=503, detail=str(exc)) from exc
     user_id = request.state.user_id
     store.delete_browser_connection(user_id, conn_id)
-    store.delete_sync_schedule(user_id, conn_id)
+    if not store.has_connected_sync_connection(user_id, conn_id):
+        store.delete_sync_schedule(user_id, conn_id)
     return {"platform": conn_id, "status": "disconnected"}
 
 

--- a/backend/routers/jobs.py
+++ b/backend/routers/jobs.py
@@ -94,9 +94,9 @@ def upsert_sync_schedule(request: Request, body: SyncScheduleRequest):
 @router.post("/sync-refresh", status_code=202)
 def refresh_connected_platforms(request: Request):
     user_id = request.state.user_id
-    schedules = [
-        item for item in store.list_sync_schedules(user_id) if item["enabled"]
-    ]
+    schedules = store.ensure_connected_sync_schedules(
+        user_id, interval_seconds=60,
+    )
     active_by_platform = {
         job["payload"].get("platform"): job
         for job in store.list_jobs(user_id, queue="sync", active=True, limit=200)
@@ -105,7 +105,6 @@ def refresh_connected_platforms(request: Request):
     jobs = []
     for schedule in schedules:
         platform = schedule["platform"]
-        store.upsert_sync_schedule(user_id, platform, 60, enabled=True)
         job = active_by_platform.get(platform)
         if job is None:
             job = store.create_job(

--- a/backend/routers/jobs.py
+++ b/backend/routers/jobs.py
@@ -94,13 +94,16 @@ def upsert_sync_schedule(request: Request, body: SyncScheduleRequest):
 @router.post("/sync-refresh", status_code=202)
 def refresh_connected_platforms(request: Request):
     user_id = request.state.user_id
-    schedules = store.ensure_connected_sync_schedules(
-        user_id, interval_seconds=60,
-    )
+    schedules = [
+        schedule for schedule in store.list_sync_schedules(user_id)
+        if schedule["enabled"]
+        and store.has_connected_sync_connection(user_id, schedule["platform"])
+    ]
     active_by_platform = {
         job["payload"].get("platform"): job
         for job in store.list_jobs(user_id, queue="sync", active=True, limit=200)
         if job["payload"].get("platform")
+        and not (job["status"] == "waiting" and job["available_at"] is None)
     }
     jobs = []
     for schedule in schedules:

--- a/backend/routers/jobs.py
+++ b/backend/routers/jobs.py
@@ -5,13 +5,14 @@ from pydantic import BaseModel, Field
 
 from backend.schemas.overview import JobResponse
 import backend.store as store
+from backend.store.job_queue import sync_job_idempotency_key
 
 router = APIRouter(prefix="/api/jobs", tags=["jobs"])
 
 
 class SyncScheduleRequest(BaseModel):
     platform: str
-    interval_seconds: int = Field(alias="intervalSeconds", ge=300, le=2_592_000)
+    interval_seconds: int = Field(alias="intervalSeconds", ge=60, le=2_592_000)
     enabled: bool = True
 
     model_config = {"populate_by_name": True}
@@ -88,6 +89,37 @@ def upsert_sync_schedule(request: Request, body: SyncScheduleRequest):
         )
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.post("/sync-refresh", status_code=202)
+def refresh_connected_platforms(request: Request):
+    user_id = request.state.user_id
+    schedules = [
+        item for item in store.list_sync_schedules(user_id) if item["enabled"]
+    ]
+    active_by_platform = {
+        job["payload"].get("platform"): job
+        for job in store.list_jobs(user_id, queue="sync", active=True, limit=200)
+        if job["payload"].get("platform")
+    }
+    jobs = []
+    for schedule in schedules:
+        platform = schedule["platform"]
+        store.upsert_sync_schedule(user_id, platform, 60, enabled=True)
+        job = active_by_platform.get(platform)
+        if job is None:
+            job = store.create_job(
+                user_id,
+                "sync",
+                None,
+                {"platform": platform, "scheduled": False, "trigger": "overview"},
+                queue="sync",
+                idempotency_key=sync_job_idempotency_key(platform),
+                max_attempts=4,
+                timeout_seconds=900,
+            )
+        jobs.append(_response(job))
+    return {"jobs": jobs, "count": len(jobs)}
 
 
 @router.delete("/sync-schedules/{platform}", status_code=204)

--- a/backend/schemas/overview.py
+++ b/backend/schemas/overview.py
@@ -156,7 +156,7 @@ class JobResponse(BaseModel):
     job_id: str = Field(alias="jobId")
     type: JobType
     status: JobStatus
-    article_id: str = Field(alias="articleId")
+    article_id: Optional[str] = Field(default=None, alias="articleId")
     result: Optional[dict] = None
     error: Optional[str] = None
     queue: str = "default"

--- a/backend/store/__init__.py
+++ b/backend/store/__init__.py
@@ -277,6 +277,10 @@ def list_sync_schedules(user_id: str, *a, **kw):
     return _backend.list_sync_schedules(user_id, *a, **kw)
 
 
+def ensure_connected_sync_schedules(*a, **kw):
+    return _backend.ensure_connected_sync_schedules(*a, **kw)
+
+
 def delete_sync_schedule(user_id: str, *a, **kw):
     return _backend.delete_sync_schedule(user_id, *a, **kw)
 

--- a/backend/store/__init__.py
+++ b/backend/store/__init__.py
@@ -281,6 +281,10 @@ def ensure_connected_sync_schedules(*a, **kw):
     return _backend.ensure_connected_sync_schedules(*a, **kw)
 
 
+def has_connected_sync_connection(user_id: str, *a, **kw):
+    return _backend.has_connected_sync_connection(user_id, *a, **kw)
+
+
 def enqueue_due_sync_jobs(*a, **kw):
     return _backend.enqueue_due_sync_jobs(*a, **kw)
 

--- a/backend/store/__init__.py
+++ b/backend/store/__init__.py
@@ -281,6 +281,10 @@ def ensure_connected_sync_schedules(*a, **kw):
     return _backend.ensure_connected_sync_schedules(*a, **kw)
 
 
+def enqueue_due_sync_jobs(*a, **kw):
+    return _backend.enqueue_due_sync_jobs(*a, **kw)
+
+
 def delete_sync_schedule(user_id: str, *a, **kw):
     return _backend.delete_sync_schedule(user_id, *a, **kw)
 

--- a/backend/store/base.py
+++ b/backend/store/base.py
@@ -327,6 +327,9 @@ class ArticleStore(Protocol):
     ) -> list[dict]:
         ...
 
+    def has_connected_sync_connection(self, user_id: str, platform: str) -> bool:
+        ...
+
     def enqueue_due_sync_jobs(self) -> int:
         ...
 

--- a/backend/store/base.py
+++ b/backend/store/base.py
@@ -327,6 +327,9 @@ class ArticleStore(Protocol):
     ) -> list[dict]:
         ...
 
+    def enqueue_due_sync_jobs(self) -> int:
+        ...
+
     def delete_sync_schedule(self, user_id: str, platform: str) -> bool:
         ...
 

--- a/backend/store/base.py
+++ b/backend/store/base.py
@@ -322,6 +322,11 @@ class ArticleStore(Protocol):
     def list_sync_schedules(self, user_id: str) -> list[dict]:
         ...
 
+    def ensure_connected_sync_schedules(
+        self, user_id: str | None = None, *, interval_seconds: int = 60,
+    ) -> list[dict]:
+        ...
+
     def delete_sync_schedule(self, user_id: str, platform: str) -> bool:
         ...
 

--- a/backend/store/job_queue.py
+++ b/backend/store/job_queue.py
@@ -599,7 +599,7 @@ class DurableJobStoreMixin:
     def ensure_connected_sync_schedules(
         self, user_id: str | None = None, *, interval_seconds: int = 60,
     ) -> list[dict]:
-        """Repair the internal schedule for every connected sync-capable blog."""
+        """Create missing schedules without changing user schedule preferences."""
         interval = max(60, int(interval_seconds))
         user_clause = " AND user_id=?" if user_id is not None else ""
         parameters = (user_id,) if user_id is not None else ()
@@ -624,10 +624,7 @@ class DurableJobStoreMixin:
                            (id, user_id, platform, interval_seconds, enabled,
                             next_run_at, created_at, updated_at)
                            VALUES (?,?,?,?,1,?,?,?)
-                           ON CONFLICT(user_id, platform) DO UPDATE SET
-                             interval_seconds=excluded.interval_seconds,
-                             enabled=1,
-                             updated_at=excluded.updated_at""",
+                           ON CONFLICT(user_id, platform) DO NOTHING""",
                         (
                             f"sync_{row['user_id']}_{row['platform']}",
                             row["user_id"], row["platform"], interval,
@@ -644,6 +641,21 @@ class DurableJobStoreMixin:
             _schedule_row(row) for row in schedule_rows
             if (row["user_id"], row["platform"]) in connected_keys
         ]
+
+    def has_connected_sync_connection(self, user_id: str, platform: str) -> bool:
+        if platform not in {"hashnode", "medium"}:
+            return False
+        with self._workspace_lock.acquire():
+            row = self._con.execute(
+                """SELECT 1 FROM browser_connections
+                   WHERE user_id=? AND platform=? AND status='connected'
+                   UNION ALL
+                   SELECT 1 FROM connections
+                   WHERE user_id=? AND platform=? AND status='connected'
+                   LIMIT 1""",
+                (user_id, platform, user_id, platform),
+            ).fetchone()
+        return row is not None
 
     def list_sync_schedules(self, user_id: str) -> list[dict]:
         rows = self._con.execute(

--- a/backend/store/job_queue.py
+++ b/backend/store/job_queue.py
@@ -596,6 +596,55 @@ class DurableJobStoreMixin:
         ).fetchone()
         return _schedule_row(row)
 
+    def ensure_connected_sync_schedules(
+        self, user_id: str | None = None, *, interval_seconds: int = 60,
+    ) -> list[dict]:
+        """Repair the internal schedule for every connected sync-capable blog."""
+        interval = max(60, int(interval_seconds))
+        user_clause = " AND user_id=?" if user_id is not None else ""
+        parameters = (user_id,) if user_id is not None else ()
+        now = _now()
+        now_s = _ts(now)
+        with self._workspace_lock.acquire():
+            connected = self._con.execute(
+                f"""SELECT user_id, platform FROM browser_connections
+                    WHERE status='connected' AND platform IN ('hashnode','medium')
+                    {user_clause}
+                    UNION
+                    SELECT user_id, platform FROM connections
+                    WHERE status='connected' AND platform IN ('hashnode','medium')
+                    {user_clause}
+                    ORDER BY user_id, platform""",
+                parameters + parameters,
+            ).fetchall()
+            with self._con:
+                for row in connected:
+                    self._con.execute(
+                        """INSERT INTO sync_schedules
+                           (id, user_id, platform, interval_seconds, enabled,
+                            next_run_at, created_at, updated_at)
+                           VALUES (?,?,?,?,1,?,?,?)
+                           ON CONFLICT(user_id, platform) DO UPDATE SET
+                             interval_seconds=excluded.interval_seconds,
+                             enabled=1,
+                             updated_at=excluded.updated_at""",
+                        (
+                            f"sync_{row['user_id']}_{row['platform']}",
+                            row["user_id"], row["platform"], interval,
+                            now_s, now_s, now_s,
+                        ),
+                    )
+            connected_keys = {
+                (row["user_id"], row["platform"]) for row in connected
+            }
+            schedule_rows = self._con.execute(
+                "SELECT * FROM sync_schedules ORDER BY user_id, platform"
+            ).fetchall()
+        return [
+            _schedule_row(row) for row in schedule_rows
+            if (row["user_id"], row["platform"]) in connected_keys
+        ]
+
     def list_sync_schedules(self, user_id: str) -> list[dict]:
         rows = self._con.execute(
             "SELECT * FROM sync_schedules WHERE user_id=? ORDER BY platform",

--- a/backend/store/job_queue.py
+++ b/backend/store/job_queue.py
@@ -33,6 +33,14 @@ def _json(value: Any) -> str:
     return json.dumps(_sanitize(value), separators=(",", ":"), sort_keys=True)
 
 
+def sync_job_idempotency_key(
+    platform: str, when: datetime | None = None,
+) -> str:
+    when = when or _now()
+    minute = when.astimezone(timezone.utc).replace(second=0, microsecond=0)
+    return f"sync:{platform}:{minute.isoformat()}"
+
+
 def _loads(value: str | None) -> Any:
     return json.loads(value) if value else None
 
@@ -562,7 +570,7 @@ class DurableJobStoreMixin:
     ) -> dict:
         if platform not in {"hashnode", "medium"}:
             raise ValueError("Scheduled sync supports Hashnode and Medium")
-        interval = max(300, int(interval_seconds))
+        interval = max(60, int(interval_seconds))
         now = _now()
         now_s = _ts(now)
         schedule_id = f"sync_{user_id}_{platform}"
@@ -618,7 +626,7 @@ class DurableJobStoreMixin:
                 ).fetchall()
                 for row in rows:
                     due_at = datetime.fromisoformat(row["next_run_at"])
-                    key = f"schedule:{row['id']}:{row['next_run_at']}"
+                    key = sync_job_idempotency_key(row["platform"], now)
                     cursor = self._con.execute(
                         """INSERT OR IGNORE INTO jobs
                            (job_id, kind, status, payload_json, queue, priority,

--- a/screens/overview/v3.html
+++ b/screens/overview/v3.html
@@ -867,6 +867,33 @@ async function refreshOverview() {
   render();
 }
 
+const TERMINAL_SYNC_STATES = new Set(['completed', 'failed', 'canceled', 'expired', 'parked']);
+
+async function waitForSyncJob(job) {
+  let current = job;
+  const deadline = Date.now() + ((current.timeoutSeconds || 900) + 30) * 1000;
+  while (!TERMINAL_SYNC_STATES.has(current.status) && Date.now() < deadline) {
+    const delay = Math.max(current.pollAfterMs || 2000, 5000);
+    await new Promise(resolve => setTimeout(resolve, delay));
+    current = await fetchJson(current.pollUrl);
+  }
+  return current;
+}
+
+async function syncOverviewFromRemotes() {
+  try {
+    const payload = await fetchJson('/api/jobs/sync-refresh', { method: 'POST' });
+    if (!payload.jobs?.length) return;
+    const results = await Promise.all(payload.jobs.map(waitForSyncJob));
+    if (results.some(job => job.status === 'completed')) {
+      await loadOverview();
+      render();
+    }
+  } catch (error) {
+    console.warn('Overview remote refresh failed', error);
+  }
+}
+
 function hasMoreArticles() {
   return ARTICLES.length < totalArticleCount;
 }
@@ -1625,6 +1652,7 @@ loadOverview()
       selectedId = restoredId;
       detailsPanelOpen = true;
     }
+    void syncOverviewFromRemotes();
   })
   .catch(error => { alert(`Failed to load overview: ${error.message}`); })
   .finally(() => {

--- a/screens/settings/v2.html
+++ b/screens/settings/v2.html
@@ -216,10 +216,6 @@ let _browserConnections = {
   hashnode: { platform: 'hashnode', status: 'disconnected' },
 };
 let _browserMethodMenus = { medium: false, hashnode: false };
-const _platformSync = {
-  hashnode: { status: 'idle', message: '' },
-  medium: { status: 'idle', message: '' },
-};
 let _browserLoginTabs = {};
 let _browserLoginTabTimers = {};
 let _browserLoginPolls = {};
@@ -434,11 +430,7 @@ function browserPlatformCard(conn) {
   let actions = '';
   if (connected) {
     const connectedMethod = apiConnected && browserConnected ? 'both' : apiConnected ? 'api' : 'browser';
-    const canSync = id === 'hashnode' ? connected : browserConnected;
-    const syncState = canSync ? _platformSync[id] : null;
-    const syncAction = syncState ? `<button id="${id}-sync" onclick="syncBrowserArticles('${id}')" ${syncState.status === 'running' ? 'disabled' : ''}
-      style="font-size:11px;padding:4px 10px;border-radius:4px;border:1px solid #252a38;background:transparent;color:#c9cfe0;cursor:${syncState.status === 'running' ? 'wait' : 'pointer'};font-family:inherit;">${syncState.status === 'running' ? 'Syncing…' : 'Sync articles'}</button>` : '';
-    actions = `${syncAction}<button onclick="disconnectBrowserPlatformConnection('${id}', '${connectedMethod}')"
+    actions = `<button onclick="disconnectBrowserPlatformConnection('${id}', '${connectedMethod}')"
       style="font-size:11px;color:#f87171;background:transparent;border:none;cursor:pointer;font-family:inherit;">Disconnect</button>`;
   } else if (finalizing) {
     actions = `<button onclick="disconnectBrowserPlatform('${id}')"
@@ -487,7 +479,6 @@ function browserPlatformCard(conn) {
             </div>
             ${method ? `<div style="font-size:11px;color:#c9cfe0;margin-top:3px;">${method}</div>` : ''}
             <div style="font-size:10px;color:#5a6080;margin-top:3px;">${helper}</div>
-            ${_platformSync[id]?.message ? `<div role="status" style="font-size:10px;color:${_platformSync[id].status === 'failed' ? '#f87171' : _platformSync[id].status === 'partial' ? '#fbbf24' : '#71d892'};margin-top:3px;">${esc(_platformSync[id].message)}</div>` : ''}
           </div>
         </div>
         <div style="display:flex;align-items:center;gap:8px;flex-shrink:0;">${actions}</div>
@@ -521,29 +512,6 @@ function chooseBrowserPlatformApiToken(id) {
 function chooseBrowserPlatformLogin(id) {
   _browserMethodMenus[id] = false;
   startBrowserLogin(id);
-}
-
-async function syncBrowserArticles(id) {
-  const syncState = _platformSync[id];
-  if (!syncState || syncState.status === 'running') return;
-  _platformSync[id] = { status: 'running', message: '' };
-  renderPlatforms(_connections.filter(c => c.type === 'blog'));
-  try {
-    const res = await fetch(`/api/connections/${id}/sync`, { method: 'POST' });
-    const data = await res.json();
-    if (!res.ok) {
-      const detail = data.detail;
-      throw new Error(typeof detail === 'string' ? detail : detail?.message || detail?.error || `HTTP ${res.status}`);
-    }
-    const status = data.status === 'partial' ? 'partial' : 'succeeded';
-    _platformSync[id] = {
-      status,
-      message: `${data.fetched} articles synced · ${data.imported} new · ${data.updated} updated`,
-    };
-  } catch (error) {
-    _platformSync[id] = { status: 'failed', message: error.message || 'Article sync failed' };
-  }
-  renderPlatforms(_connections.filter(c => c.type === 'blog'));
 }
 
 function createBrowserLoginTab(url='about:blank') {

--- a/tests/overview-v3.spec.js
+++ b/tests/overview-v3.spec.js
@@ -69,6 +69,17 @@ test.describe('Current overview screen', () => {
     await expect(page.locator('.article-card-title').first()).not.toBeEmpty();
   });
 
+  test('requests a remote sync when Overview reloads', async ({ page }) => {
+    let refreshRequests = 0;
+    await page.route('**/api/jobs/sync-refresh', async route => {
+      refreshRequests += 1;
+      await route.fulfill({ json: { jobs: [], count: 0 } });
+    });
+
+    await page.reload();
+    await expect.poll(() => refreshRequests).toBe(1);
+  });
+
   test('shows all platform preview tabs on each card', async ({ page }) => {
     const firstCard = page.locator('.article-card').first();
     await expect(firstCard.locator('.plat-tab')).toHaveCount(3);

--- a/tests/settings.spec.js
+++ b/tests/settings.spec.js
@@ -112,7 +112,7 @@ test.describe('Settings screen', () => {
     expect(body.token).toBe('sk-ant-test');
   });
 
-  test('[contract] connected Hashnode browser profile can sync articles', async ({ page }) => {
+  test('[contract] connected Hashnode browser profile only offers disconnect', async ({ page }) => {
     await page.route('**/api/connections/hashnode/browser-connection', route => route.fulfill({
       json: {
         platform: 'hashnode',
@@ -122,32 +122,15 @@ test.describe('Settings screen', () => {
         error: null,
       },
     }));
-    await page.route('**/api/connections/hashnode/sync', route => route.fulfill({
-      json: {
-        status: 'succeeded',
-        fetched: 104,
-        imported: 103,
-        updated: 1,
-      },
-    }));
     await page.reload();
 
-    const requestPromise = page.waitForRequest(
-      request => request.url().endsWith('/api/connections/hashnode/sync')
-        && request.method() === 'POST',
-    );
     const card = page.locator('#plat-card-hashnode');
-    await card.getByRole('button', { name: 'Sync articles' }).click();
-    await requestPromise;
-
-    await expect(card.getByRole('status')).toHaveText(
-      '104 articles synced · 103 new · 1 updated',
-    );
+    await expect(card.getByRole('button')).toHaveText(['Disconnect']);
     await expect(card.getByText('Refresh login', { exact: true })).toHaveCount(0);
     await expect(card.getByText('Test', { exact: true })).toHaveCount(0);
   });
 
-  test('[contract] connected Medium browser profile can sync articles', async ({ page }) => {
+  test('[contract] connected Medium browser profile only offers disconnect', async ({ page }) => {
     await page.route('**/api/connections/medium/browser-connection', route => route.fulfill({
       json: {
         platform: 'medium',
@@ -157,27 +140,10 @@ test.describe('Settings screen', () => {
         error: null,
       },
     }));
-    await page.route('**/api/connections/medium/sync', route => route.fulfill({
-      json: {
-        status: 'succeeded',
-        fetched: 12,
-        imported: 10,
-        updated: 2,
-      },
-    }));
     await page.reload();
 
-    const requestPromise = page.waitForRequest(
-      request => request.url().endsWith('/api/connections/medium/sync')
-        && request.method() === 'POST',
-    );
     const card = page.locator('#plat-card-medium');
-    await card.getByRole('button', { name: 'Sync articles' }).click();
-    await requestPromise;
-
-    await expect(card.getByRole('status')).toHaveText(
-      '12 articles synced · 10 new · 2 updated',
-    );
+    await expect(card.getByRole('button')).toHaveText(['Disconnect']);
   });
 
   test('Medium live login finalizes automatically while the tab stays open', async ({ page, context }) => {

--- a/tests/tests_backend/test_browser_connections.py
+++ b/tests/tests_backend/test_browser_connections.py
@@ -165,6 +165,25 @@ def test_hashnode_browser_login_persists_only_profile_references(client, monkeyp
     assert "profile_id" not in completed.json()
     persisted = store.get_browser_connection("user_seed", "hashnode")
     assert persisted["skyvern_profile_id"] == "bp_profile"
+    schedules = store.list_sync_schedules("user_seed")
+    assert [
+        (item["platform"], item["interval_seconds"], item["enabled"])
+        for item in schedules
+    ] == [("hashnode", 900, True)]
+    jobs = store.list_jobs("user_seed", queue="sync")
+    assert len(jobs) == 1
+    assert jobs[0]["payload"] == {
+        "platform": "hashnode",
+        "scheduled": False,
+        "trigger": "browser_connection",
+    }
+
+    retried = client.post(
+        "/api/connections/hashnode/browser-connection/complete"
+    )
+    assert retried.status_code == 200
+    assert len(store.list_sync_schedules("user_seed")) == 1
+    assert len(store.list_jobs("user_seed", queue="sync")) == 1
     raw_url = store._backend._con.execute(
         """SELECT app_url FROM browser_connections
            WHERE user_id='user_seed' AND platform='hashnode'"""
@@ -289,6 +308,7 @@ def test_hashnode_browser_disconnect_deletes_remote_profile(client, monkeypatch)
     store.update_browser_connection(
         "user_seed", "hashnode", "connected", profile_id="bp_profile"
     )
+    store.upsert_sync_schedule("user_seed", "hashnode", 900)
     deleted = []
     monkeypatch.setattr(
         connections_router.runner,
@@ -299,6 +319,7 @@ def test_hashnode_browser_disconnect_deletes_remote_profile(client, monkeypatch)
     assert response.status_code == 200
     assert deleted == [("hashnode", "bp_profile")]
     assert store.get_browser_connection("user_seed", "hashnode") is None
+    assert store.list_sync_schedules("user_seed") == []
 
 
 def test_hashnode_browser_disconnect_retains_profile_when_remote_cleanup_fails(
@@ -361,3 +382,7 @@ def test_medium_browser_login_uses_same_profile_reference_flow(client, monkeypat
     assert completed_platforms == ["medium"]
     persisted = store.get_browser_connection("user_seed", "medium")
     assert persisted["skyvern_profile_id"] == "bp_medium"
+    assert store.list_sync_schedules("user_seed")[0]["platform"] == "medium"
+    jobs = store.list_jobs("user_seed", queue="sync")
+    assert len(jobs) == 1
+    assert jobs[0]["payload"]["platform"] == "medium"

--- a/tests/tests_backend/test_browser_connections.py
+++ b/tests/tests_backend/test_browser_connections.py
@@ -169,7 +169,7 @@ def test_hashnode_browser_login_persists_only_profile_references(client, monkeyp
     assert [
         (item["platform"], item["interval_seconds"], item["enabled"])
         for item in schedules
-    ] == [("hashnode", 900, True)]
+    ] == [("hashnode", 60, True)]
     jobs = store.list_jobs("user_seed", queue="sync")
     assert len(jobs) == 1
     assert jobs[0]["payload"] == {

--- a/tests/tests_backend/test_browser_connections.py
+++ b/tests/tests_backend/test_browser_connections.py
@@ -322,6 +322,35 @@ def test_hashnode_browser_disconnect_deletes_remote_profile(client, monkeypatch)
     assert store.list_sync_schedules("user_seed") == []
 
 
+def test_browser_disconnect_keeps_schedule_for_connected_api(client, monkeypatch):
+    store.save_connection(
+        "user_seed", "hashnode", "api-token", status="connected",
+    )
+    store.start_browser_connection(
+        "user_seed", "hashnode", session_id="pbs_session",
+        organization_id="o_org", app_url="http://localhost/login",
+    )
+    store.update_browser_connection(
+        "user_seed", "hashnode", "connected", profile_id="bp_profile",
+    )
+    store.upsert_sync_schedule("user_seed", "hashnode", 900)
+    monkeypatch.setattr(
+        connections_router.runner, "delete_browser_profile", lambda *_args: None,
+    )
+
+    response = client.delete("/api/connections/hashnode/browser-connection")
+
+    assert response.status_code == 200
+    assert store.list_sync_schedules("user_seed")[0]["platform"] == "hashnode"
+
+
+def test_browser_sync_ignores_extensions_without_scheduled_sync():
+    connections_router._ensure_browser_sync("user_seed", "ghost", "pbs_ghost")
+
+    assert store.list_sync_schedules("user_seed") == []
+    assert store.list_jobs("user_seed", queue="sync") == []
+
+
 def test_hashnode_browser_disconnect_retains_profile_when_remote_cleanup_fails(
     client, monkeypatch,
 ):

--- a/tests/tests_backend/test_jobs.py
+++ b/tests/tests_backend/test_jobs.py
@@ -221,7 +221,7 @@ class TestSyncSchedules:
             "user_seed", "sync", None, {"platform": "hashnode"}, queue="sync",
         )
         store._backend.claim_job("test-worker", queues=("sync",))
-        store.defer_job(
+        store._backend.defer_job(
             parked["job_id"], "test-worker", "operator action required",
         )
 

--- a/tests/tests_backend/test_jobs.py
+++ b/tests/tests_backend/test_jobs.py
@@ -220,7 +220,7 @@ class TestSyncSchedules:
         parked = store.create_job(
             "user_seed", "sync", None, {"platform": "hashnode"}, queue="sync",
         )
-        store.claim_job("test-worker", queues=("sync",))
+        store._backend.claim_job("test-worker", queues=("sync",))
         store.defer_job(
             parked["job_id"], "test-worker", "operator action required",
         )

--- a/tests/tests_backend/test_jobs.py
+++ b/tests/tests_backend/test_jobs.py
@@ -138,8 +138,13 @@ class TestSyncSchedules:
     ):
         now = job_queue._now().replace(second=15, microsecond=0)
         monkeypatch.setattr(job_queue, "_now", lambda: now)
-        store.upsert_sync_schedule("user_seed", "hashnode", 900)
-        store.upsert_sync_schedule("user_seed", "medium", 900)
+        for platform in ("hashnode", "medium"):
+            store.start_browser_connection(
+                "user_seed", platform, session_id=f"pbs_{platform}",
+                organization_id="o_org", app_url="http://localhost/login",
+                profile_id="bp_shared",
+            )
+            store.update_browser_connection("user_seed", platform, "connected")
 
         first = client.post("/api/jobs/sync-refresh")
         second = client.post("/api/jobs/sync-refresh")
@@ -162,7 +167,12 @@ class TestSyncSchedules:
     def test_overview_refresh_reuses_an_active_connection_sync(
         self, client: TestClient,
     ):
-        store.upsert_sync_schedule("user_seed", "hashnode", 60)
+        store.start_browser_connection(
+            "user_seed", "hashnode", session_id="pbs_hashnode",
+            organization_id="o_org", app_url="http://localhost/login",
+            profile_id="bp_shared",
+        )
+        store.update_browser_connection("user_seed", "hashnode", "connected")
         existing = store.create_job(
             "user_seed",
             "sync",
@@ -176,3 +186,14 @@ class TestSyncSchedules:
         assert response.status_code == 202
         assert response.json()["jobs"][0]["jobId"] == existing["job_id"]
         assert len(store.list_jobs("user_seed", queue="sync")) == 1
+
+    def test_overview_refresh_ignores_a_schedule_without_a_connection(
+        self, client: TestClient,
+    ):
+        store.upsert_sync_schedule("user_seed", "hashnode", 60)
+
+        response = client.post("/api/jobs/sync-refresh")
+
+        assert response.status_code == 202
+        assert response.json() == {"jobs": [], "count": 0}
+        assert store.list_jobs("user_seed", queue="sync") == []

--- a/tests/tests_backend/test_jobs.py
+++ b/tests/tests_backend/test_jobs.py
@@ -5,6 +5,7 @@ Tests for /api/jobs — backend/routers/jobs.py
 import pytest
 from fastapi.testclient import TestClient
 import backend.store as store
+import backend.store.job_queue as job_queue
 
 # ─── GET /api/jobs/:jobId ─────────────────────────────────────────────────────
 
@@ -124,9 +125,54 @@ class TestSyncSchedules:
         )
         assert response.status_code == 422
 
-    def test_schedule_enforces_minimum_interval(self, client: TestClient):
+    def test_schedule_accepts_one_minute_interval(self, client: TestClient):
         response = client.put(
             "/api/jobs/sync-schedules",
             json={"platform": "hashnode", "intervalSeconds": 60},
         )
-        assert response.status_code == 422
+        assert response.status_code == 200
+        assert response.json()["interval_seconds"] == 60
+
+    def test_overview_refresh_enqueues_each_enabled_schedule_once(
+        self, client: TestClient, monkeypatch,
+    ):
+        now = job_queue._now().replace(second=15, microsecond=0)
+        monkeypatch.setattr(job_queue, "_now", lambda: now)
+        store.upsert_sync_schedule("user_seed", "hashnode", 900)
+        store.upsert_sync_schedule("user_seed", "medium", 900)
+
+        first = client.post("/api/jobs/sync-refresh")
+        second = client.post("/api/jobs/sync-refresh")
+
+        assert first.status_code == 202
+        assert first.json()["count"] == 2
+        assert [job["jobId"] for job in second.json()["jobs"]] == [
+            job["jobId"] for job in first.json()["jobs"]
+        ]
+        assert len(store.list_jobs("user_seed", queue="sync")) == 2
+        assert {
+            item["interval_seconds"]
+            for item in store.list_sync_schedules("user_seed")
+        } == {60}
+        assert {
+            job["payload"]["trigger"]
+            for job in store.list_jobs("user_seed", queue="sync")
+        } == {"overview"}
+
+    def test_overview_refresh_reuses_an_active_connection_sync(
+        self, client: TestClient,
+    ):
+        store.upsert_sync_schedule("user_seed", "hashnode", 60)
+        existing = store.create_job(
+            "user_seed",
+            "sync",
+            None,
+            {"platform": "hashnode", "trigger": "browser_connection"},
+            queue="sync",
+        )
+
+        response = client.post("/api/jobs/sync-refresh")
+
+        assert response.status_code == 202
+        assert response.json()["jobs"][0]["jobId"] == existing["job_id"]
+        assert len(store.list_jobs("user_seed", queue="sync")) == 1

--- a/tests/tests_backend/test_jobs.py
+++ b/tests/tests_backend/test_jobs.py
@@ -164,6 +164,7 @@ class TestSyncSchedules:
                 profile_id="bp_shared",
             )
             store.update_browser_connection("user_seed", platform, "connected")
+        store.ensure_connected_sync_schedules("user_seed", interval_seconds=60)
 
         first = client.post("/api/jobs/sync-refresh")
         second = client.post("/api/jobs/sync-refresh")
@@ -192,6 +193,7 @@ class TestSyncSchedules:
             profile_id="bp_shared",
         )
         store.update_browser_connection("user_seed", "hashnode", "connected")
+        store.ensure_connected_sync_schedules("user_seed", interval_seconds=60)
         existing = store.create_job(
             "user_seed",
             "sync",
@@ -205,6 +207,47 @@ class TestSyncSchedules:
         assert response.status_code == 202
         assert response.json()["jobs"][0]["jobId"] == existing["job_id"]
         assert len(store.list_jobs("user_seed", queue="sync")) == 1
+
+    def test_overview_refresh_does_not_reuse_a_parked_job(
+        self, client: TestClient,
+    ):
+        store.start_browser_connection(
+            "user_seed", "hashnode", session_id="pbs_hashnode",
+            organization_id="o_org", app_url="http://localhost/login",
+        )
+        store.update_browser_connection("user_seed", "hashnode", "connected")
+        store.ensure_connected_sync_schedules("user_seed", interval_seconds=60)
+        parked = store.create_job(
+            "user_seed", "sync", None, {"platform": "hashnode"}, queue="sync",
+        )
+        store.claim_job("test-worker", queues=("sync",))
+        store.defer_job(
+            parked["job_id"], "test-worker", "operator action required",
+        )
+
+        response = client.post("/api/jobs/sync-refresh")
+
+        assert response.status_code == 202
+        assert response.json()["jobs"][0]["jobId"] != parked["job_id"]
+        assert response.json()["jobs"][0]["status"] == "queued"
+
+    def test_overview_refresh_respects_a_disabled_schedule(
+        self, client: TestClient,
+    ):
+        store.start_browser_connection(
+            "user_seed", "medium", session_id="pbs_medium",
+            organization_id="o_org", app_url="http://localhost/login",
+        )
+        store.update_browser_connection("user_seed", "medium", "connected")
+        store.upsert_sync_schedule("user_seed", "medium", 86_400, enabled=False)
+
+        response = client.post("/api/jobs/sync-refresh")
+
+        assert response.status_code == 202
+        assert response.json() == {"jobs": [], "count": 0}
+        schedule = store.list_sync_schedules("user_seed")[0]
+        assert schedule["interval_seconds"] == 86_400
+        assert schedule["enabled"] is False
 
     def test_overview_refresh_ignores_a_schedule_without_a_connection(
         self, client: TestClient,

--- a/tests/tests_backend/test_jobs.py
+++ b/tests/tests_backend/test_jobs.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 import backend.store as store
 import backend.store.job_queue as job_queue
+from backend.main import startup_cleanup
 
 # ─── GET /api/jobs/:jobId ─────────────────────────────────────────────────────
 
@@ -102,6 +103,24 @@ class TestJobs:
 
 
 class TestSyncSchedules:
+
+    def test_startup_repairs_and_enqueues_connected_blog_sync(self):
+        store.start_browser_connection(
+            "user_seed", "medium", session_id="pbs_medium",
+            organization_id="o_org", app_url="http://localhost/login",
+            profile_id="bp_shared",
+        )
+        store.update_browser_connection("user_seed", "medium", "connected")
+
+        startup_cleanup()
+
+        schedules = store.list_sync_schedules("user_seed")
+        assert [(item["platform"], item["interval_seconds"]) for item in schedules] == [
+            ("medium", 60),
+        ]
+        jobs = store.list_jobs("user_seed", queue="sync")
+        assert len(jobs) == 1
+        assert jobs[0]["payload"] == {"platform": "medium", "scheduled": True}
 
     def test_create_list_and_delete_schedule(self, client: TestClient):
         created = client.put(

--- a/tests/tests_backend/test_store/test_job_queue.py
+++ b/tests/tests_backend/test_store/test_job_queue.py
@@ -286,6 +286,26 @@ def test_connected_blogs_repair_missing_schedules_and_are_immediately_due(
     assert store.enqueue_due_sync_jobs() == 0
 
 
+def test_schedule_repair_preserves_user_interval_and_paused_state(store):
+    now_s = datetime(2026, 8, 24, 8, 0, tzinfo=timezone.utc).isoformat()
+    store._con.execute(
+        """INSERT INTO connections
+           (platform, token, status, username, connected_at, user_id)
+           VALUES ('hashnode', 'encrypted-token', 'connected', NULL, ?, ?)""",
+        (now_s, store.SEED_USER_ID),
+    )
+    store._con.commit()
+    original = store.upsert_sync_schedule(
+        store.SEED_USER_ID, "hashnode", 86_400, enabled=False,
+    )
+
+    repaired = store.ensure_connected_sync_schedules(interval_seconds=60)
+
+    assert repaired == [original]
+    assert repaired[0]["interval_seconds"] == 86_400
+    assert repaired[0]["enabled"] is False
+
+
 def test_schedule_repair_ignores_disconnected_blogs(store):
     now_s = datetime(2026, 8, 24, 8, 0, tzinfo=timezone.utc).isoformat()
     store._con.execute(

--- a/tests/tests_backend/test_store/test_job_queue.py
+++ b/tests/tests_backend/test_store/test_job_queue.py
@@ -253,6 +253,56 @@ def test_due_sync_schedule_enqueues_once_and_advances(store, monkeypatch):
     assert advanced["next_run_at"] > due.isoformat()
 
 
+def test_connected_blogs_repair_missing_schedules_and_are_immediately_due(
+    store, monkeypatch,
+):
+    start = datetime(2026, 8, 24, 8, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(job_queue, "_now", lambda: start)
+    now_s = start.isoformat()
+    store._con.execute(
+        """INSERT INTO browser_connections
+           (user_id, platform, status, skyvern_session_id,
+            skyvern_organization_id, skyvern_profile_id, app_url,
+            created_at, updated_at)
+           VALUES (?, 'medium', 'connected', 'pbs_medium', 'o_org',
+                   'bp_shared', NULL, ?, ?)""",
+        (store.SEED_USER_ID, now_s, now_s),
+    )
+    store._con.execute(
+        """INSERT INTO connections
+           (platform, token, status, username, connected_at, user_id)
+           VALUES ('hashnode', 'encrypted-token', 'connected', NULL, ?, ?)""",
+        (now_s, store.SEED_USER_ID),
+    )
+    store._con.commit()
+
+    repaired = store.ensure_connected_sync_schedules(interval_seconds=60)
+
+    assert [(item["platform"], item["interval_seconds"]) for item in repaired] == [
+        ("hashnode", 60), ("medium", 60),
+    ]
+    assert {item["next_run_at"] for item in repaired} == {now_s}
+    assert store.enqueue_due_sync_jobs() == 2
+    assert store.enqueue_due_sync_jobs() == 0
+
+
+def test_schedule_repair_ignores_disconnected_blogs(store):
+    now_s = datetime(2026, 8, 24, 8, 0, tzinfo=timezone.utc).isoformat()
+    store._con.execute(
+        """INSERT INTO browser_connections
+           (user_id, platform, status, skyvern_session_id,
+            skyvern_organization_id, skyvern_profile_id, app_url,
+            created_at, updated_at)
+           VALUES (?, 'medium', 'disconnected', NULL, 'o_org',
+                   'bp_shared', NULL, ?, ?)""",
+        (store.SEED_USER_ID, now_s, now_s),
+    )
+    store._con.commit()
+
+    assert store.ensure_connected_sync_schedules(interval_seconds=60) == []
+    assert store.list_sync_schedules(store.SEED_USER_ID) == []
+
+
 def test_due_schedule_reuses_an_overview_sync_in_the_same_minute(store, monkeypatch):
     start = datetime(2026, 8, 24, 8, 0, tzinfo=timezone.utc)
     monkeypatch.setattr(job_queue, "_now", lambda: start)

--- a/tests/tests_backend/test_store/test_job_queue.py
+++ b/tests/tests_backend/test_store/test_job_queue.py
@@ -237,11 +237,11 @@ def test_due_sync_schedule_enqueues_once_and_advances(store, monkeypatch):
     start = datetime(2026, 8, 24, 8, 0, tzinfo=timezone.utc)
     monkeypatch.setattr(job_queue, "_now", lambda: start)
     schedule = store.upsert_sync_schedule(
-        store.SEED_USER_ID, "medium", 300
+        store.SEED_USER_ID, "medium", 60
     )
-    assert schedule["next_run_at"] == (start + timedelta(seconds=300)).isoformat()
+    assert schedule["next_run_at"] == (start + timedelta(seconds=60)).isoformat()
 
-    due = start + timedelta(seconds=301)
+    due = start + timedelta(seconds=61)
     monkeypatch.setattr(job_queue, "_now", lambda: due)
     assert store.enqueue_due_sync_jobs() == 1
     assert store.enqueue_due_sync_jobs() == 0
@@ -251,6 +251,28 @@ def test_due_sync_schedule_enqueues_once_and_advances(store, monkeypatch):
     assert job["payload"] == {"platform": "medium", "scheduled": True}
     advanced = store.list_sync_schedules(store.SEED_USER_ID)[0]
     assert advanced["next_run_at"] > due.isoformat()
+
+
+def test_due_schedule_reuses_an_overview_sync_in_the_same_minute(store, monkeypatch):
+    start = datetime(2026, 8, 24, 8, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(job_queue, "_now", lambda: start)
+    store.upsert_sync_schedule(store.SEED_USER_ID, "hashnode", 60)
+    due = start + timedelta(seconds=61)
+    monkeypatch.setattr(job_queue, "_now", lambda: due)
+    existing = store.create_job(
+        store.SEED_USER_ID,
+        "sync",
+        None,
+        {"platform": "hashnode", "trigger": "overview"},
+        queue="sync",
+        idempotency_key=job_queue.sync_job_idempotency_key("hashnode"),
+    )
+
+    assert store.enqueue_due_sync_jobs() == 0
+    assert [
+        item["job_id"] for item in store.list_jobs(store.SEED_USER_ID, queue="sync")
+    ] == [existing["job_id"]]
+    assert store.list_sync_schedules(store.SEED_USER_ID)[0]["next_run_at"] > due.isoformat()
 
 
 def test_sync_schedule_is_user_scoped_and_deletable(store):

--- a/tests/tests_ui/screens/test_settings.py
+++ b/tests/tests_ui/screens/test_settings.py
@@ -274,7 +274,7 @@ def test_stuck_verifying_login_can_be_canceled(settings_page):
     card.get_by_text("Not connected", exact=True).wait_for(timeout=5000)
 
 
-def test_hashnode_connected_card_offers_sync_and_disconnect(page):
+def test_hashnode_connected_card_only_offers_disconnect(page):
     page.request.post(
         f"{BASE_URL}/api/auth/login",
         data={"email": "seed@example.com", "password": "seed1234", "remember_me": False},
@@ -292,48 +292,13 @@ def test_hashnode_connected_card_offers_sync_and_disconnect(page):
 
     page.goto(SETTINGS_URL)
     card = page.locator("#plat-card-hashnode")
-    card.get_by_text("Browser login · Persistent profile", exact=True).wait_for()
+    card.get_by_text("Connected", exact=True).wait_for()
 
     actions = card.get_by_role("button")
-    assert actions.count() == 2
-    assert actions.nth(0).inner_text() == "Sync articles"
-    assert actions.nth(1).inner_text() == "Disconnect"
+    assert actions.count() == 1
+    assert actions.nth(0).inner_text() == "Disconnect"
     assert card.get_by_text("Test", exact=True).count() == 0
     assert card.get_by_text("Refresh login", exact=True).count() == 0
-
-
-def test_hashnode_sync_action_reports_import_result(page):
-    page.request.post(
-        f"{BASE_URL}/api/auth/login",
-        data={"email": "seed@example.com", "password": "seed1234", "remember_me": False},
-    )
-    page.route(
-        f"{BASE_URL}/api/connections/hashnode/browser-connection",
-        lambda route: route.fulfill(json={
-            "platform": "hashnode",
-            "status": "connected",
-            "authorizationUrl": None,
-            "verifiedAt": "2026-08-19T00:00:00Z",
-            "error": None,
-        }),
-    )
-    page.route(
-        f"{BASE_URL}/api/connections/hashnode/sync",
-        lambda route: route.fulfill(json={
-            "status": "succeeded",
-            "fetched": 104,
-            "imported": 103,
-            "updated": 1,
-        }),
-    )
-
-    page.goto(SETTINGS_URL)
-    card = page.locator("#plat-card-hashnode")
-    card.get_by_role("button", name="Sync articles").click()
-
-    card.get_by_role("status").get_by_text(
-        "104 articles synced · 103 new · 1 updated",
-    ).wait_for()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- enqueue an immediate durable import when a Hashnode or Medium browser login is finalized
- ensure each connected browser platform has an enabled 15-minute recurring sync schedule
- make repeated completion requests repair missing sync records without creating duplicate jobs
- remove the manual Settings sync action and delete the recurring schedule on disconnect

## Tests

- `pytest tests/tests_backend/test_browser_connections.py tests/tests_backend/test_store/test_job_queue.py -q` (29 passed)
- `pytest tests/tests_ui/screens/test_settings.py -m browser -k connected_card_only_offers_disconnect -q` (1 passed)

## Stack

Stacked on #113 (`feat/112`) so the browser-login observation and automatic handoff behavior lands first.

Closes #114
