### PR TITLE
feat: persist secondary browser identities

### DIFF
--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -669,7 +669,17 @@ def start_browser_connection(request: Request, conn_id: str):
     try:
         session = runner.start_browser_login(conn_id, reusable_profile_id)
     except runner.RunnerUnavailable as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        if reusable_profile is None:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+        store.clear_browser_profile_reference(
+            user_id, reusable_profile["platform"],
+        )
+        reusable_profile = None
+        reusable_profile_id = None
+        try:
+            session = runner.start_browser_login(conn_id, None)
+        except runner.RunnerUnavailable as retry_exc:
+            raise HTTPException(status_code=503, detail=str(retry_exc)) from retry_exc
     if (
         reusable_profile
         and session["organization_id"] != reusable_profile["organization_id"]
@@ -678,9 +688,14 @@ def start_browser_connection(request: Request, conn_id: str):
             runner.cancel_browser_login(conn_id, session["session_id"])
         except runner.RunnerUnavailable:
             pass
-        raise HTTPException(
-            status_code=502, detail="Browser profile ownership could not be verified"
+        store.clear_browser_profile_reference(
+            user_id, reusable_profile["platform"],
         )
+        reusable_profile_id = None
+        try:
+            session = runner.start_browser_login(conn_id, None)
+        except runner.RunnerUnavailable as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
     connection = store.start_browser_connection(
         user_id,
         conn_id,

--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -69,6 +69,18 @@ def _require_browser_extension_id(platform: str) -> None:
         raise HTTPException(status_code=400, detail="Invalid browser extension id")
 
 
+def _delete_generated_profile(
+    platform: str, connection: dict, result: dict,
+) -> None:
+    profile_id = result.get("profile_id")
+    if not profile_id or profile_id == connection.get("skyvern_profile_id"):
+        return
+    try:
+        runner.delete_browser_profile(platform, profile_id)
+    except runner.RunnerUnavailable:
+        pass
+
+
 def _ensure_browser_sync(user_id: str, platform: str, session_id: str) -> None:
     schedules = store.list_sync_schedules(user_id)
     schedule = next(
@@ -650,19 +662,34 @@ def start_hashnode_browser_connection(request: Request):
 @router.post("/{conn_id}/browser-connection", status_code=201)
 def start_browser_connection(request: Request, conn_id: str):
     _require_browser_extension_id(conn_id)
-    previous = store.get_browser_connection(request.state.user_id, conn_id)
+    user_id = request.state.user_id
+    previous = store.get_browser_connection(user_id, conn_id)
     if previous and previous.get("skyvern_session_id") and previous["status"] == "waiting_for_login":
         try:
             runner.cancel_browser_login(conn_id, previous["skyvern_session_id"])
         except runner.RunnerUnavailable:
             pass
-    reusable_profile_id = previous.get("skyvern_profile_id") if previous else None
+    reusable_profile = store.get_reusable_browser_profile(user_id, conn_id)
+    reusable_profile_id = (
+        reusable_profile.get("profile_id") if reusable_profile else None
+    )
     try:
         session = runner.start_browser_login(conn_id, reusable_profile_id)
     except runner.RunnerUnavailable as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
+    if (
+        reusable_profile
+        and session["organization_id"] != reusable_profile["organization_id"]
+    ):
+        try:
+            runner.cancel_browser_login(conn_id, session["session_id"])
+        except runner.RunnerUnavailable:
+            pass
+        raise HTTPException(
+            status_code=502, detail="Browser profile ownership could not be verified"
+        )
     connection = store.start_browser_connection(
-        request.state.user_id,
+        user_id,
         conn_id,
         session_id=session["session_id"],
         organization_id=session["organization_id"],
@@ -714,11 +741,7 @@ def complete_browser_connection(request: Request, conn_id: str):
         or current.get("skyvern_session_id") != connection["skyvern_session_id"]
         or current["status"] != "verifying"
     ):
-        if result.get("profile_id"):
-            try:
-                runner.delete_browser_profile(conn_id, result["profile_id"])
-            except runner.RunnerUnavailable:
-                pass
+        _delete_generated_profile(conn_id, connection, result)
         return _browser_connection_response(conn_id, None)
     if not result.get("authenticated"):
         failed = store.update_browser_connection(
@@ -728,11 +751,7 @@ def complete_browser_connection(request: Request, conn_id: str):
         )
         return _browser_connection_response(conn_id, failed)
     if result.get("organization_id") != connection["skyvern_organization_id"]:
-        if result.get("profile_id"):
-            try:
-                runner.delete_browser_profile(conn_id, result["profile_id"])
-            except runner.RunnerUnavailable:
-                pass
+        _delete_generated_profile(conn_id, connection, result)
         failed = store.update_browser_connection(
             user_id, conn_id, "failed",
             error="Browser profile ownership could not be verified",
@@ -765,11 +784,15 @@ def disconnect_browser_connection(request: Request, conn_id: str):
             raise HTTPException(status_code=503, detail=str(exc)) from exc
     if connection and connection.get("skyvern_profile_id"):
         try:
-            runner.delete_browser_profile(conn_id, connection["skyvern_profile_id"])
+            runner.logout_browser_profile(
+                conn_id,
+                connection["skyvern_organization_id"],
+                connection["skyvern_profile_id"],
+            )
         except runner.RunnerUnavailable as exc:
             raise HTTPException(status_code=503, detail=str(exc)) from exc
     user_id = request.state.user_id
-    store.delete_browser_connection(user_id, conn_id)
+    store.disconnect_browser_connection(user_id, conn_id)
     store.delete_sync_schedule(user_id, conn_id)
     return {"platform": conn_id, "status": "disconnected"}
 

--- a/backend/services/cli_runner.py
+++ b/backend/services/cli_runner.py
@@ -458,6 +458,15 @@ def delete_browser_profile(platform: str, profile_id: str) -> None:
         raise RunnerUnavailable(f"Browser login runner unavailable: {exc}") from exc
 
 
+def logout_browser_profile(
+    platform: str, organization_id: str, profile_id: str,
+) -> None:
+    _post(
+        f"/browser/{platform}/profiles/{profile_id}/logout",
+        organization_id=organization_id,
+    )
+
+
 def delete_hashnode_browser_profile(profile_id: str) -> None:
     delete_browser_profile("hashnode", profile_id)
 

--- a/backend/services/cli_runner.py
+++ b/backend/services/cli_runner.py
@@ -36,8 +36,8 @@ def _post(path: str, **json_kwargs) -> dict:
             resp = c.post(path, json=json_kwargs or None)
             resp.raise_for_status()
             return resp.json()
-    except httpx.ConnectError:
-        raise RunnerUnavailable("CLI runner not reachable at " + CLI_RUNNER_URL)
+    except httpx.TransportError as exc:
+        raise RunnerUnavailable(f"CLI runner transport failed: {exc}") from exc
     except httpx.HTTPStatusError as exc:
         raise RunnerUnavailable(f"Runner error {exc.response.status_code}: {exc.response.text}")
 
@@ -48,8 +48,8 @@ def _get(path: str) -> dict:
             resp = c.get(path)
             resp.raise_for_status()
             return resp.json()
-    except httpx.ConnectError:
-        raise RunnerUnavailable("CLI runner not reachable at " + CLI_RUNNER_URL)
+    except httpx.TransportError as exc:
+        raise RunnerUnavailable(f"CLI runner transport failed: {exc}") from exc
     except httpx.HTTPStatusError as exc:
         raise RunnerUnavailable(f"Runner error {exc.response.status_code}: {exc.response.text}")
 

--- a/backend/store/__init__.py
+++ b/backend/store/__init__.py
@@ -311,6 +311,10 @@ def get_browser_connection(user_id: str, *a, **kw):
     return _backend.get_browser_connection(user_id, *a, **kw)
 
 
+def get_reusable_browser_profile(user_id: str, *a, **kw):
+    return _backend.get_reusable_browser_profile(user_id, *a, **kw)
+
+
 def start_browser_connection(user_id: str, *a, **kw):
     return _backend.start_browser_connection(user_id, *a, **kw)
 
@@ -321,6 +325,10 @@ def update_browser_connection(user_id: str, *a, **kw):
 
 def delete_browser_connection(user_id: str, *a, **kw):
     return _backend.delete_browser_connection(user_id, *a, **kw)
+
+
+def disconnect_browser_connection(user_id: str, *a, **kw):
+    return _backend.disconnect_browser_connection(user_id, *a, **kw)
 
 
 # ── Agent sessions ───────────────────────────────────────────────────────────

--- a/backend/store/__init__.py
+++ b/backend/store/__init__.py
@@ -327,6 +327,10 @@ def get_reusable_browser_profile(user_id: str, *a, **kw):
     return _backend.get_reusable_browser_profile(user_id, *a, **kw)
 
 
+def clear_browser_profile_reference(user_id: str, *a, **kw):
+    return _backend.clear_browser_profile_reference(user_id, *a, **kw)
+
+
 def start_browser_connection(user_id: str, *a, **kw):
     return _backend.start_browser_connection(user_id, *a, **kw)
 

--- a/backend/store/base.py
+++ b/backend/store/base.py
@@ -369,6 +369,11 @@ class ArticleStore(Protocol):
     ) -> dict | None:
         ...
 
+    def clear_browser_profile_reference(
+        self, user_id: str, platform: str,
+    ) -> None:
+        ...
+
     def start_browser_connection(self, user_id: str, platform: str, **kwargs: Any) -> dict:
         ...
 

--- a/backend/store/base.py
+++ b/backend/store/base.py
@@ -353,6 +353,11 @@ class ArticleStore(Protocol):
     def get_browser_connection(self, user_id: str, platform: str) -> dict | None:
         ...
 
+    def get_reusable_browser_profile(
+        self, user_id: str, platform: str,
+    ) -> dict | None:
+        ...
+
     def start_browser_connection(self, user_id: str, platform: str, **kwargs: Any) -> dict:
         ...
 
@@ -362,6 +367,11 @@ class ArticleStore(Protocol):
         ...
 
     def delete_browser_connection(self, user_id: str, platform: str) -> bool:
+        ...
+
+    def disconnect_browser_connection(
+        self, user_id: str, platform: str,
+    ) -> dict | None:
         ...
 
     def complete_job(self, user_id: str, job_id: str, result: dict | None = None, error: str | None = None) -> None:

--- a/backend/store/browser_connections.py
+++ b/backend/store/browser_connections.py
@@ -35,6 +35,26 @@ class BrowserConnectionStoreMixin:
         ).fetchone()
         return _browser_connection_row(row) if row else None
 
+    def get_reusable_browser_profile(
+        self, user_id: str, platform: str,
+    ) -> dict | None:
+        row = self._con.execute(
+            """SELECT skyvern_organization_id, skyvern_profile_id
+               FROM browser_connections
+               WHERE user_id=? AND skyvern_profile_id IS NOT NULL
+               ORDER BY CASE WHEN platform=? THEN 0 ELSE 1 END,
+                        CASE WHEN status='connected' THEN 0 ELSE 1 END,
+                        updated_at DESC
+               LIMIT 1""",
+            (user_id, platform),
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "organization_id": row["skyvern_organization_id"],
+            "profile_id": row["skyvern_profile_id"],
+        }
+
     def start_browser_connection(
         self,
         user_id: str,
@@ -148,3 +168,20 @@ class BrowserConnectionStoreMixin:
                     (user_id, platform),
                 )
         return cursor.rowcount > 0
+
+    def disconnect_browser_connection(
+        self, user_id: str, platform: str,
+    ) -> dict | None:
+        now = _now()
+        with self._workspace_lock.acquire():
+            with self._con:
+                cursor = self._con.execute(
+                    """UPDATE browser_connections
+                       SET status='disconnected', skyvern_session_id=NULL,
+                           app_url=NULL, error=NULL, verified_at=NULL, updated_at=?
+                       WHERE user_id=? AND platform=?""",
+                    (now, user_id, platform),
+                )
+        if cursor.rowcount == 0:
+            return None
+        return self.get_browser_connection(user_id, platform)

--- a/backend/store/browser_connections.py
+++ b/backend/store/browser_connections.py
@@ -39,21 +39,34 @@ class BrowserConnectionStoreMixin:
         self, user_id: str, platform: str,
     ) -> dict | None:
         row = self._con.execute(
-            """SELECT skyvern_organization_id, skyvern_profile_id
+            """SELECT platform, skyvern_organization_id, skyvern_profile_id
                FROM browser_connections
                WHERE user_id=? AND skyvern_profile_id IS NOT NULL
+                 AND (status='connected' OR (platform=? AND status='disconnected'))
                ORDER BY CASE WHEN platform=? THEN 0 ELSE 1 END,
-                        CASE WHEN status='connected' THEN 0 ELSE 1 END,
                         updated_at DESC
                LIMIT 1""",
-            (user_id, platform),
+            (user_id, platform, platform),
         ).fetchone()
         if row is None:
             return None
         return {
+            "platform": row["platform"],
             "organization_id": row["skyvern_organization_id"],
             "profile_id": row["skyvern_profile_id"],
         }
+
+    def clear_browser_profile_reference(
+        self, user_id: str, platform: str,
+    ) -> None:
+        with self._workspace_lock.acquire():
+            with self._con:
+                self._con.execute(
+                    """UPDATE browser_connections
+                       SET skyvern_profile_id=NULL, updated_at=?
+                       WHERE user_id=? AND platform=?""",
+                    (_now(), user_id, platform),
+                )
 
     def start_browser_connection(
         self,

--- a/cli-runner/blog_extensions/contracts.py
+++ b/cli-runner/blog_extensions/contracts.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
 from typing import Any, Mapping, NotRequired, TypedDict
+from urllib.parse import urlsplit
 
 
 PROTOCOL_VERSION = 1
@@ -107,6 +108,11 @@ class BrowserLoginAdapter(ABC):
 
     platform: str
     login_url: str
+
+    def session_domains(self) -> tuple[str, ...]:
+        """Domains whose cookies represent this platform's own login."""
+        hostname = urlsplit(self.login_url).hostname
+        return (hostname,) if hostname else ()
 
     @abstractmethod
     def verify_profile(self, profile_dir: Path) -> dict[str, Any]:

--- a/cli-runner/blog_extensions/profile_sessions.py
+++ b/cli-runner/blog_extensions/profile_sessions.py
@@ -51,10 +51,10 @@ def _clear_cookie_snapshot(
 def clear_profile_session(
     profile_dir: Path, session_domains: tuple[str, ...],
 ) -> int:
-    if not profile_dir.is_dir():
-        raise ValueError("Browser profile is unavailable")
     if not session_domains:
         raise ValueError("Browser extension does not declare a session domain")
+    if not profile_dir.is_dir():
+        return 0
 
     from patchright.sync_api import sync_playwright
 

--- a/cli-runner/blog_extensions/profile_sessions.py
+++ b/cli-runner/blog_extensions/profile_sessions.py
@@ -1,0 +1,70 @@
+"""Targeted logout for a shared persisted browser profile."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+
+def domain_matches(domain: object, session_domains: Iterable[str]) -> bool:
+    candidate = str(domain or "").lstrip(".").lower()
+    return any(
+        candidate == allowed or candidate.endswith(f".{allowed}")
+        for allowed in (item.lstrip(".").lower() for item in session_domains)
+    )
+
+
+def clear_context_session(context: Any, session_domains: tuple[str, ...]) -> int:
+    removed = 0
+    for cookie in context.cookies():
+        if not domain_matches(cookie.get("domain"), session_domains):
+            continue
+        context.clear_cookies(
+            name=cookie.get("name"),
+            domain=cookie.get("domain"),
+            path=cookie.get("path") or "/",
+        )
+        removed += 1
+    return removed
+
+
+def _clear_cookie_snapshot(
+    profile_dir: Path, session_domains: tuple[str, ...],
+) -> None:
+    snapshot = profile_dir / ".skyvern_session_cookies.json"
+    try:
+        cookies = json.loads(snapshot.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError):
+        return
+    if not isinstance(cookies, list):
+        return
+    retained = [
+        cookie for cookie in cookies
+        if not isinstance(cookie, dict)
+        or not domain_matches(cookie.get("domain"), session_domains)
+    ]
+    temporary = snapshot.with_suffix(".json.tmp")
+    temporary.write_text(json.dumps(retained, separators=(",", ":")), encoding="utf-8")
+    temporary.replace(snapshot)
+
+
+def clear_profile_session(
+    profile_dir: Path, session_domains: tuple[str, ...],
+) -> int:
+    if not profile_dir.is_dir():
+        raise ValueError("Browser profile is unavailable")
+    if not session_domains:
+        raise ValueError("Browser extension does not declare a session domain")
+
+    from patchright.sync_api import sync_playwright
+
+    with sync_playwright() as playwright:
+        context = playwright.chromium.launch_persistent_context(
+            str(profile_dir), headless=True,
+        )
+        try:
+            removed = clear_context_session(context, session_domains)
+        finally:
+            context.close()
+    _clear_cookie_snapshot(profile_dir, session_domains)
+    return removed

--- a/cli-runner/main.py
+++ b/cli-runner/main.py
@@ -58,6 +58,7 @@ from blog_extensions import (
     get_registry,
 )
 from blog_extensions.runtime import execute_operation
+from blog_extensions.profile_sessions import clear_profile_session
 from skyvern_browser import (
     SkyvernUnavailable,
     capture_browser_screenshot,
@@ -299,6 +300,10 @@ class HashnodeBrowserProfileRequest(BaseModel):
     profile_id: str
 
 
+class BrowserProfileSessionRequest(BaseModel):
+    organization_id: str
+
+
 _chat_processes: dict[str, subprocess.Popen] = {}
 
 def _browser_extension(platform: str):
@@ -518,6 +523,23 @@ def browser_profile_delete(platform: str, profile_id: str):
         raise HTTPException(422, str(exc)) from exc
     except SkyvernUnavailable as exc:
         raise HTTPException(503, _safe_reason(str(exc))) from exc
+
+
+@app.post("/browser/{platform}/profiles/{profile_id}/logout")
+def browser_profile_logout(
+    platform: str, profile_id: str, req: BrowserProfileSessionRequest,
+):
+    extension = _browser_extension(platform)
+    try:
+        profile_dir = profile_directory(req.organization_id, profile_id)
+        removed = clear_profile_session(
+            profile_dir, extension.login.session_domains()
+        )
+        return {"status": "disconnected", "cookies_removed": removed}
+    except ValueError as exc:
+        raise HTTPException(422, str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(502, _safe_reason(str(exc))) from exc
 
 
 # ── Health ─────────────────────────────────────────────────────────────────────

--- a/tests/tests_backend/test_blog_extension_runner.py
+++ b/tests/tests_backend/test_blog_extension_runner.py
@@ -110,6 +110,27 @@ def test_browser_login_screenshot_returns_non_cacheable_png(monkeypatch):
     assert response.headers["cache-control"] == "no-store"
 
 
+def test_profile_logout_uses_extension_session_domains(tmp_path, monkeypatch):
+    seen = {}
+    monkeypatch.setattr(runner_main, "profile_directory", lambda *_args: tmp_path)
+    monkeypatch.setattr(
+        runner_main,
+        "clear_profile_session",
+        lambda profile_dir, domains: seen.update(
+            profile_dir=profile_dir, domains=domains
+        ) or 2,
+    )
+
+    result = runner_main.browser_profile_logout(
+        "medium",
+        "bp_profile",
+        runner_main.BrowserProfileSessionRequest(organization_id="o_org"),
+    )
+
+    assert result == {"status": "disconnected", "cookies_removed": 2}
+    assert seen == {"profile_dir": tmp_path, "domains": ("medium.com",)}
+
+
 def test_public_operation_requires_explicit_approval():
     request = runner_main.BrowserOperationRequest(
         organization_id="o_test",

--- a/tests/tests_backend/test_blog_extension_runner.py
+++ b/tests/tests_backend/test_blog_extension_runner.py
@@ -11,6 +11,8 @@ from fastapi import HTTPException
 RUNNER = Path(__file__).resolve().parents[2] / "cli-runner"
 if str(RUNNER) not in sys.path:
     sys.path.insert(0, str(RUNNER))
+from blog_extensions.profile_sessions import clear_profile_session
+
 spec = importlib.util.spec_from_file_location(
     "blog_extension_runner_under_test", RUNNER / "main.py"
 )
@@ -129,6 +131,14 @@ def test_profile_logout_uses_extension_session_domains(tmp_path, monkeypatch):
 
     assert result == {"status": "disconnected", "cookies_removed": 2}
     assert seen == {"profile_dir": tmp_path, "domains": ("medium.com",)}
+
+
+def test_profile_logout_treats_missing_local_profile_as_already_logged_out(
+    tmp_path,
+):
+    assert clear_profile_session(
+        tmp_path / "missing-profile", ("medium.com",),
+    ) == 0
 
 
 def test_public_operation_requires_explicit_approval():

--- a/tests/tests_backend/test_blog_extensions.py
+++ b/tests/tests_backend/test_blog_extensions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 from pathlib import Path
 import sys
 import time
@@ -20,6 +21,11 @@ from blog_extensions import (
 )
 from blog_extensions.registry import ExtensionConfigurationError
 from blog_extensions.testing import assert_extension_contract, article_from_fixture
+from blog_extensions.profile_sessions import (
+    _clear_cookie_snapshot,
+    clear_context_session,
+    domain_matches,
+)
 
 
 FIXTURE = Path(__file__).with_name("fixtures") / "blog_extension_article.json"
@@ -73,6 +79,47 @@ def test_hashnode_live_session_recognizes_secure_authjs_cookie():
     }]})
 
     assert result["authenticated"] is True
+
+
+def test_targeted_logout_preserves_secondary_identity_cookies():
+    class Context:
+        def __init__(self):
+            self.cleared = []
+
+        def cookies(self):
+            return [
+                {"name": "sid", "domain": ".medium.com", "path": "/"},
+                {"name": "accounts", "domain": ".google.com", "path": "/"},
+                {"name": "session", "domain": ".github.com", "path": "/"},
+            ]
+
+        def clear_cookies(self, **kwargs):
+            self.cleared.append(kwargs)
+
+    context = Context()
+
+    assert clear_context_session(context, ("medium.com",)) == 1
+    assert context.cleared == [{
+        "name": "sid", "domain": ".medium.com", "path": "/",
+    }]
+    assert domain_matches("sub.medium.com", ("medium.com",))
+    assert not domain_matches("notmedium.com", ("medium.com",))
+
+
+def test_targeted_logout_filters_only_platform_cookies_from_snapshot(tmp_path):
+    snapshot = tmp_path / ".skyvern_session_cookies.json"
+    snapshot.write_text(json.dumps([
+        {"name": "sid", "domain": ".medium.com"},
+        {"name": "accounts", "domain": ".google.com"},
+        {"name": "session", "domain": ".github.com"},
+    ]), encoding="utf-8")
+
+    _clear_cookie_snapshot(tmp_path, ("medium.com",))
+
+    assert json.loads(snapshot.read_text(encoding="utf-8")) == [
+        {"name": "accounts", "domain": ".google.com"},
+        {"name": "session", "domain": ".github.com"},
+    ]
 
 
 def test_fixture_loader_builds_normalized_article_input():

--- a/tests/tests_backend/test_browser_connections.py
+++ b/tests/tests_backend/test_browser_connections.py
@@ -276,7 +276,7 @@ def test_canceled_login_discards_a_late_completion_result(client, monkeypatch):
     assert store.get_browser_connection("user_seed", "medium") is None
 
 
-def test_hashnode_browser_retry_reuses_provider_session_profile(client, monkeypatch):
+def test_hashnode_browser_retry_ignores_failed_profile(client, monkeypatch):
     store.start_browser_connection(
         "user_seed", "hashnode", session_id="pbs_previous",
         organization_id="o_org", app_url="http://localhost/previous",
@@ -297,9 +297,9 @@ def test_hashnode_browser_retry_reuses_provider_session_profile(client, monkeypa
     started = client.post("/api/connections/hashnode/browser-connection")
 
     assert started.status_code == 201
-    assert reused == [("hashnode", "bp_identity")]
+    assert reused == [("hashnode", None)]
     persisted = store.get_browser_connection("user_seed", "hashnode")
-    assert persisted["skyvern_profile_id"] == "bp_identity"
+    assert persisted["skyvern_profile_id"] is None
 
 
 def test_hashnode_browser_disconnect_preserves_shared_profile(client, monkeypatch):
@@ -342,7 +342,7 @@ def test_browser_disconnect_keeps_schedule_for_connected_api(client, monkeypatch
     )
     store.upsert_sync_schedule("user_seed", "hashnode", 900)
     monkeypatch.setattr(
-        connections_router.runner, "delete_browser_profile", lambda *_args: None,
+        connections_router.runner, "logout_browser_profile", lambda *_args: None,
     )
 
     response = client.delete("/api/connections/hashnode/browser-connection")
@@ -421,9 +421,70 @@ def test_reusable_identity_profile_is_scoped_to_its_user():
 
     assert store.get_reusable_browser_profile("user_seed", "medium") is None
     assert store.get_reusable_browser_profile(other["id"], "medium") == {
+        "platform": "hashnode",
         "organization_id": "o_other",
         "profile_id": "bp_other",
     }
+
+
+def test_stale_reusable_profile_falls_back_to_a_fresh_profile(client, monkeypatch):
+    store.start_browser_connection(
+        "user_seed", "hashnode", session_id="pbs_old",
+        organization_id="o_old", app_url="http://localhost/old",
+        profile_id="bp_stale",
+    )
+    store.update_browser_connection("user_seed", "hashnode", "connected")
+    attempts = []
+
+    def start(_platform, profile_id):
+        attempts.append(profile_id)
+        if profile_id:
+            raise runner.RunnerUnavailable("profile unavailable")
+        return {
+            "session_id": "pbs_fresh",
+            "organization_id": "o_new",
+            "app_url": "http://localhost/fresh",
+        }
+
+    monkeypatch.setattr(connections_router.runner, "start_browser_login", start)
+
+    response = client.post("/api/connections/medium/browser-connection")
+
+    assert response.status_code == 201
+    assert attempts == ["bp_stale", None]
+    hashnode = store.get_browser_connection("user_seed", "hashnode")
+    assert hashnode["skyvern_profile_id"] is None
+
+
+def test_reusable_profile_ownership_mismatch_restarts_fresh(client, monkeypatch):
+    store.start_browser_connection(
+        "user_seed", "hashnode", session_id="pbs_old",
+        organization_id="o_old", app_url="http://localhost/old",
+        profile_id="bp_stale",
+    )
+    store.update_browser_connection("user_seed", "hashnode", "connected")
+    attempts = []
+
+    def start(_platform, profile_id):
+        attempts.append(profile_id)
+        return {
+            "session_id": f"pbs_{len(attempts)}",
+            "organization_id": "o_new",
+            "app_url": "http://localhost/login",
+        }
+
+    canceled = []
+    monkeypatch.setattr(connections_router.runner, "start_browser_login", start)
+    monkeypatch.setattr(
+        connections_router.runner, "cancel_browser_login",
+        lambda platform, session_id: canceled.append((platform, session_id)),
+    )
+
+    response = client.post("/api/connections/medium/browser-connection")
+
+    assert response.status_code == 201
+    assert attempts == ["bp_stale", None]
+    assert canceled == [("medium", "pbs_1")]
 
 
 def test_late_completion_does_not_delete_a_reused_profile(client, monkeypatch):

--- a/tests/tests_backend/test_browser_connections.py
+++ b/tests/tests_backend/test_browser_connections.py
@@ -238,7 +238,9 @@ def test_verifying_browser_login_can_be_canceled_immediately(client, monkeypatch
 
     assert response.status_code == 200
     assert response.json()["status"] == "disconnected"
-    assert store.get_browser_connection("user_seed", "medium") is None
+    persisted = store.get_browser_connection("user_seed", "medium")
+    assert persisted["status"] == "disconnected"
+    assert persisted["skyvern_session_id"] is None
     assert canceled == []
 
 
@@ -300,7 +302,7 @@ def test_hashnode_browser_retry_reuses_provider_session_profile(client, monkeypa
     assert persisted["skyvern_profile_id"] == "bp_identity"
 
 
-def test_hashnode_browser_disconnect_deletes_remote_profile(client, monkeypatch):
+def test_hashnode_browser_disconnect_preserves_shared_profile(client, monkeypatch):
     store.start_browser_connection(
         "user_seed", "hashnode", session_id="pbs_session",
         organization_id="o_org", app_url="http://localhost/login",
@@ -309,16 +311,21 @@ def test_hashnode_browser_disconnect_deletes_remote_profile(client, monkeypatch)
         "user_seed", "hashnode", "connected", profile_id="bp_profile"
     )
     store.upsert_sync_schedule("user_seed", "hashnode", 900)
-    deleted = []
+    logged_out = []
     monkeypatch.setattr(
         connections_router.runner,
-        "delete_browser_profile",
-        lambda platform, profile_id: deleted.append((platform, profile_id)),
+        "logout_browser_profile",
+        lambda platform, organization_id, profile_id: logged_out.append(
+            (platform, organization_id, profile_id)
+        ),
     )
     response = client.delete("/api/connections/hashnode/browser-connection")
     assert response.status_code == 200
-    assert deleted == [("hashnode", "bp_profile")]
-    assert store.get_browser_connection("user_seed", "hashnode") is None
+    assert logged_out == [("hashnode", "o_org", "bp_profile")]
+    persisted = store.get_browser_connection("user_seed", "hashnode")
+    assert persisted["status"] == "disconnected"
+    assert persisted["skyvern_profile_id"] == "bp_profile"
+    assert persisted["skyvern_session_id"] is None
     assert store.list_sync_schedules("user_seed") == []
 
 
@@ -333,11 +340,11 @@ def test_hashnode_browser_disconnect_retains_profile_when_remote_cleanup_fails(
         "user_seed", "hashnode", "connected", profile_id="bp_profile"
     )
 
-    def unavailable(_platform, _profile_id):
+    def unavailable(_platform, _organization_id, _profile_id):
         raise runner.RunnerUnavailable("Skyvern unavailable")
 
     monkeypatch.setattr(
-        connections_router.runner, "delete_browser_profile", unavailable,
+        connections_router.runner, "logout_browser_profile", unavailable,
     )
 
     response = client.delete("/api/connections/hashnode/browser-connection")
@@ -346,6 +353,80 @@ def test_hashnode_browser_disconnect_retains_profile_when_remote_cleanup_fails(
     assert response.json()["detail"] == "Skyvern unavailable"
     persisted = store.get_browser_connection("user_seed", "hashnode")
     assert persisted["skyvern_profile_id"] == "bp_profile"
+
+
+def test_medium_login_reuses_hashnode_identity_profile(client, monkeypatch):
+    store.start_browser_connection(
+        "user_seed", "hashnode", session_id="pbs_hashnode",
+        organization_id="o_org", app_url="http://localhost/hashnode",
+        profile_id="bp_shared",
+    )
+    store.update_browser_connection("user_seed", "hashnode", "connected")
+    reused = []
+    monkeypatch.setattr(
+        connections_router.runner,
+        "start_browser_login",
+        lambda platform, profile_id: reused.append((platform, profile_id)) or {
+            "session_id": "pbs_medium",
+            "organization_id": "o_org",
+            "app_url": "http://localhost:8083/browser-session/pbs_medium",
+        },
+    )
+
+    response = client.post("/api/connections/medium/browser-connection")
+
+    assert response.status_code == 201
+    assert reused == [("medium", "bp_shared")]
+    medium = store.get_browser_connection("user_seed", "medium")
+    assert medium["skyvern_profile_id"] == "bp_shared"
+
+
+def test_reusable_identity_profile_is_scoped_to_its_user():
+    other = store.create_user("profile-owner@example.com", "password-hash")
+    store.start_browser_connection(
+        other["id"], "hashnode", session_id="pbs_other",
+        organization_id="o_other", app_url="http://localhost/hashnode",
+        profile_id="bp_other",
+    )
+    store.update_browser_connection(other["id"], "hashnode", "connected")
+
+    assert store.get_reusable_browser_profile("user_seed", "medium") is None
+    assert store.get_reusable_browser_profile(other["id"], "medium") == {
+        "organization_id": "o_other",
+        "profile_id": "bp_other",
+    }
+
+
+def test_late_completion_does_not_delete_a_reused_profile(client, monkeypatch):
+    store.start_browser_connection(
+        "user_seed", "medium", session_id="pbs_late",
+        organization_id="o_org", app_url="http://localhost/login",
+        profile_id="bp_shared",
+    )
+    deleted_profiles = []
+
+    def complete_after_cancel(*_args, **_kwargs):
+        store.delete_browser_connection("user_seed", "medium")
+        return {
+            "authenticated": True,
+            "profile_id": "bp_shared",
+            "organization_id": "o_org",
+        }
+
+    monkeypatch.setattr(
+        connections_router.runner, "complete_browser_login", complete_after_cancel,
+    )
+    monkeypatch.setattr(
+        connections_router.runner,
+        "delete_browser_profile",
+        lambda platform, profile_id: deleted_profiles.append((platform, profile_id)),
+    )
+
+    response = client.post("/api/connections/medium/browser-connection/complete")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "disconnected"
+    assert deleted_profiles == []
 
 
 def test_medium_browser_login_uses_same_profile_reference_flow(client, monkeypatch):

--- a/tests/tests_backend/test_cli_runner.py
+++ b/tests/tests_backend/test_cli_runner.py
@@ -1,3 +1,7 @@
+import httpx
+import pytest
+
+import backend.services.cli_runner as cli_runner
 from backend.services.cli_runner import api_key_from_connection_token
 
 
@@ -9,3 +13,22 @@ def test_persisted_cli_session_markers_do_not_override_runner_login():
     assert api_key_from_connection_token("web_session:openai") is None
     assert api_key_from_connection_token("cli_session") is None
     assert api_key_from_connection_token(None) is None
+
+
+def test_logout_wraps_runner_read_timeout(monkeypatch):
+    request = httpx.Request("POST", "http://runner/logout")
+
+    class TimeoutClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def post(self, *_args, **_kwargs):
+            raise httpx.ReadTimeout("timed out", request=request)
+
+    monkeypatch.setattr(cli_runner, "_client", TimeoutClient)
+
+    with pytest.raises(cli_runner.RunnerUnavailable, match="transport failed"):
+        cli_runner.logout_browser_profile("medium", "o_org", "bp_profile")


### PR DESCRIPTION
Closes #116

## Summary
- reuse one user-scoped Skyvern browser profile across blog platform login flows
- disconnect only the selected blog platform by clearing its declared session cookies
- retain Google, GitHub, Microsoft, LinkedIn, Apple, and other identity-provider sessions in the shared profile
- preserve disconnected profile references while keeping cookies and credentials out of BlogHub storage and APIs
- protect reused profiles from stale login cleanup and enforce profile ownership

## Tests
- 45 focused browser connection, extension, runner, and Skyvern tests passed
- 38 adjacent connection, publishing, job, and draft tests passed; 2 skipped