### PR TITLE
fix: converge shared browser identity profiles

### DIFF
--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -580,6 +580,7 @@ def _browser_connection_response(
     connection: dict | None,
     live_session: dict | None = None,
     health: dict | None = None,
+    browser_memory: dict | None = None,
 ) -> dict:
     if connection is None:
         return {
@@ -592,6 +593,7 @@ def _browser_connection_response(
             },
             "connectionHealth": None,
             "verificationNeeded": False,
+            "browserMemory": browser_memory,
         }
     live_authentication = (live_session or {}).get("live_authentication") or {}
     live_authenticated = live_authentication.get("authenticated")
@@ -625,6 +627,7 @@ def _browser_connection_response(
             connection["status"] == "connected"
             and connection_health.needs_user_refresh(health)
         ),
+        "browserMemory": browser_memory,
     }
 
 
@@ -802,7 +805,16 @@ def start_browser_connection(request: Request, conn_id: str):
         app_url=session["app_url"],
         profile_id=reusable_profile_id,
     )
-    return _browser_connection_response(conn_id, connection)
+    return _browser_connection_response(
+        conn_id,
+        connection,
+        browser_memory={
+            "reused": reusable_profile is not None,
+            "sourcePlatform": (
+                reusable_profile.get("platform") if reusable_profile else None
+            ),
+        },
+    )
 
 
 @router.post("/hashnode/browser-connection/complete")

--- a/backend/store/browser_connections.py
+++ b/backend/store/browser_connections.py
@@ -43,7 +43,8 @@ class BrowserConnectionStoreMixin:
                FROM browser_connections
                WHERE user_id=? AND skyvern_profile_id IS NOT NULL
                  AND (status='connected' OR (platform=? AND status='disconnected'))
-               ORDER BY CASE WHEN platform=? THEN 0 ELSE 1 END,
+               ORDER BY CASE WHEN status='connected' THEN 0 ELSE 1 END,
+                        CASE WHEN platform=? THEN 0 ELSE 1 END,
                         updated_at DESC
                LIMIT 1""",
             (user_id, platform, platform),

--- a/tests/tests_backend/test_browser_connections.py
+++ b/tests/tests_backend/test_browser_connections.py
@@ -440,6 +440,49 @@ def test_medium_login_reuses_hashnode_identity_profile(client, monkeypatch):
     assert reused == [("medium", "bp_shared")]
     medium = store.get_browser_connection("user_seed", "medium")
     assert medium["skyvern_profile_id"] == "bp_shared"
+    assert response.json()["browserMemory"] == {
+        "reused": True,
+        "sourcePlatform": "hashnode",
+    }
+
+
+def test_connected_shared_profile_wins_over_disconnected_platform_profile(
+    client, monkeypatch,
+):
+    store.start_browser_connection(
+        "user_seed", "medium", session_id="pbs_medium_old",
+        organization_id="o_org", app_url="http://localhost/medium",
+        profile_id="bp_medium_old",
+    )
+    store.update_browser_connection("user_seed", "medium", "connected")
+    store.disconnect_browser_connection("user_seed", "medium")
+    store.start_browser_connection(
+        "user_seed", "hashnode", session_id="pbs_hashnode",
+        organization_id="o_org", app_url="http://localhost/hashnode",
+        profile_id="bp_shared",
+    )
+    store.update_browser_connection("user_seed", "hashnode", "connected")
+    reused = []
+    monkeypatch.setattr(
+        connections_router.runner,
+        "start_browser_login",
+        lambda platform, profile_id: reused.append((platform, profile_id)) or {
+            "session_id": "pbs_medium_new",
+            "organization_id": "o_org",
+            "app_url": "http://localhost:8083/browser-session/pbs_medium_new",
+        },
+    )
+
+    response = client.post("/api/connections/medium/browser-connection")
+
+    assert response.status_code == 201
+    assert reused == [("medium", "bp_shared")]
+    assert response.json()["browserMemory"] == {
+        "reused": True,
+        "sourcePlatform": "hashnode",
+    }
+    medium = store.get_browser_connection("user_seed", "medium")
+    assert medium["skyvern_profile_id"] == "bp_shared"
 
 
 def test_reusable_identity_profile_is_scoped_to_its_user():


### PR DESCRIPTION
## Summary
- prefer an active connected browser identity over a stale per-platform profile
- converge reconnecting blog platforms onto the shared Skyvern profile
- report non-sensitive browser-memory reuse metadata when login starts
- cover the distinct-profile regression reproduced in the UI

## Tests
- 5 focused browser identity/logout tests passed
- Python compile validation passed
- The combined browser suite was attempted with isolated temporary storage but stalled during collection in the local WSL/Windows mount; CI remains the authoritative full-suite run

Closes #121